### PR TITLE
WB-2204 Calendar defaults to year 1969 (and is unusable) when you have 0 recordings

### DIFF
--- a/assets/app/app/audiodata/recordings/recordings.js
+++ b/assets/app/app/audiodata/recordings/recordings.js
@@ -60,8 +60,7 @@ angular.module('a2.audiodata.recordings', [
             if(expect.count){
                 $scope.totalRecs = data.count;
             }
-            if(expect.date_range) {
-                if(expect.date_range && data.date_range.min_date && data.date_range.max_date) {
+        	if(expect.date_range && data.date_range.min_date && data.date_range.max_date) {
                     $scope.minDate = new Date(data.date_range.min_date);
                     $scope.maxDate = new Date(data.date_range.max_date);
                 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/51106210/95652184-8c3fa000-0b19-11eb-88b6-24d3b4c3bdfe.png)
