### PR TITLE
WB-2273 redirect to /connect-with-rfcx if email is unverified

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -46,10 +46,12 @@ router.get('/classifiers', function(req, res) {
 });
 
 router.get('/connect-with-rfcx', function(req, res) {
+    const query = req.query || {}
     res.type('html');
     res.render('connect-with-rfcx', {
         user: req.session.user,
-        auth0UniversalLoginUrl: auth0Service.universalLoginUrl
+        auth0UniversalLoginUrl: auth0Service.universalLoginUrl,
+        error: query.error || null
     });
 });
 

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -14,6 +14,7 @@ var request = require('request');
 var ejs = require('ejs');
 var fs = require('fs');
 var path = require('path');
+var url = require('url');
 var dd = console.log;
 
 var config = require('../config');
@@ -175,6 +176,14 @@ router.get('/auth0-login', async function(req, res, next) {
     try {
         const query = req.query || {}
         if (query.error) {
+            if (req.session.user && req.session.user.username !== 'guest') {
+                return res.redirect(url.format({
+                    pathname: '/connect-with-rfcx',
+                    query: {
+                        error: query.error_description
+                    }
+                }));
+            }
             return next(new Error(query.error_description))
         }
         if (!query.code) {

--- a/app/views/connect-with-rfcx.ejs
+++ b/app/views/connect-with-rfcx.ejs
@@ -21,11 +21,16 @@
                         <% } else if (user.rfcx_id) { %>
                             <span class="label label-success">Complete</span>
                         <% } else { %>
-                            <span class="label label-warning">Not started</span>
+                            <span class="label label-warning">Not completed</span>
                         <% } %>
                         </h3>
                     </div>
                     <div class="panel-body">
+                    <% if (error) { %>
+                        <div class="alert alert-info">
+                            <strong>Warning!</strong> <%- error %>
+                        </div>
+                    <% } %>
                     <% if (!user || user.isAnonymousGuest) { %>
                         <p><a href="/login">Login</a> to check your status.</p>
                     <% } else if (user.rfcx_id) { %>
@@ -43,10 +48,10 @@
                     <% } %>
                     </div>
                 </div>
-                
+
                 <div>
                     <h2>Arbimon II account migration</h2>
-                    
+
                     <p>As an Arbimon user, you are now part of a comprehensive technology ecosystem to support bioacoustics research! Our goal
                     is to make Arbimon the best platform for your research, conservation, and management projects. With one single login,
                     you will now have access to the following applications:</p>
@@ -63,7 +68,7 @@
 
                     <p>Add yourself to our distribution list to receive important updates about the Edge and the Explorer app by scrolling to
                     the bottom of <a href="https://www.rfcx.org">www.rfcx.org</a> and adding your email.</p>
-                    
+
                     <h3>Questions?</h3>
 
                     <p>In order to best support you during this exciting expansion, we’ve added a direct line to our support team - which can


### PR DESCRIPTION
Error message is changed to: "Email verification is required to authenticate with RFCx."
If user is logged in with legacy Arbimon account and makes "connect with rfcx" with unverified email address, he will be redirected to /connect-with-rfcx page and see additional warning with above message.
If user is not logged in and tries to login with unverified email through Auth0, he will still be redirected to error page.