### PR TITLE
PI-180 hide parameters on the CNN details page

### DIFF
--- a/assets/app/app/analysis/cnn/details.html
+++ b/assets/app/app/analysis/cnn/details.html
@@ -54,7 +54,6 @@
                         {{ job_details.playlist_name }} ({{ job_details.playlist_count }} recordings)
                         <br>{{ job_details.timestamp }}
                         <br>CNN Model: {{job_details.cnn_model_name}}
-                        <br>Parameters: {{ job_details.parameters }}
                         <br>{{job_details.matches || 0}} matches ({{job_details.present || 0}} present, {{job_details.absent || 0}} not present, {{job_details.matches - (job_details.absent + job_details.present)}} unvalidated)
                 </div>
             </div>


### PR DESCRIPTION
Jack: "There are not really parameters to show for each CNN job. We could just display the confidence threshold there, but I have not set the database up for that. So I would not worry about this task. I would remove the "Parameters: {}" line from there, until we settle on what should be shown."