### PR TITLE
PI-353 fix rois rendering style in chrome

### DIFF
--- a/assets/less/a2-components/audiodata.less
+++ b/assets/less/a2-components/audiodata.less
@@ -204,6 +204,9 @@
         width:125px;
         height:125px;
         margin:2px;
+        @media screen and (-webkit-min-device-pixel-ratio:0) {
+            image-rendering: pixelated;
+        }
         &.is-small {
             width:64px;
             height:64px;


### PR DESCRIPTION
<img width="753" alt="Screenshot 2021-01-18 at 18 12 22" src="https://user-images.githubusercontent.com/31901584/105246856-e32b2b80-5b84-11eb-8332-1182fb3f8c04.png">
<img width="749" alt="Screenshot 2021-01-18 at 18 11 51" src="https://user-images.githubusercontent.com/31901584/105246865-e6261c00-5b84-11eb-951d-0024c5d250ba.png">
