### PR TITLE
CE-203 add endpoint for site update from Core API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New features:
 - PI-574 Default map on the sites page should display sites
 - PI-609/PI-252 Get Companions' images and show them for a current site
 - PI-563 Fix timezone issue where AudioMoth UTC timezone is not translated
+- CE-203 add endpoint for site update from Core API
 
 Resolved issues:
 - PI-495 Fix fuzzy images for Pattern Matching boxes in Chrome browser


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-203](https://jira.rfcx.org/browse/CE-203)
- [x] Release notes updated
- [x] Deployment notes updated
- [x] DB migrations n/a

## 📝 Summary

- add endpoint for site update from Core API

## 📸 Screenshots

## 🛑 Problems

## 💡 More ideas

TODO later:
- if stream not found, try to request if from Core API
