### PR TITLE
CE-174 rework streams-sites unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Arbimon Release Notes
 
+## v3.0.13 - Mar XX, 2021
+
+New features:
+- CE-174 rework streams-sites unification
+
 ## v3.0.12 - Feb XX, 2021
 
 New features:

--- a/DEPLOYMENT_NOTES.md
+++ b/DEPLOYMENT_NOTES.md
@@ -1,5 +1,10 @@
 # Arbimon Deployment Notes
 
+## v3.0.13
+
+- Run migration 008-add-external-id-to-projects.sql
+- Add missing `external_id` to projects and sites
+
 ## v3.0.12
 
 - Run migration 007-sites-table-add-timezone-column.sql

--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -22,6 +22,13 @@ var APIError = require('../utils/apierror');
 var species = require('./species');
 var songtypes = require('./songtypes');
 
+const projectSchema = joi.object().keys({
+    name: joi.string(),
+    url: joi.string(),
+    description: joi.string().optional(),
+    is_private: joi.boolean(),
+});
+
 var Projects = {
 
     plans: {
@@ -55,6 +62,10 @@ var Projects = {
         if(query.hasOwnProperty("id")) {
             whereExp.push("p.project_id = ?");
             data.push(query.id);
+        }
+        if(query.hasOwnProperty("external_id")) {
+            whereExp.push("p.external_id = ?");
+            data.push(query.external_id);
         }
         if(query.hasOwnProperty("url")) {
             whereExp.push("p.url = ?");
@@ -877,11 +888,13 @@ var Projects = {
             url: `${rfcxConfig.apiBaseUrl}/projects`,
             headers: {
                 'content-type': 'application/json',
-                Authorization: `Bearer ${idToken}`
+                Authorization: `Bearer ${idToken}`,
+                source: 'arbimon'
             },
-            body: JSON.stringify(body)
+            body,
+            json: true
           }
-          return rp(options)
+        return rp(options).then(({ body }) => body)
     },
 
     updateInCoreAPI: async function(data, idToken) {
@@ -894,7 +907,8 @@ var Projects = {
             url: `${rfcxConfig.apiBaseUrl}/internal/arbimon/projects/${data.project_id}`,
             headers: {
                 'content-type': 'application/json',
-                Authorization: `Bearer ${idToken}`
+                Authorization: `Bearer ${idToken}`,
+                source: 'arbimon'
             },
             body: JSON.stringify(body)
           }
@@ -919,6 +933,98 @@ var Projects = {
             }
             return body[0]
         })
+    },
+
+    setExternalId: function (projectId, externalId) {
+        return dbpool.query(`UPDATE projects SET external_id = "${externalId}" WHERE project_id = ${projectId}`, [])
+    },
+
+    /**
+     * Finds unique url value which doesn't exist in db by iterating over several combinations
+     * @param {*} name project name
+     * @param {*} externalId external id
+     * @param {*} userId user id
+     */
+    findUniqueUrl: async function (name, externalId, userId) {
+        const n = this.nameToUrl(name)
+        const random = Math.round(Math.random() * 100000000)
+        const possibilities = [ n, `${externalId}-${n}`,  `${userId}-${externalId}-${n}`, `${userId}-${externalId}-${random}-${n}`]
+        for (let url of possibilities) {
+            const existingProject = await this.find({ url }).get(0)
+            if (!existingProject) {
+                return url
+            }
+        }
+    },
+
+    /**
+     * Creates a project with given data
+     * @param {*} data
+     * @param {string} data.name
+     * @param {string} data.description
+     * @param {string} data.url
+     * @param {boolean} data.is_private
+     * @param {integer} userId
+     */
+    createProject: async function (data, userId) {
+        const projectData = {
+            plan: this.plans.free,
+            project_type_id: 1,
+            ...data
+        }
+        await q.ninvoke(joi, 'validate', projectData, projectSchema, {
+            stripUnknown: true,
+            presence: 'required',
+        });
+        const id = await q.ninvoke(this, "create", projectData, userId)
+        return this.find({ id }).get(0)
+    },
+
+    /**
+     * Creates personal project for given user
+     * @param {*} user
+     * @param {integer} user.user_id
+     * @param {string} user.firstname
+     * @param {string} user.lastname
+     */
+    findOrCreatePersonalProject: async function (user) {
+        const projectData = {
+            is_private: true,
+            plan: this.plans.free,
+            name: `${user.firstname} ${user.lastname}'s project`,
+            url: `${user.user_id}-${this.nameToUrl(user.firstname)}-project`,
+            description: `${user.firstname}'s personal project`,
+            project_type_id: 1
+        };
+        await q.ninvoke(joi, 'validate', projectData, projectSchema, {
+            stripUnknown: true,
+            presence: 'required',
+        });
+        const projWithExistingUrl = await this.find({ url: projectData.url }).get(0);
+        if (projWithExistingUrl) {
+            return projWithExistingUrl
+        }
+        const projectId = await q.ninvoke(this, "create", projectData, user.user_id)
+        return this.find({ id: projectId }).get(0)
+    },
+
+    /**
+     * Removes everything except latin characters, replaces spaces with dashes
+     * @param {*} name
+     */
+    nameToUrl: function (name) {
+        return name.replace(/[^a-z0-9A-Z-]/g, '-').replace(/-+/g,'-').replace(/(^-)|(-$)/g, '').toLowerCase()
+    },
+
+    /**
+     * Checks whether user has permission for the project or not
+     * @param {integer} projectId
+     * @param {integer} userId
+     */
+    userHasPermission: async function (projectId, userId) {
+        const projectUsers = await this.getUsersAsync(projectId);
+        const hasPermission = !!projectUsers.find(x => x.id === userId);
+        return !!hasPermission
     }
 };
 

--- a/app/model/sites.js
+++ b/app/model/sites.js
@@ -14,6 +14,7 @@ var dbpool = require('../utils/dbpool');
 var queryHandler = dbpool.queryHandler;
 
 var site_log_processor = require('../utils/site_log_processor');
+const projects = require('./projects')
 
 var Sites = {
 
@@ -228,6 +229,11 @@ var Sites = {
                 queryHandler(q, callback);
             }
         });
+    },
+
+    removeFromProjectAsync: function (siteId, projectId) {
+        let remove = util.promisify(this.removeFromProject)
+        return remove(siteId, projectId)
     },
 
     listPublished: function(callback) {
@@ -649,6 +655,7 @@ var Sites = {
             name: site.name,
             latitude: site.lat,
             longitude: site.lon,
+            altitude: site.alt,
             project_external_id: site.project_id,
             external_id: site.site_id
         }
@@ -657,11 +664,13 @@ var Sites = {
             url: `${rfcxConfig.apiBaseUrl}/streams`,
             headers: {
                 'content-type': 'application/json',
-                Authorization: `Bearer ${idToken}`
+                Authorization: `Bearer ${idToken}`,
+                source: 'arbimon'
             },
-            body: JSON.stringify(body)
+            body,
+            json: true
           }
-          return rp(options)
+          return rp(options).then(({ body }) => body)
     },
 
     updateInCoreAPI: async function(data, idToken) {
@@ -669,13 +678,15 @@ var Sites = {
         data.name !== undefined && (body.name = data.name)
         data.lat !== undefined && (body.latitude = data.lat)
         data.lon !== undefined && (body.longitude = data.lon)
+        data.alt !== undefined && (body.altitude = data.lon)
         data.project_id !== undefined && (body.project_external_id = data.project_id)
         const options = {
             method: 'PATCH',
             url: `${rfcxConfig.apiBaseUrl}/internal/arbimon/streams/${data.site_id}`,
             headers: {
                 'content-type': 'application/json',
-                Authorization: `Bearer ${idToken}`
+                Authorization: `Bearer ${idToken}`,
+                source: 'arbimon'
             },
             body: JSON.stringify(body)
           }
@@ -688,7 +699,8 @@ var Sites = {
             url: `${rfcxConfig.apiBaseUrl}/internal/arbimon/streams/${site_id}`,
             headers: {
                 'content-type': 'application/json',
-                Authorization: `Bearer ${idToken}`
+                Authorization: `Bearer ${idToken}`,
+                source: 'arbimon'
             }
           }
           return rp(options)
@@ -707,6 +719,19 @@ var Sites = {
           }
 
         return rp(options).then(({ body }) => body)
+    },
+
+    setExternalId: function (siteId, externalId) {
+        return dbpool.query(`UPDATE sites SET external_id = "${externalId}" WHERE site_id = ${siteId}`, [])
+    },
+
+    /**
+     * Checks whether user has permission for the project or not
+     * @param {object} site
+     * @param {integer} userId
+     */
+    userHasPermission: async function (site, userId) {
+        return projects.userHasPermission(site.project_id, userId)
     },
 
     countAllSites: function(callback) {

--- a/app/routes/data-api/index.js
+++ b/app/routes/data-api/index.js
@@ -10,6 +10,7 @@ var routes = [
     '/jobs',
     '/app-listings',
     '/ingest',
+    '/integration',
 ];
 
 

--- a/app/routes/data-api/ingest.js
+++ b/app/routes/data-api/ingest.js
@@ -3,152 +3,17 @@
 
 var express = require('express');
 var router = express.Router();
-var joi = require('joi');
-var q = require('q');
 var model = require('../../model');
 const request = require('request');
 
 const authentication = require('../../middleware/jwt');
 const verifyToken = authentication.verifyToken;
 const hasRole = authentication.hasRole;
-const { Converter, ValidationError, EmptyResultError, ForbiddenError, httpErrorHandler } = require('@rfcx/http-utils');
+const { Converter, EmptyResultError, httpErrorHandler } = require('@rfcx/http-utils');
 
 const config = require('../../config');
 const rfcxConfig = config('rfcx');
 const auth0Service = require('../../model/auth0');
-
-var projectSchema = joi.object().keys({
-  name: joi.string(),
-  url: joi.string(),
-  description: joi.string(),
-  is_private: joi.boolean(),
-});
-
-var freePlan = { ...model.projects.plans.free };
-
-var createProject = function(project, userId) {
-  return q.ninvoke(model.projects, "create", project, userId).then(function(projectId) {
-      model.projects.insertNews({
-          news_type_id: 1, // project created
-          user_id: userId,
-          project_id: projectId,
-          data: JSON.stringify({})
-      });
-
-      return model.projects.find({id: projectId}).get(0)
-  });
-};
-
-// Ensures that user with specified Auth0 token exists in MySQL and creates a project for him
-router.get('/user-project', verifyToken(), hasRole(['appUser', 'rfcxUser']), async function(req, res) {
-  try {
-      const user = await model.users.ensureUserExistFromAuth0(req.user);
-      const project = {
-          is_private: true,
-          plan: freePlan,
-          name: `${user.firstname} ${user.lastname}'s project`,
-          url: `${user.user_id}-${user.firstname.replace(/[^a-z0-9A-Z-]/g, '-').replace(/-+/g,'-').replace(/(^-)|(-$)/g, '').toLowerCase()}-project`,
-          description: `${user.firstname}'s personal project`,
-          project_type_id: 1
-      };
-      await q.ninvoke(joi, 'validate', project, projectSchema, {
-          stripUnknown: true,
-          presence: 'required',
-      });
-      const projWithExistingUrl = await model.projects.find({url: project.url}).get(0);
-      if (projWithExistingUrl) {
-          console.log(`Found existing project by url for user ${user.user_id}`);
-          return res.json(projWithExistingUrl);
-      }
-      const proj = await createProject(project, user.user_id);
-      console.log(`Created new personal project for user ${user.user_id}`);
-      res.status(201).json(proj);
-  } catch (e) {
-      httpErrorHandler(req, res, 'Failed creating a project')(e);
-  }
-})
-
-router.post('/project/:id/sites/create', verifyToken(), hasRole(['appUser', 'rfcxUser']), async function(req, res) {
-    try {
-      const project = await model.projects.find({id: req.params.id}).get(0);
-      if (!project) {
-        throw new EmptyResultError('Project with given uri not found.');
-      }
-      const projectUsers = await model.projects.getUsersAsync(project.project_id);
-      const user = await model.users.ensureUserExistFromAuth0(req.user);
-      const hasPermission = !!projectUsers.find(x => x.id === user.user_id);
-      if (!hasPermission) {
-        throw new ForbiddenError(`You don't have permission to manage project sites`);
-      }
-      const convertedParams = {};
-      const params = new Converter(req.body, convertedParams);
-      params.convert('name').toString();
-      params.convert('external_id').toString();
-      params.convert('lat').toFloat().minimum(-90).maximum(90);
-      params.convert('lon').toFloat().minimum(-180).maximum(180);
-      params.convert('alt').toFloat().minimum(0);
-
-      await params.validate();
-      const siteData = {
-        name: convertedParams.name,
-        external_id: convertedParams.external_id,
-        lat: convertedParams.lat,
-        lon: convertedParams.lon,
-        alt: convertedParams.alt,
-        project_id: project.project_id,
-        legacy: false
-      };
-      const existingSite = await model.sites.find({ external_id: siteData.external_id, project_id: siteData.project_id }).get(0);
-      if (existingSite) {
-        return res.json(existingSite);
-      }
-      const insertData = await model.sites.insertAsync(siteData);
-      const site = await model.sites.findByIdAsync(insertData.insertId);
-      model.projects.insertNews({
-          news_type_id: 2, // site created
-          user_id: user.user_id,
-          project_id: project.project_id,
-          data: JSON.stringify({ site: siteData.name })
-      });
-      res.status(201).json(site[0]);
-    } catch (e) {
-        httpErrorHandler(req, res, 'Failed creating a site')(e);
-    }
-})
-
-router.patch('/sites/:externalId', verifyToken(), hasRole(['appUser', 'rfcxUser']), async function(req, res) {
-  try {
-    const user = await model.users.ensureUserExistFromAuth0(req.user);
-    const converter = new Converter(req.body, {});
-    converter.convert('name').optional().toString();
-    converter.convert('latitude').optional().toFloat().minimum(-90).maximum(90);
-    converter.convert('longitude').optional().toFloat().minimum(-180).maximum(180);
-    converter.convert('altitude').optional().toFloat().minimum(0);
-
-    const params = await converter.validate();
-    const site = await model.sites.find({ external_id: req.params.externalId }).get(0);
-    if (!site) {
-      // TODO request site from CORE API if not found
-      throw new EmptyResultError('Site with given external_id not found.');
-    }
-    const project = await model.projects.find({id: site.project_id}).get(0);
-    const projectUsers = await model.projects.getUsersAsync(project.project_id);
-    const hasPermission = !!projectUsers.find(x => x.id === user.user_id);
-    if (!hasPermission) {
-      throw new ForbiddenError(`You don't have permission to manage project sites`);
-    }
-    await model.sites.updateAsync({
-      site_id: site.site_id,
-      name: params.name,
-      lat: params.latitude,
-      lon: params.longitude,
-      alt: params.altitude
-    })
-    res.sendStatus(200);
-  } catch (e) {
-    httpErrorHandler(req, res, 'Failed updating a site')(e);
-  }
-})
 
 router.post('/recordings/create', verifyToken(), hasRole(['systemUser']), async function(req, res) {
   try {
@@ -176,7 +41,6 @@ router.post('/recordings/create', verifyToken(), hasRole(['systemUser']), async 
         try {
           // Find info about this site (guardian) in Core API DB
           const externalSite = await model.sites.findInCoreAPI(convertedParams.site_external_id)
-          const url = externalSite.site.guid
           // Check if we have a project for this site in the DB
           var project = await model.projects.find({ url }).get(0)
           if (!project) {
@@ -185,13 +49,13 @@ router.post('/recordings/create', verifyToken(), hasRole(['systemUser']), async 
             // All guardian sites belong to support user by default
             const user = (await model.users.findByEmailAsync('support@rfcx.org'))[0];
             // Create missing project
-            project = await createProject({
-              is_private: true,
-              plan: freePlan,
+            const url = await model.projects.findUniqueUrl(externalProject.name, externalProject.id, user.user_id)
+            project = await model.projects.createProject({
               name: externalProject.name,
-              url: externalProject.guid,
               description: externalProject.description,
-              project_type_id: 1
+              is_private: true,
+              external_id: externalProject.id,
+              url: externalSite.site.guid
             }, user.user_id)
           }
           // Create missing site

--- a/app/routes/data-api/integration.js
+++ b/app/routes/data-api/integration.js
@@ -1,0 +1,131 @@
+/* jshint node:true */
+"use strict";
+
+var express = require('express');
+var router = express.Router();
+var model = require('../../model');
+
+const authentication = require('../../middleware/jwt');
+const verifyToken = authentication.verifyToken;
+const hasRole = authentication.hasRole;
+const { Converter, EmptyResultError, ForbiddenError, httpErrorHandler } = require('@rfcx/http-utils');
+
+router.post('/projects', verifyToken(), hasRole(['appUser', 'rfcxUser']), async function(req, res) {
+  try {
+    const converter = new Converter(req.body, {});
+    converter.convert('name').toString();
+    converter.convert('description').optional().toString();
+    converter.convert('is_private').toBoolean().default(true);
+    converter.convert('external_id').toString();
+    const params = await converter.validate();
+    const user = await model.users.ensureUserExistFromAuth0(req.user);
+    const url = await model.projects.findUniqueUrl(params.name, params.external_id, user.user_id)
+    const { name, description, is_private, external_id } = params
+    const project = await model.projects.createProject({ name, description, is_private, external_id, url }, user.user_id)
+    res.status(201).json(project);
+  } catch (e) {
+    httpErrorHandler(req, res, 'Failed creating a site')(e);
+  }
+})
+
+router.post('/sites', verifyToken(), hasRole(['appUser', 'rfcxUser']), async function(req, res) {
+  try {
+    const converter = new Converter(req.body, {});
+    converter.convert('name').toString();
+    converter.convert('latitude').toFloat().minimum(-90).maximum(90);
+    converter.convert('longitude').toFloat().minimum(-180).maximum(180);
+    converter.convert('altitude').toFloat().minimum(0);
+    converter.convert('external_id').toString();
+    converter.convert('project_id').optional().toString();
+    converter.convert('project_external_id').optional().toString();
+    const params = await converter.validate();
+    const user = await model.users.ensureUserExistFromAuth0(req.user);
+
+    let project
+    if (!params.project_id && !params.project_external_id) {
+      project = await model.projects.findOrCreatePersonalProject(user)
+    } else {
+      if (params.project_id) {
+        project = await model.projects.find({id: params.project_id}).get(0);
+      } else if (params.project_external_id) {
+        project = await model.projects.find({ external_id: params.project_external_id }).get(0);
+        // TODO: request project and permissions from Core API
+      }
+      if (!project) {
+        throw new EmptyResultError('Project with given parameters not found.');
+      }
+      const hasPermission = await model.projects.userHasPermission(project.project_id, user.user_id)
+      if (!hasPermission) {
+        throw new ForbiddenError(`You don't have permission to manage project sites`);
+      }
+    }
+
+    const siteData = {
+      name: params.name,
+      lat: params.latitude,
+      lon: params.longitude,
+      alt: params.altitude,
+      external_id: params.external_id,
+      project_id: project.project_id,
+      legacy: false
+    };
+    const existingSite = await model.sites.find({ external_id: siteData.external_id, project_id: siteData.project_id }).get(0);
+    if (existingSite) {
+      return res.json(existingSite);
+    }
+    const insertData = await model.sites.insertAsync(siteData);
+    const site = await model.sites.findByIdAsync(insertData.insertId);
+    res.status(201).json(site[0]);
+  } catch (e) {
+    httpErrorHandler(req, res, 'Failed creating a site')(e);
+  }
+})
+
+router.patch('/sites/:externalId', verifyToken(), hasRole(['appUser', 'rfcxUser']), async function(req, res) {
+  try {
+    const user = await model.users.ensureUserExistFromAuth0(req.user);
+    const converter = new Converter(req.body, {});
+    converter.convert('name').optional().toString();
+    converter.convert('latitude').optional().toFloat().minimum(-90).maximum(90);
+    converter.convert('longitude').optional().toFloat().minimum(-180).maximum(180);
+    converter.convert('altitude').optional().toFloat().minimum(0);
+
+    const params = await converter.validate();
+    const site = await model.sites.find({ external_id: req.params.externalId }).get(0);
+    if (!site) {
+      // TODO request site from CORE API if not found
+      throw new EmptyResultError('Site with given external_id not found.');
+    }
+    if (!await model.sites.userHasPermission(site, user.user_id)) {
+      throw new ForbiddenError(`You don't have permission to manage project sites`);
+    }
+    await model.sites.updateAsync({
+      site_id: site.site_id,
+      name: params.name,
+      lat: params.latitude,
+      lon: params.longitude,
+      alt: params.altitude
+    })
+    res.sendStatus(200);
+  } catch (e) {
+    httpErrorHandler(req, res, 'Failed updating a site')(e);
+  }
+})
+
+router.delete('/sites/:externalId', verifyToken(), hasRole(['appUser', 'rfcxUser']), async function(req, res) {
+  try {
+    const user = await model.users.ensureUserExistFromAuth0(req.user);
+    const site = await model.sites.find({ external_id: req.params.externalId }).get(0);
+    if (site) {
+      if (!await model.sites.userHasPermission(site, user.user_id)) {
+        throw new ForbiddenError(`You don't have permission to manage project sites`);
+      }
+      await model.sites.removeFromProjectAsync(site.site_id, site.project_id)
+    }
+    res.sendStatus(204);
+  } catch (e) {
+    httpErrorHandler(req, res, 'Failed deleting a site')(e);
+  }
+})
+
+module.exports = router;

--- a/app/routes/data-api/orders.js
+++ b/app/routes/data-api/orders.js
@@ -217,6 +217,9 @@ router.post('/create-project', function(req, res, next) {
                                 project.project_id = projectId
                                 if (rfcxConfig.coreAPIEnabled) {
                                     model.projects.createInCoreAPI(project, req.session.idToken)
+                                        .then((externalProject) => {
+                                            return model.projects.setExternalId(project.project_id, externalProject.id)
+                                        })
                                 }
                             }
                             res.json({
@@ -244,6 +247,9 @@ router.post('/create-project', function(req, res, next) {
                             project.project_id = projectId
                             if (rfcxConfig.coreAPIEnabled) {
                                 model.projects.createInCoreAPI(project, req.session.idToken)
+                                    .then((externalProject) => {
+                                        return model.projects.setExternalId(project.project_id, externalProject.id)
+                                    })
                             }
                         }
                         res.json({

--- a/app/routes/data-api/project/sites.js
+++ b/app/routes/data-api/project/sites.js
@@ -40,18 +40,14 @@ router.post('/create', function(req, res, next) {
         model.sites.insert(site, function(err, result) {
             if(err) return next(err);
 
-            model.projects.insertNews({
-                news_type_id: 2, // site created
-                user_id: req.session.user.id,
-                project_id: project.project_id,
-                data: JSON.stringify({ site: site.name })
-            });
-
             if (rfcxConfig.coreAPIEnabled) {
                 model.sites.createInCoreAPI({
                     ...site,
                     site_id: result.insertId
                 }, req.session.idToken)
+                    .then((externalSite) => {
+                        return model.sites.setExternalId(result.insertId, externalSite.id)
+                    })
             }
 
             res.json({ message: "New site created" });

--- a/scripts/db/000-base-tables.sql
+++ b/scripts/db/000-base-tables.sql
@@ -1216,6 +1216,7 @@ CREATE TABLE `projects` (
   `pattern_matching_enabled` tinyint(1) NOT NULL DEFAULT '0',
   `citizen_scientist_enabled` tinyint(1) NOT NULL DEFAULT '0',
   `cnn_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  `external_id` varchar(12) DEFAULT NULL,
   PRIMARY KEY (`project_id`),
   UNIQUE KEY `url` (`url`),
   KEY `project_type_id` (`project_type_id`),

--- a/scripts/db/008-add-external-id-to-projects.sql
+++ b/scripts/db/008-add-external-id-to-projects.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `arbimon2`.`projects`
+ADD COLUMN `external_id` varchar(12) DEFAULT NULL;


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-174](https://jira.rfcx.org/browse/CE-174)
- [x] Release notes updated
- [x] Deployment notes updated
- [x] DB migrations na

## 📝 Summary

- Send delete stream request to Core API when site is deleted
- _Send data to Core API when project is created and save `external_id` from results_
- _Send data to Core API when site is created and save `external_id` from results_
- _Move site and project creation into `integration` routes and build logic around received site or project_
- _Rework unification between Arbimon and Core API to exchange `external_id`s_

## 📸 Screenshots

## 🛑 Problems

- Hope no any!

## 💡 More ideas

### Test cases which I have checked:
Projects:
1) User creates new project in Arbimon
Result: project with same name and `external_id === project_id` is created in RFCx. `external_id` is saved both in RFCx and Arbimon projects

2) User created new project in Core API
Result: site with same name is created in Arbimon. `external_id` is saved both in RFCx and Arbimon projects


Streams/Sites:

1) User creates new site in the Arbimon
Result: stream is created in Core API. `external_id` is saved both in RFCx and Arbimon projects

2) User updates site in the Arbimon
Result: stream is updated in Corea API.

3) User creates stream in Core API without project id.
Result: stream is created in Core API, site is created in user's personal project in Arbimon. `external_id` is saved both in RFCx and Arbimon projects

4) User creates stream in Core API with project id of some shared project
Result: stream is created in Core API under project, site is created in the same project of the Arbimon

5) User updates stream in Core API
Result: stream is updated in Arbimon

6) User deletes stream in Core API
Result: site is deleted in Arbimon

7) User deletes site in Arbimon
Result: stream is deleted in Core API
