### PR TITLE
Hotfix do not show tabs for the project owner

### DIFF
--- a/assets/app/app.js
+++ b/assets/app/app.js
@@ -82,5 +82,5 @@ var a2 = angular.module('a2.app', [
             return '/citizen-scientist/' + Project.getUrl() + '/';
         }
     }
-    $scope.citizenScientistUser = a2UserPermit.can('use citizen scientist interface') && !a2UserPermit.isSuper();
+    $scope.citizenScientistUser = !a2UserPermit.can('delete project') && a2UserPermit.can('use citizen scientist interface') && !a2UserPermit.isSuper();
 });


### PR DESCRIPTION
## ✅ DoD

- [x] hotfix do not show tabs for the project owner

## 📝 Summary

!a2UserPermit.can('delete project') - not project owner
a2UserPermit.can('use citizen scientist interface') - citizen scientist
!a2UserPermit.isSuper() - not super user
## 📸 Screenshots

Put screenshots here!

## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
