### PR TITLE
Make projects private by default

### DIFF
--- a/assets/app/directives/a2forms.js
+++ b/assets/app/directives/a2forms.js
@@ -208,7 +208,7 @@ angular.module('a2.forms',['templates-arbimon2'])
                 $scope.verify();
             }
             else {
-                $scope.project = { is_private: 0 };
+                $scope.project = { is_private: 1 };
                 $scope.valid = false;
             }
             

--- a/assets/app/directives/project-form.html
+++ b/assets/app/directives/project-form.html
@@ -44,13 +44,13 @@
     </div>
     <div class="radio">
         <label class="control-label" for="public">
-            <input id="public" type="radio" ng-model="project.is_private" value="0" ng-checked="true" class="cs-pointer">
+            <input id="public" type="radio" ng-model="project.is_private" value="0" class="cs-pointer">
             <i class="fa fa-globe"></i> Public - anyone can view this project as a guest. Only authorize users can edit
         </label>
     </div>
     <div class="radio">
         <label class="control-label" for="private">
-            <input id="private" type="radio" ng-model="project.is_private" value="1" class="cs-pointer">
+            <input id="private" type="radio" ng-model="project.is_private" value="1" ng-checked="true" class="cs-pointer">
             <i class="fa fa-lock"></i> Private - only you and users you authorize can access this project
         </label>
     </div>


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves _None_
- [ ] Release notes updated
- [x] Deployment notes na
- [x] DB migrations na

## 📝 Summary

- To reduce the number of poor quality public projects, make "private" the default when creating a project.

## 📸 Screenshots

<img width="616" alt="Screenshot 2021-04-12 at 15 33 21" src="https://user-images.githubusercontent.com/1175362/114365212-6ff1ee00-9ba4-11eb-9369-c8044da442e6.png">

## 🛑 Problems

_None_

## 💡 More ideas

I'm tempted to go a step further and remove the option for public from this page. It is possible for a user to make a project public in the Settings page. What do you think @zephyrgold ?
