### PR TITLE
CE-537 Fix the location of the legend for the scatter plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Resolved issues:
 - PI-730 Fix blank Visualizer page in Pattern Matching - Expert's View part in Citizen Scientist
 - Support for Core API v1.1.x changes
 - PI-739 The Visualizer page not loading before switching tabs
+- CE-537 Fix the location of the legend for the scatter plot
 
 Performance improvements:
 

--- a/assets/app/app/analysis/clustering-jobs/index.js
+++ b/assets/app/app/analysis/clustering-jobs/index.js
@@ -249,11 +249,13 @@ angular.module('a2.analysis.clustering-jobs', [
         // shapes layout
         $scope.layout = {
             shapes: shapes,
-            height: 400,
+            height: 500,
             width: el ? el.offsetWidth : 1390,
             showlegend: true,
             legend: {
-                orientation: 'h',
+                x: 1,
+                xanchor: 'right',
+                y: 1,
                 itemclick: 'toggleothers',
                 font: {
                     color: 'white'


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-537](https://jira.rfcx.org/browse/PI-537)
- [x] Release notes updated

## 📝 Summary

- Move the legend to top right corner

## 📸 Screenshots

<img width="1623" alt="Screenshot 2021-04-20 at 12 07 55" src="https://user-images.githubusercontent.com/31901584/115370502-cb8a3000-a1d1-11eb-97bd-8dda44895117.png">


## 🛑 Problems

None

## 💡 More ideas

None
