### PR TITLE
CE-728 Cluster scatter plot is too rectangular

### DIFF
--- a/assets/app/app/analysis/clustering-jobs/index.js
+++ b/assets/app/app/analysis/clustering-jobs/index.js
@@ -249,7 +249,7 @@ angular.module('a2.analysis.clustering-jobs', [
         // shapes layout
         $scope.layout = {
             shapes: shapes,
-            height: 500,
+            height: el ? el.offsetWidth - el.offsetWidth/3 : 800,
             width: el ? el.offsetWidth : 1390,
             showlegend: true,
             legend: {


### PR DESCRIPTION
Pull request created in: https://jira.rfcx.org/browse/CE-728

## ✅ DoD

- [x] Cluster scatter plot is too rectangular

## 📝 Summary

- The scatter plot should be closer to square-shaped

## 📸 Screenshots

https://user-images.githubusercontent.com/51106210/119328770-aa27d280-bcae-11eb-89fb-f06630bb4682.mp4
