### PR TITLE
CE-729 Remove redundant icon in cluster selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Resolved issues:
 - CE-683 Fix creating soundscape composition classes
 - CE-683 Display system classes with project soundscape composition classes
 - CE-730 Don't show coordinates of points in Clustering scatter plot when hovering over
+- CE-729 Remove redundant icon in cluster selector
 
 Performance improvements:
 

--- a/assets/less/style.less
+++ b/assets/less/style.less
@@ -1524,7 +1524,7 @@ img.outlined {
 }
 
 /* Firefox */
-.hide-input-arrow > input[type=number] {
+.hide-input-arrow {
   -moz-appearance: textfield;
 }
 


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-729](https://jira.rfcx.org/browse/CE-729)

## 📝 Summary

- Remove redundant icon in cluster selector by remove `input[number]` from `.hide-input-arrow`

## 📸 Screenshots

Chrome
![image](https://user-images.githubusercontent.com/44169425/119808094-fde42700-bf0d-11eb-87b6-2392debbcb1f.png)

Firefox
![image](https://user-images.githubusercontent.com/44169425/119808134-09cfe900-bf0e-11eb-8dd2-acbbece24c3e.png)

## 🛑 Problems

None

## 💡 More ideas

None