### PR TITLE
CE-724 Can view results from specific AED job if multiple have been run on the same playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Resolved issues:
 - CE-729 Remove redundant icon in cluster selector
 - Fix sorting issue on the Grid View page
 - CE-723 Selected visualizer link in Grid View opens ROI in the Visualizer
+- CE-724 Can view results from specific AED job if multiple have been run on the same playlist
 
 Performance improvements:
 

--- a/app/model/audio-event-detections-clustering.js
+++ b/app/model/audio-event-detections-clustering.js
@@ -28,7 +28,7 @@ var AudioEventDetectionsClustering = {
         }
 
         if (!options.playlist) {
-            select.push("JP.name, JP.parameters");
+            select.push("JP.job_id, JP.name, JP.parameters");
             select.push("JP.`date_created` as `timestamp`");
             select.push("P.playlist_id, P.`name` as `playlist_name`");
             tables.push("JOIN playlists P ON JP.playlist_id = P.playlist_id");
@@ -57,9 +57,8 @@ var AudioEventDetectionsClustering = {
         }
 
         if (options.playlist) {
-            select.push('A.aed_id, A.`recording_id` as `rec_id`');
-            tables.push('JOIN playlist_aed PLE ON A.aed_id = PLE.aed_id');
-            constraints.push('PLE.playlist_id = ' + dbpool.escape(options.playlist));
+            select.push('A.aed_id, A.`recording_id` as `rec_id`, JP.job_id, JP.name');
+            constraints.push('JP.playlist_id = ' + dbpool.escape(options.playlist));
         }
 
         postprocess.push((rows) => {

--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -92,8 +92,7 @@ var ClusteringJobs = {
             options = {};
         }
         select.push(
-            "A.aed_id, A.time_min, A.time_max, A.frequency_min, A.frequency_max, A.recording_id",
-            "A.`uri_image` as `uri`"
+            "A.aed_id, A.time_min, A.time_max, A.frequency_min, A.frequency_max, A.recording_id, A.`uri_image` as `uri`"
         );
 
         if (options.aed) {
@@ -110,6 +109,13 @@ var ClusteringJobs = {
             select.push('C.`date_created`');
             tables.push("JOIN job_params_audio_event_clustering C ON A.job_id = C.audio_event_detection_job_id");
             groupby.push('A.aed_id');
+        }
+
+        if (options.rec_id) {
+            select.push("PL.`name` as `playlist_name`, PL.`playlist_id`");
+            tables.push('JOIN playlist_aed PLE ON A.aed_id = PLE.aed_id');
+            tables.push('JOIN playlists PL ON PLE.playlist_id = PL.playlist_id');
+            constraints.push('A.recording_id = ' + dbpool.escape(options.rec_id));
         }
 
         return dbpool.query(

--- a/app/routes/data-api/project/clustering-jobs.js
+++ b/app/routes/data-api/project/clustering-jobs.js
@@ -44,7 +44,8 @@ router.get('/:job_id/job-details', function (req, res, next) {
 router.get('/:job_id/rois-details', function(req, res, next) {
     res.type('json');
     var params = {
-        aed: req.query.aed
+        aed: req.query.aed,
+        rec_id: req.query.rec_id
     };
     if (req.query.perSite) params.perSite = req.query.perSite;
     if (req.query.perDate) params.perDate = req.query.perDate;

--- a/assets/app/a2services/clustering-jobs-service.js
+++ b/assets/app/a2services/clustering-jobs-service.js
@@ -36,6 +36,9 @@ angular.module('a2.srv.clustering-jobs', [
             if (opts.aed) {
                 config.params.aed = opts.aed;
             }
+            if (opts.rec_id) {
+                config.params.rec_id = opts.rec_id;
+            }
             if (opts.search && opts.search == 'per_site')  {
                 config.params.perSite = true;
             }

--- a/assets/app/app/analysis/audio-event-detections-clustering/index.js
+++ b/assets/app/app/analysis/audio-event-detections-clustering/index.js
@@ -13,7 +13,7 @@ angular.module('a2.analysis.audio-event-detections-clustering', [
             templateUrl: '/app/analysis/audio-event-detections-clustering/list.html'
         })
 })
-.controller('AudioEventDetectionsClusteringModelCtrl' , function($scope, $modal, $location, JobsData, notify, a2AudioEventDetectionsClustering, Project) {
+.controller('AudioEventDetectionsClusteringModelCtrl' , function($scope, $modal, $location, JobsData, notify, a2AudioEventDetectionsClustering, Project, $localStorage, $window) {
     $scope.loadAudioEventDetections = function() {
         $scope.loading = true;
         $scope.projectUrl = Project.getUrl();
@@ -31,6 +31,11 @@ angular.module('a2.analysis.audio-event-detections-clustering', [
     };
 
     $scope.loadAudioEventDetections();
+
+    $scope.onSelectedJob = function(playlist_id, job_id) {
+        $localStorage.setItem('analysis.audioEventJob',  job_id);
+        $window.location.href = '/project/'+Project.getUrl()+'/visualizer/playlist/'+playlist_id;
+    }
 
     $scope.createNewClusteringModel = function () {
       var modalInstance = $modal.open({

--- a/assets/app/app/analysis/audio-event-detections-clustering/list.html
+++ b/assets/app/app/analysis/audio-event-detections-clustering/list.html
@@ -34,7 +34,7 @@
                 </field>
                 <field class="is-v-middle">
                     <a class="btn btn-default btn-xs"
-                        ng-href="/project/{{projectUrl}}/visualizer/playlist/{{row.playlist_id}}"
+                        ng-click="onSelectedJob(row.playlist_id, row.job_id)"
                         title="View in Visualizer">
                         <i class="fa fa-cubes"></i>
                     </a>

--- a/assets/app/app/visualizer/layer-item/audio-events-layer.html
+++ b/assets/app/app/visualizer/layer-item/audio-events-layer.html
@@ -4,11 +4,41 @@
         Audio Events
     </h5>
     <div ng-show="layer.is_open">
-        <div ng-if="layer.audio_events.audioEvents && !layer.audio_events.audioEvents.length">
+        <div ng-if="!layer.audio_events.audioEvents || !layer.audio_events.clusteringEvents" class="row ng-cloak text-center py-2">
+            <i class="fa fa-spinner fa-spin" style="font-size: 16px;"></i>
+        </div>
+        <div ng-if="layer.audio_events.audioEvents && !layer.audio_events.audioEvents.length && !layer.audio_events.clusteringEvents && layer.audio_events.clusteringEvents.length">
             There are no audio events in this {{ layer.audio_events.isPlaylist? 'playlist' : 'recording' }}.
         </div>
-        <div ng-if="layer.audio_events.audioEvents && layer.audio_events.audioEvents.length">
-                There {{ layer.audio_events.audioEvents.length > 1 ? 'are' : 'is'}} {{ layer.audio_events.audioEvents.length }} audio events in this {{ layer.audio_events.isPlaylist? 'playlist' : 'recording' }}.
+        <div ng-if="layer.audio_events.audioEvents && layer.audio_events.clusteringEvents">
+            <div ng-if="layer.audio_events.audioEvents && layer.audio_events.audioEvents.length">
+                <strong>Detection Jobs</strong>
+                <ul class="ulnodeco px-2">
+                    <li ng-repeat="job in layer.audio_events.audioEventJobs" class="my-3" style="display: flex; flex-direction: row; justify-content: flex-start; align-items: baseline; position: relative; white-space: nowrap;">
+                        <span class="hidelongtext" style="width: 90%;" title="{{ row.name }}">
+                            {{ job.name }}
+                        </span>
+                        <button class="layer-btn" ng-click="job.visible = !job.visible; layer.audio_events.toggleAudioEvents(true, job.job_id, job.visible)" style="border: 0; background: transparent; position: absolute; top: -1; right: -12px;"
+                            ng-class="{'layer-btn_active': job.visible && job.count}">
+                            <i class="fa" ng-class="{'fa-eye': job.visible, 'fa-eye-slash': !job.visible}"></i>
+                        </button>
+                    </li>
+                </ul>
+            </div>
+            <div ng-if="layer.audio_events.clusteringEvents && layer.audio_events.clusteringEvents.length">
+                <strong>Cluster Playlists</strong>
+                <ul class="ulnodeco px-2">
+                    <li ng-repeat="row in layer.audio_events.clusterPlaylists" class="my-3" style="display: flex; flex-direction: row; justify-content: flex-start; align-items: baseline; position: relative; white-space: nowrap;">
+                        <span class="hidelongtext" style="width: 90%;" title="{{ row.playlist_name }}">
+                            {{ row.playlist_name }}
+                        </span>
+                        <button class="layer-btn" ng-click="row.visible = !row.visible; layer.audio_events.toggleAudioEvents(false, row.playlist_id, row.visible)" style="border: 0; background: transparent; position: absolute; top: -1; right: -12px;"
+                            ng-class="{'layer-btn_active': row.visible}">
+                            <i class="fa" ng-class="{'fa-eye': row.visible, 'fa-eye-slash': !row.visible}"></i>
+                        </button>
+                    </li>
+                </ul>
+            </div>
         </div>
     </div>
 </div>

--- a/assets/app/app/visualizer/layer-item/default.html
+++ b/assets/app/app/visualizer/layer-item/default.html
@@ -6,7 +6,7 @@
     <div class="layer-btns">
         <button class="layer-btn" ng-click="layer.visible = !layer.visible | trackEvent:'Visualizer-Default':'layer visibility'"
             ng-class="{'layer-btn_active': layer.templates && (layer.templates.recordingTemplates && layer.templates.recordingTemplates.length)
-                || (layer.training_data.data.rois.length || layer.training_data.data.editor.roi) || (layer.audio_events.audioEvents && layer.audio_events.audioEvents.length)}">
+                || (layer.training_data.data.rois.length || layer.training_data.data.editor.roi)}">
             <i class="fa" ng-class="{'fa-eye': layer.visible, 'fa-eye-slash':!layer.visible}"></i>
         </button>
     </div>

--- a/assets/app/app/visualizer/spectrogram-layer/audio-events-layer.html
+++ b/assets/app/app/visualizer/spectrogram-layer/audio-events-layer.html
@@ -7,7 +7,23 @@
                 top:layout.hz2y(roi.y2, 1) + 'px',
                 width:layout.dsec2width(roi.x2, roi.x1, 1) + 'px',
                 height:layout.dhz2height(roi.y2, roi.y1) + 'px',
-                display: roi.display || ''
+                display: roi.display || '',
+                opacity: roi.opacity
+            }">
+        </div>
+    </div>
+</div>
+<div>
+    <div ng-repeat="roi in layer.audio_events.clusteringEvents">
+        <div class="roi audio-event"
+            ng-class="roi.class || ''"
+            ng-style="{
+                left:layout.sec2x(roi.x1, 1) + 'px',
+                top:layout.hz2y(roi.y2, 1) + 'px',
+                width:layout.dsec2width(roi.x2, roi.x1, 1) + 'px',
+                height:layout.dhz2height(roi.y2, roi.y1) + 'px',
+                display: roi.display || '',
+                opacity: roi.opacity
             }">
         </div>
     </div>


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-724](https://jira.rfcx.org/browse/CE-724)
- [x] Release notes updated

## 📝 Summary

- Changed the logic of displaying AEDs jobs and Cluster Playlists on the Visualizer page
- I've created the test cases, for the best checking the updates:

1. User navigates to https://staging-arbimon.rfcx.org/project/bci-panama-2018/visualizer page. User selects any recording (https://staging-arbimon.rfcx.org/project/bci-panama-2018/visualizer/rec/3302034). User clicks on Audio Events row. The recording doesn't have any events. The user sees the text: "There are no audio events in this recording."

2. User navigates to https://staging-arbimon.rfcx.org/project/bci-panama-2018/visualizer page. User selects any recording (https://staging-arbimon.rfcx.org/project/bci-panama-2018/visualizer/rec/3302348). User clicks on Audio Events row. User sees the spinner. The recording has events. All events are hidden. User sees Detection Jobs and Cluster Playlists related with that recording. User clicks on any eye icon. User sees red boxes on the spectrogram.
<img width="1680" alt="Screenshot 2021-05-31 at 18 46 16" src="https://user-images.githubusercontent.com/31901584/120240536-79750980-c269-11eb-8ebf-cc72c5493f51.png">

3. User navigates to https://staging-arbimon.rfcx.org/project/bci-panama-2018/visualizer page. User selects any playlists (https://staging-arbimon.rfcx.org/project/bci-panama-2018/visualizer/playlist/8578/3302374). User clicks on Audio Events row. User sees the spinner. The recording has events. All events are hidden. User sees only Cluster Playlists related with that recording (The playlist created from the Grid View page). User clicks on any eye icon. User sees red boxes on the spectrogram.
<img width="1673" alt="Screenshot 2021-05-31 at 18 50 36" src="https://user-images.githubusercontent.com/31901584/120240582-9a3d5f00-c269-11eb-8a36-f826de737284.png">

4. User navigates to http://localhost:3000/project/bci-panama-2018/analysis/audio-event-detections-clustering page. User selects any audio event job (http://localhost:3000/project/bci-panama-2018/visualizer/playlist/6382). User navigates to the Visualizer pagr. User selects any recording in the playlist. User sees red boxes on the spectrogram. User clicks on Audio Events row. User sees active job in the Detection Jobs area. User can activate(clicks on eye icon) different jobs and clusters on the spectrogram. User reloads the page. User can't see active jobs.
<img width="1680" alt="Screenshot 2021-05-31 at 18 27 45" src="https://user-images.githubusercontent.com/31901584/120240603-a75a4e00-c269-11eb-90c4-d95d05dd658c.png">

5. User navigates to https://staging-arbimon.rfcx.org/project/bci-panama-2018/analysis/clustering-jobs page. User selects any audio clustering job (https://staging-arbimon.rfcx.org/project/bci-panama-2018/analysis/clustering-jobs/12328). User clicks on lasso and selects dots on the scale. User clicks on the Context View menu. User navigates to the Visualizer page. User clicks on any recording in the temporary playlist or if the user sees one recording it’s right. User sees oranges boxes on the spectrogram. User clicks on Audio Events menu. User sees any Detections jobs and Clustering Playlists related to selected recording. User can activate any job. User can create the playlist with AEDs from oranges boxes clicks on “+” button on the buttons controls.
<img width="1680" alt="Screenshot 2021-05-31 at 22 05 25" src="https://user-images.githubusercontent.com/31901584/120240624-b9d48780-c269-11eb-95ac-a4542bcf1199.png">
<img width="1680" alt="Screenshot 2021-05-31 at 21 59 00" src="https://user-images.githubusercontent.com/31901584/120240633-c062ff00-c269-11eb-8ec7-fdc05ae187d0.png">

6. User navigates to https://staging-arbimon.rfcx.org/project/bci-panama-2018/analysis/clustering-jobs page. User selects any audio clustering job (https://staging-arbimon.rfcx.org/project/bci-panama-2018/analysis/clustering-jobs/12328). User clicks on lasso and selects dots on the scale. User clicks on the Grid View menu. User clicks on t”he View on Visualizer” btn in any box. User navigates to the Visualizer page. User sees 1 orange box on the spectrogram. User clicks on the Audio Events menu. User sees any Detections jobs and Clustering Playlists related to selected recording. User can activate any job.
<img width="1680" alt="Screenshot 2021-05-31 at 22 16 41" src="https://user-images.githubusercontent.com/31901584/120240698-dc66a080-c269-11eb-8ab2-c825bf504dbc.png">
<img width="1677" alt="Screenshot 2021-05-31 at 22 17 22" src="https://user-images.githubusercontent.com/31901584/120240706-e1c3eb00-c269-11eb-904d-5eeb6c5b84dd.png">

## 📸 Screenshots

I've attached above to the test cases

## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
