### PR TITLE
CE-989 The columns order are changed. Show Unknown if the recording hasn't in the file name data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - CE-940 Change "Storage: " to "Recordings:"
 
+Other:
+- The columns order is changed on the recording page
+- Show "Unknown" if the recording hasn't in the file name data
+
 ## v3.0.30 - June XX, 2021
 
 Resolved issues:

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -1230,7 +1230,7 @@ var Recordings = {
                             _1.imported = siteData[_1.site_id].project_id !== parameters.project_id;
                             _1.comments = _1.meta ? Recordings.__parse_comments_data(_1.meta) : null;
                             _1.meta = _1.meta ? Recordings.__parse_meta_data(_1.meta) : null;
-                            _1.filename = _1.meta && _1.meta.filename? _1.meta.filename : null;
+                            _1.filename = _1.meta? (_1.meta.filename? _1.meta.filename : 'Unknown') : null;
                             Recordings.__compute_thumbnail_path_async(_1);
                             if (!_1.legacy) {
                                 _1.file = `${moment.utc(_1.datetime).format('YYYYMMDD_HHmmss')}${path.extname(_1.file)}`;

--- a/assets/app/app/audiodata/recordings/recordings.html
+++ b/assets/app/app/audiodata/recordings/recordings.html
@@ -50,9 +50,9 @@
 <div class="row">
     <div class="col-sm-12">
         <a2-table rows="recs" data-checked="checked" ext-sort="controller.sortRecs(sortBy, reverse)" default-sort="site">
-            <field title="Filename" key="file">{{ row.filename? row.filename : row.file }}</field>
             <field title="Site" key="site">{{ row.site }}</field>
             <field title="Recorded Time" key="datetime" >{{ (row.datetime | momentUtc : 'YYYY-MM-DD HH:mm:ss') }}</field>
+            <field title="Filename" key="file">{{ row.filename? row.filename : row.file }}</field>
             <field title="Uploaded Time" key="upload_time" >{{ (row.upload_time | momentUtc : 'YYYY-MM-DD HH:mm:ss') }}</field>
             <field title="Recorder" key="recorder">{{ row.recorder }}</field>
             <field title="Comments" key="comments" className="comments hidelongtext seconds-div-center">


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-989](https://jira.rfcx.org/browse/CE-989)
- [x] Release notes updated

## 📝 Summary

- The columns order are changed on the recording page
- Show "Unknown" if the recording hasn't in the file name data

## 📸 Screenshots

<img width="1573" alt="Screenshot 2021-06-28 at 11 28 29" src="https://user-images.githubusercontent.com/31901584/123604970-07f68f80-d804-11eb-94c0-fff2ed6d5ade.png">


## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
