### PR TITLE
CE-1183 User is able to select the month of Jenuary in the recordings filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Arbimon Release Notes
 
+## v3.0.35 - August XX, 2021
+
+Resolved issues:
+
+- CE-1183 Fixed filter in the recordings page. The user is able to select the month of January
+
 ## v3.0.34 - August XX, 2021
 
 New features:

--- a/TEST_NOTES.md
+++ b/TEST_NOTES.md
@@ -1,6 +1,15 @@
 # Arbimon Test Notes
 Test Notes are used to list what pages / components / features / user flows are affected by each update.
 
+## v3.0.35
+
+- CE-1183 Fixed filter in the recordings page. The user is able to select the month of January
+  -  The user selects "Date and Time" filter for month of January. The user sees the recordings with the selected date.
+  -  The user selects "Range", "Date and Time" filters for month of January. The user sees the recordings with the selected date.
+  -  The user selects "Date and Time" filter for month of February. The user sees the recordings with the selected date.
+  -  Setting the "Range" filter in February, while keeping January in "Date and Time" filter. The result supposed to be zero records, because January is outside the range.
+  - Setting the "Range" filter in February, while setting month of March in "Date and Time" filter. The result is no records, because March is outside the Range.
+
 ## v3.0.34
 
 - CE-1101 A search bar is updated for projects across Arbimon

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -1159,8 +1159,7 @@ var Recordings = {
                 constraints.push('YEAR(r.datetime) IN (?)');
                 data.push(parameters.years);
             }
-
-            if(parameters.months) {
+            if(parameters.months !== undefined) {
                 constraints.push('MONTH(r.datetime) IN (?)');
                 data.push((parameters.months instanceof Array) ?
                     parameters.months.map(function(m) { return parseInt(m)+1; }) :


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-1183](https://jira.rfcx.org/browse/CE-1183)
- [x] Release notes updated
- [x] Test notes notes updated

## 📝 Summary

- User is able to select the month of Jenuary in the recordings filters

## 📸 Screenshots

<img width="1624" alt="Screenshot 2021-08-09 at 12 36 04" src="https://user-images.githubusercontent.com/31901584/128686717-39fc25f0-353e-4063-b4d0-ed6a67b73dec.png">
<img width="1595" alt="Screenshot 2021-08-09 at 12 35 44" src="https://user-images.githubusercontent.com/31901584/128686731-69c6b501-660d-4350-a722-2c40dfbb8dfc.png">


## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
