### PR TITLE
Add missing present column change for recording_validations

### DIFF
--- a/scripts/db/018-add-present-review.sql
+++ b/scripts/db/018-add-present-review.sql
@@ -1,2 +1,3 @@
 ALTER TABLE `arbimon2`.`recording_validations` 
 ADD COLUMN `present_review` INT NOT NULL DEFAULT 0 AFTER `present`;
+ALTER TABLE recording_validations MODIFY present TINYINT(1) NULL;


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves a bunch of issues related to species validation
- [x] Release notes NA
- [x] Test notes notes NA
- [x] Deployment notes NA
- [x] DB migrations NA

## 📝 Summary

- The change to the make `present` nullable was missing from the migration.

## 📸 Screenshots

_None_

## 🛑 Problems

- [ ] If the backfill script is in the repo then we should replace `1` with `null` for `present`

## 💡 More ideas

_None_

