### PR TITLE
CE-1502 Display 10 items per page in the pagination of Visualizer playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Arbimon Release Notes
 
-## v3.0.41 - October XX, 2021
+## v3.0.41 - November XX, 2021
+
+Resolved issues:
 
 - CE-1455 Fixed issue with moving of the navigation bar when there is a long project name
+
+Other:
+
+- CE-1502 Display 10 items per page in the pagination of Visualizer playlists
 
 ## v3.0.40 - October 19, 2021
 

--- a/TEST_NOTES.md
+++ b/TEST_NOTES.md
@@ -1,7 +1,14 @@
 # Arbimon Test Notes
 Test Notes are used to list what pages / components / features / user flows are affected by each update.
 
-## v3.0.39
+## v3.0.41
+
+- CE-1502 Display 10 items per page in the pagination of Visualizer playlists
+  - Visualizer page: Open any recordings playlist. Check that list show 10 items in the playlist. Move to different pagination pages. Select any recording in the playlist. Reload the page. Check the pagination state.
+  - Visualizer page: Open any soundscapes playlist. Click on the soundscape box/ or create any test box. Click on the view button to navigate to the related recordings playlist. Check that list show 10 items in the playlist. Move to different pagination pages. Select any recording in the playlist. Reload the page. Check the pagination state.
+  -
+
+## v3.0.40
 
 - CE-1425 Do not update project_id for site if the value is not changed
   - Site page in the own project: Edit any data except the project. Check a new data in the Companion/Uploader/Ranger apps

--- a/assets/app/app/visualizer/browser/recordings/by-playlist/recordings_by_playlist.js
+++ b/assets/app/app/visualizer/browser/recordings/by-playlist/recordings_by_playlist.js
@@ -16,7 +16,7 @@ angular.module('a2.browser_recordings_by_playlist', [
 .service('a2PlaylistLOVO', function($q, makeClass, a2Playlists, a2Pager, $state, $localStorage){
     return makeClass({
         static: {
-            PageSize : 100,
+            PageSize : 10,
             BlockSize: 7
         },
         constructor : function(playlist){


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-1502](https://jira.rfcx.org/browse/CE-1502)
- [x] Release notes updated
- [x] Test notes notes updated
- [ ] Deployment notes updated / na
- [ ] DB migrations updated / na

## 📝 Summary

- Display 10 items per page in the pagination of Visualizer playlists

## 📸 Screenshots



https://user-images.githubusercontent.com/31901584/140036845-9537c219-bb13-4c35-b7c0-7918c3655490.mov


## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
