### PR TITLE
Display recordings uploaded time with timezone offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,8 @@
 
 ## v3.0.43 - November XX, 2021
 
-Resolved issues:
 
-- CE-1487 The issue with a count of recordings validations is fixed in the CSV export report
-- CE-1487 Do not show the label `Select all species` in the empty validations list of the Export recording form
-
-## v3.0.42 - November 23, 2021
+## v3.0.42 - November 26, 2021
 
 New features:
 
@@ -16,6 +12,9 @@ New features:
 
 Resolved issues:
 
+- Display recordings uploaded time with timezone offset
+- CE-1487 The issue with a count of recordings validations is fixed in the CSV export report
+- CE-1487 Do not show the label `Select all species` in the empty validations list of the Export recording form
 - CE-1510 Fixed total validations RFM
 - CE-1521 The logic is updated for the grouping species report by including all existing dates/hours
 - CE-1534 Fixed location of controls buttons in the player on the visualizer page

--- a/assets/app/app/audiodata/recordings/recordings.html
+++ b/assets/app/app/audiodata/recordings/recordings.html
@@ -53,7 +53,7 @@
             <field title="Site" key="site">{{ row.site }}</field>
             <field title="Recorded Time" key="datetime" >{{ (row.datetime | momentUtc : 'YYYY-MM-DD HH:mm:ss') }}</field>
             <field title="Filename" key="file">{{ row.filename? row.filename : row.file }}</field>
-            <field title="Uploaded Time" key="upload_time" >{{ (row.upload_time | momentUtc : 'YYYY-MM-DD HH:mm:ss') }}</field>
+            <field title="Uploaded Time" key="upload_time" >{{ (row.upload_time | momentTz : 'YYYY-MM-DD HH:mm:ss' : row.timezone) }}</field>
             <field title="Recorder" key="recorder">{{ row.recorder }}</field>
             <field title="Comments" key="comments" className="comments hidelongtext seconds-div-center">
                 <div ng-if="row.recorder === 'AudioMoth' && row.comments">{{row.comments}}</div>


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves: Display recordings uploaded time with timezone offset
- [x] Release notes updated
- [ ] Test notes notes updated
- [ ] Deployment notes updated / na
- [ ] DB migrations updated / na

## 📝 Summary

- Write a list of changes _(use italic to highlight additional/unplanned work)_

## 📸 Screenshots


<img width="1680" alt="Screenshot 2021-11-25 at 14 25 14" src="https://user-images.githubusercontent.com/31901584/143434052-8486ef97-e28e-4c0a-ad85-36956af3af66.png">
<img width="1680" alt="Screenshot 2021-11-25 at 14 23 40" src="https://user-images.githubusercontent.com/31901584/143434065-5a23810a-d60f-4133-9d9a-fe41a9624564.png">

## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
