### PR TITLE
The greyed-out boxes should be the ones left out of the clustering playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Resolved issues:
 
 - Use a pagination for a temporary clustering playlist selected with the Context View menu
 - Clear recordings data when the user selects the next playlist after a temporary clustering playlist
+- Display the cluster name for the one selected cluster
+- The greyed-out boxes should be the ones left out of the clustering playlist
 
 Performance improvements:
 

--- a/assets/app/app/analysis/clustering-jobs/index.js
+++ b/assets/app/app/analysis/clustering-jobs/index.js
@@ -741,7 +741,7 @@ angular.module('a2.analysis.clustering-jobs', [
                 })
             } else {
                 $scope.ids[0] = {
-                    cluster: $scope.gridData[0].cluster,
+                    cluster: $scope.gridData[0].cluster || $scope.gridData[0].name,
                     rois: data
                 }
             }
@@ -784,12 +784,12 @@ angular.module('a2.analysis.clustering-jobs', [
 
     $scope.togglePopup = function() {
         $scope.isPopupOpened = !$scope.isPopupOpened;
-        // collect seleted aed
+        // The greyed-out boxes should be the ones left out of the playlist.
         if ($scope.rows && $scope.rows.length) {
             $scope.selectedRois = {};
             $scope.rows.forEach(row => {
                 row.rois.forEach(roi => {
-                    if (roi.selected) {
+                    if (!roi.selected) {
                         if (!$scope.selectedRois[roi.recording_id]) {
                             $scope.selectedRois[roi.recording_id] = {
                                 aed: [roi.aed_id]


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves hot clustering grid view page fixes
- [x] Release notes updated
- [ ] Test notes notes updated
- [ ] Deployment notes updated / na
- [ ] DB migrations updated / na

## 📝 Summary

- Display the cluster name for the one selected cluster
- The greyed-out boxes should be the ones left out of the clustering playlist

## 📸 Screenshots

Put screenshots here!

## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
