### PR TITLE
Use project publicity attribute for stream creation in Core API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Resolved issues:
 - Clear recordings data when the user selects the next playlist after a temporary clustering playlist
 - Display the cluster name for the one selected cluster
 - The greyed-out boxes should be the ones left out of the clustering playlist
+- When creating a site send project's "private" attribute as stream visibility type
 
 Performance improvements:
 

--- a/app/model/sites.js
+++ b/app/model/sites.js
@@ -654,7 +654,7 @@ var Sites = {
         callback);
     },
 
-    createSiteInArbimonAndCoreAPI: async function(site, projectExternalId, token) {
+    createSiteInArbimonAndCoreAPI: async function(site, project, token) {
         var connection;
         return dbpool.getConnection()
             .then(async (con) => {
@@ -667,10 +667,11 @@ var Sites = {
                         name: site.name,
                         lat: site.lat,
                         lon: site.lon,
-                        alt: site.alt
+                        alt: site.alt,
+                        is_public: !project.is_private
                     }
-                    if (projectExternalId) {
-                        coreSite.project_id = projectExternalId;
+                    if (project.external_id) {
+                        coreSite.project_id = project.external_id;
                     }
                     let siteExternalId = await this.createInCoreAPI(coreSite, token);
                     await this.setExternalId(result.insertId, siteExternalId, connection);
@@ -695,7 +696,8 @@ var Sites = {
             longitude: site.lon,
             altitude: site.alt,
             project_id: site.project_id,
-            external_id: site.site_id
+            external_id: site.site_id,
+            is_public: !!site.is_public
         }
         const options = {
             method: 'POST',

--- a/app/routes/data-api/project/sites.js
+++ b/app/routes/data-api/project/sites.js
@@ -38,7 +38,7 @@ router.post('/create', function(req, res, next) {
         site.project_id = project.project_id;
 
         try {
-            await model.sites.createSiteInArbimonAndCoreAPI(site, project.external_id, req.session.idToken);
+            await model.sites.createSiteInArbimonAndCoreAPI(site, project, req.session.idToken);
             res.json({ message: "New site created" });
         }
         catch(e) {


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [273](https://github.com/rfcx/rfcx-api/issues/273)
- [x] Release notes updated
- [x] Test notes notes n/a
- [x] Deployment notes na
- [x] DB migrations na

## 📝 Summary

- When creating a site send project's "private" attribute as stream visibility type

## 📸 Screenshots

In private project:
<img width="892" alt="Screenshot 2021-12-14 at 22 13 06" src="https://user-images.githubusercontent.com/2122991/146065580-65d78c10-9a4f-46a6-9e4f-bb9eb509a9f0.png">
<img width="1125" alt="Screenshot 2021-12-14 at 22 13 40" src="https://user-images.githubusercontent.com/2122991/146065588-846593d0-e704-453c-8059-d8b9e594dccb.png">
<img width="906" alt="Screenshot 2021-12-14 at 22 14 07" src="https://user-images.githubusercontent.com/2122991/146065597-bc50a856-5ffe-420c-8f18-46e297d4f9c6.png">

In public project
<img width="882" alt="Screenshot 2021-12-14 at 22 14 50" src="https://user-images.githubusercontent.com/2122991/146065616-a0f77c6f-1f8d-4b0a-9847-572bb703c262.png">
<img width="1117" alt="Screenshot 2021-12-14 at 22 15 10" src="https://user-images.githubusercontent.com/2122991/146065622-75a335b1-468c-43bf-924c-5c7ccbba04f3.png">
<img width="901" alt="Screenshot 2021-12-14 at 22 15 22" src="https://user-images.githubusercontent.com/2122991/146065625-2d95a2c9-0434-41d2-a103-b427baa721f8.png">


## 🛑 Problems

## 💡 More ideas
