### PR TITLE
Reduced a count of boxes on the page for best per site day filter

### DIFF
--- a/assets/app/app/analysis/patternmatching/index.js
+++ b/assets/app/app/analysis/patternmatching/index.js
@@ -322,10 +322,10 @@ angular.module('a2.analysis.patternmatching', [
             }
             this.sitesListBatchSize = 1;
         } else if (['best_per_site', 'best_per_site_day'].includes(search)) {
-            if (this.sitesListBatchSize !== 20) {
+            if (this.sitesListBatchSize !== 10) {
                 shouldRecalculate = true
             }
-            this.sitesListBatchSize = 20;
+            this.sitesListBatchSize = 10;
         }
         if (shouldRecalculate) {
             this.splitSitesListIntoBatches();


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves https://github.com/rfcx/engineering-support/issues/59
- [ ] Release notes updated
- [ ] Test notes notes updated
- [ ] Deployment notes updated / na
- [ ] DB migrations updated / na

## 📝 Summary

- It takes to reduced a count of boxes on the page for best per site day filter to increase the query performance

## 📸 Screenshots

<img width="602" alt="Screenshot 2022-07-16 at 00 11 11" src="https://user-images.githubusercontent.com/31901584/179311178-2f02fb9d-189e-486f-9ec5-766dfb7b336c.png">


## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
