### PR TITLE
Filter project playlists for new AED jobs

### DIFF
--- a/app/model/playlists.js
+++ b/app/model/playlists.js
@@ -65,7 +65,7 @@ var Playlists = {
             // joins.push("JOIN playlist_recordings PLR ON PL.playlist_id = PLR.playlist_id");
         }
 
-        if (options.isFiltered){
+        if (options.filterByUserRole) {
             const ifExternalUser = options.roleId && (options.roleId === 2 || options.roleId === 3)
             constraints.push(`PL.total_recordings <= ${ifExternalUser ? '5000' : '100000'}`)
         }

--- a/app/model/users.js
+++ b/app/model/users.js
@@ -268,15 +268,10 @@ var Users = {
     },
 
     getUserProjectRole: async function(user_id, project_id) {
-        return dbpool.query(
-            'SELECT r.name, r.role_id \n'+
-            'FROM user_project_role AS upr \n'+
-            'JOIN roles AS r ON upr.role_id = r.role_id \n'+
-            'WHERE upr.user_id = ? \n'+
-            'AND upr.project_id = ?', [
-            user_id,
-            project_id
-        ]);
+        const q = `SELECT r.role_id FROM user_project_role AS upr
+            JOIN roles AS r ON upr.role_id = r.role_id
+            WHERE upr.user_id = ${user_id} AND upr.project_id = ${project_id}`
+        return dbpool.query(q).get(0)
     },
 
     findOwnedProjects: function(user_id, query) {

--- a/app/routes/data-api/project/playlists.js
+++ b/app/routes/data-api/project/playlists.js
@@ -16,14 +16,14 @@ getProjectPlaylists = async function(req, res, next) {
 
     // Get user role to filter playlists
     let roleData
-    if (req.query.isFiltered) {
-        [roleData] = await model.users.getUserProjectRole(userId, projectId)
+    if (req.query.filterByUserRole) {
+        roleData = await model.users.getUserProjectRole(userId, projectId)
     }
     return model.playlists.find({project: projectId}, {
         count:true,
         show_type:true,
         show_info: !!req.query.info,
-        isFiltered: req.query.isFiltered,
+        filterByUserRole: req.query.filterByUserRole,
         roleId: roleData && roleData.role_id
     }, function(err, count) {
         if(err) return next(err);

--- a/assets/app/a2services/playlists-service.js
+++ b/assets/app/a2services/playlists-service.js
@@ -9,8 +9,8 @@ angular.module('a2.srv.playlists', [
             if(options){
                 options={params:options};
             }
-            if (options && options.isFiltered) {
-                options.params.isFiltered = options.isFiltered
+            if (options && options.filterByUserRole) {
+                options.params.filterByUserRole = options.filterByUserRole
             }
             return $http.get('/api/project/'+projectName+'/playlists', options).then(function(response) {
                 return response.data;

--- a/assets/app/app/analysis/audio-event-detections-clustering/index.js
+++ b/assets/app/app/analysis/audio-event-detections-clustering/index.js
@@ -78,7 +78,7 @@ angular.module('a2.analysis.audio-event-detections-clustering', [
             };
 
             this.loading.playlists = true;
-            a2Playlists.getList({isFiltered: true}).then((function(playlists){
+            a2Playlists.getList({filterByUserRole: true}).then((function(playlists){
                 this.loading.playlists = false;
                 list.playlists = playlists;
             }).bind(this));


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves Jack's request for aed/clustering tools
- [ ] Release notes updated
- [ ] Test notes notes updated
- [ ] Deployment notes updated / na
- [ ] DB migrations updated / na

## 📝 Summary

>4. The playlists in the Create Clustering Job page should be filtered to only included the playlists with size <=5,000 recordings for general users. For the internal team we would like to increase the limit to 100,000 recordings. I am not sure if there is a way to distinguish internal/external Arbimon users right now though... I can ask Marconi for more input on this.

## 📸 Screenshots

<img width="1304" alt="Screenshot 2022-09-08 at 11 30 47" src="https://user-images.githubusercontent.com/31901584/189080143-4ae5a371-4249-47ed-8e3c-5e128ad8f9a1.png">
<img width="946" alt="Screenshot 2022-09-08 at 11 30 40" src="https://user-images.githubusercontent.com/31901584/189080156-e2286c57-fcc4-4467-9611-67017e20bc81.png">
<img width="659" alt="Screenshot 2022-09-08 at 11 30 34" src="https://user-images.githubusercontent.com/31901584/189080158-013e700a-3c1b-4899-acd0-c07da4a9d6ea.png">


## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
