### PR TITLE
Do not include recording count for deleted site to the site with the same name in the filters

### DIFF
--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -333,6 +333,7 @@ var Recordings = {
                 constraints.shift()
                 data.push(urlquery.site['='])
                 constraints.push('S.name = ? AND S.project_id = ?');
+                constraints.push('S.deleted_at is null');
                 data.push(project_id);
             }
             group_by = sqlutil.compute_groupby_constraints(urlquery, fields, options.group_by, {


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #XXX
- [ ] Release notes updated
- [ ] Test notes notes updated
- [ ] Deployment notes updated / na
- [ ] DB migrations updated / na

## 📝 Summary

the original issue:
> When deleted site (Site A had 5 files), I uploaded 5 files by creating a new site (Site A) I named it the same as the one I deleted. The files number will show 10 files in recordings>filters>site.

## 📸 Screenshots

<img width="897" alt="Screenshot 2022-09-19 at 11 47 35 AM" src="https://user-images.githubusercontent.com/31901584/190981542-808ef3c8-29da-4ff4-84ae-931e763bf059.png">
<img width="1003" alt="Screenshot 2022-09-19 at 11 47 30 AM" src="https://user-images.githubusercontent.com/31901584/190981549-6e5a665a-bfdb-4bc5-bec0-7b40aae05a8f.png">


## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
