### PR TITLE
Make the private templates available to rfcx users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v3.0.68 - December 27, 2022
 
+New features:
+
+- Make the private templates available to rfcx users
+
+Resolved issues:
+
 - Delete recording validation after removing the PM job
 
 ## v3.0.67 - December 22, 2022

--- a/app/routes/data-api/project/templates.js
+++ b/app/routes/data-api/project/templates.js
@@ -31,6 +31,7 @@ router.get('/', function(req, res, next) {
     if (req.query.publicTemplates === 'true') {
         params.publicTemplates = req.query.publicTemplates;
         params.user_id = req.session.user.id;
+        params.isRfcxUser = req.session.user.isRfcx
     }
     else {
         params.project = req.project.project_id;
@@ -59,7 +60,8 @@ router.get('/count', function(req, res, next) {
     return converter.validate()
         .then(async (params) => {
             const condition = params && params.projectTemplates ? ' AND T.source_project_id IS NULL' : null
-            const count = await model.templates.templatesCount(project_id, params && params.publicTemplates, null, condition)
+            const isRfcxUser = req.session.user.isRfcx
+            const count = await model.templates.templatesCount(project_id, params && params.publicTemplates, null, condition, isRfcxUser)
             res.json({ count })
         })
         .catch(httpErrorHandler(req, res, 'Error getting templates count'))


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #1029 
- [x] Release notes updated
- [x] Test notes updated
- [x] Deployment notes na
- [x] DB migrations  na
- [x] HelpScout documentation updates  na

## 📝 Summary

- Rfcx users are able to see the private/public templates on the template page

## 📸 Screenshots

Put screenshots here!

## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
