### PR TITLE
Hide "allow citizen science validations" for projects without citizen science enabled

### DIFF
--- a/assets/app/app/analysis/patternmatching/createnewpatternmatching.html
+++ b/assets/app/app/analysis/patternmatching/createnewpatternmatching.html
@@ -95,7 +95,7 @@
             </i>
             <input id="param-th" class="form-control" ng-model="controller.data.params.threshold" placeholder="0.1" type="text"/>
         </div>
-        <div class="form-group">
+        <div class="form-group" ng-if="userPermit.has('citizen_scientist')">
             <label for="param-cs"><input id="param-cs" ng-model="controller.data.params.citizen_scientist" type="checkbox"/> Allow citizen scientist validations </label>
         </div>
     </form>


### PR DESCRIPTION
## ✅ DoD

- [x] Hide "allow citizen science validations" for projects without citizen science enabled [#1365](https://github.com/rfcx/arbimon-legacy/issues/1365)

## 📸 Screenshots

[recording-2023-11-16-14-57-10.webm](https://github.com/rfcx/arbimon-legacy/assets/51106210/9c261c39-7856-4bb7-a2d6-85348544ebe1)

