### PR TITLE
Set is_privileged for pm jobs when creator is rfcx member

### DIFF
--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -853,13 +853,16 @@ var PatternMatchings = {
         }),
     }),
 
-    requestNewPatternMatchingJob: function(data){
+    requestNewPatternMatchingJob: function(data) {
+        // jobs created by RFCx email accounts will be privileged on PM Invoker side
+        const isPrivileged = data.user && data.user.email && data.user.email.endsWith('@rfcx.org')
         return q.ninvoke(joi, 'validate', data, PatternMatchings.JOB_SCHEMA).then(() => lambda.invoke({
             FunctionName: config('lambdas').pattern_matching,
             InvocationType: 'Event',
             Payload: JSON.stringify({
                 project_id: data.project,
-                user_id: data.user,
+                user_id: data.user.id,
+                is_privileged: isPrivileged,
                 playlist_id: data.playlist,
                 template_id: data.template,
                 name: data.name,

--- a/app/routes/data-api/project/pattern_matchings.js
+++ b/app/routes/data-api/project/pattern_matchings.js
@@ -296,7 +296,7 @@ router.post('/new', function(req, res, next) {
     }).then(function(){
         return model.patternMatchings.requestNewPatternMatchingJob({
             project    : project_id,
-            user       : req.session.user.id,
+            user       : req.session.user,
             name       : req.body.name,
             template   : req.body.template,
             playlist   : req.body.playlist,


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #1653
- [ ] Release notes updated
- [ ] Test notes notes updated
- [ ] Deployment notes updated / na
- [ ] DB migrations updated / na
- [ ] HelpScout documentation updates proposed / na

## 📝 Summary

- Send is_privileged: true to PM job invoker when creator email ends with @rfcx.org

## 📸 Screenshots

## 🛑 Problems

## 💡 More ideas
