### PR TITLE
Fix sort for deployed

### DIFF
--- a/app/routes/data-api/project/sites.js
+++ b/app/routes/data-api/project/sites.js
@@ -34,8 +34,8 @@ router.get('/', function(req, res, next) {
             const reg = /^(.\d*[\d:]*?)\.?:00*$/.exec(utc)
             row.utc = reg && reg[1] ? `UTC${reg[1]}` : `UTC${utc}`
             if (deploymentBySite && deploymentBySite[row.external_id]) {
-                row.deployment = deploymentBySite[row.external_id].deployedAt ? moment.tz(deploymentBySite[row.external_id].deployedAt, row.timezone).format('lll') : 'no data'
-            } else row.deployment = 'no data'
+                row.deployment = deploymentBySite[row.external_id].deployedAt ? deploymentBySite[row.external_id].deployedAt : null
+            } else row.deployment = null
         }
         res.json(rows);
     }).catch(next);

--- a/assets/app/app/audiodata/sites.html
+++ b/assets/app/app/audiodata/sites.html
@@ -83,8 +83,8 @@
                     </span>
                 </field>
                 <field title="Deployed" key="deployment" tdclass="date hidelongtext">
-                    <span title="{{ row.deployment }}">
-                        {{ row.deployment }}
+                    <span title="{{ row.deployment ? (row.deployment | moment : 'lll' : row.timezone) : 'no data' }}">
+                        {{ row.deployment ? (row.deployment | moment : 'lll' : row.timezone) : 'no data' }}
                     </span>
                 </field>
             </a2-table>


### PR DESCRIPTION
I have fixed the sort again on prod sort it still not correct it sorted by _**A-Z**_ 
you can check on here: https://arbimon.org/project/puerto-rico-island-wide/audiodata/sites

Now I have updated it to sort by date

https://github.com/rfcx/arbimon-legacy/assets/51106210/53a6908b-3d5b-420f-b0bd-46a272f9f2b1

