### PR TITLE
#1644 Add recording query endpoint to return recording id

### DIFF
--- a/app/model/sites.js
+++ b/app/model/sites.js
@@ -53,6 +53,11 @@ var Sites = {
         ).nodeify(callback);
     },
 
+    findAsync: function(query) {
+        let find = util.promisify(this.find)
+        return find(query)
+    },
+
     findById: function (site_id, callback) {
         var query = "SELECT * FROM sites WHERE site_id = " + dbpool.escape(site_id);
 

--- a/app/routes/data-api/project/recordings.js
+++ b/app/routes/data-api/project/recordings.js
@@ -64,6 +64,18 @@ router.get('/search', function(req, res, next) {
     });
 });
 
+router.get('/query', function(req, res, next) {
+    res.type('json');
+    var params = req.query;
+
+    params.project_id = req.project.project_id;
+
+    model.recordings.query(params, function(err, recording) {
+        if (err) return res.json(0);
+        res.json(recording);
+    });
+});
+
 router.get('/search-count', function(req, res, next) {
     res.type('json');
     var params = req.query;


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #1644
- [x] Release notes updated
- [x] Test notes notes updated
- [x] Deployment notes updated / na
- [x] DB migrations updated / na
- [x] HelpScout documentation updates proposed / na

## 📝 Summary

- Add endpoint to return recording id

```
GET /legacy-api/project/{{project_slug}}/recordings/query
params of the GET request:
query: {
            start: joi.string(),
            end: joi.string().optional(),
            site_external_id: joi.string(),
            project_id: joi.number()
        } 
end the optional, so you can skip it for now
start parameter should have this format 'YYYY-MM-DD HH:mm:ss'

```

## 📸 Screenshots

Put screenshots here!

## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have
