### PR TITLE
fix(audio): set Content-Type / filename matching actually-served format

### DIFF
--- a/app/routes/data-api/project/recordings.js
+++ b/app/routes/data-api/project/recordings.js
@@ -382,14 +382,51 @@ router.get('/:get/:oneRecUrl?', function(req, res, next) {
         file : function(err, file) {
             if (err || !file) return next(err);
 
+            // For audio: set Content-Type + a Content-Disposition filename
+            // whose extension matches the actually-served format BEFORE
+            // calling res.download (which writes headers immediately).
+            //
+            // Background: fetchAudioFile transcodes to MP3 by default and to
+            // WAV when query.format === '.wav' (see app/model/recordings.js
+            // fetchAudioFile + getAssetFileFromMediaAPI). The previous code
+            // called res.download(file.path, recording.file, ...) which:
+            //   1. set Content-Type from recording.file (e.g. "...WAV" -> audio/wav)
+            //      even when we actually transcoded to MP3,
+            //   2. left Content-Disposition advertising the original AudioMoth
+            //      filename (e.g. 20240320_092904.WAV) even though the body
+            //      was an MP3,
+            //   3. then tried to override Content-Type and status to 206 in a
+            //      follow-up block, which set the status to 206 even when no
+            //      Range request was made (invalid HTTP without Content-Range).
+            // The result was four pieces of metadata claiming three different
+            // formats with a fourth thing (MP3 ID3v2.4) in the body. Strict
+            // clients that select a decoder from Content-Type or the URL
+            // extension would refuse to decode.
+            if (get === 'audio') {
+                const isWav = query.format === '.wav' || query.format === 'wav';
+                const ext = isWav ? '.wav' : '.mp3';
+                const contentType = isWav ? 'audio/wav' : 'audio/mpeg';
+                // Normalize the served filename: keep the original basename
+                // (typically the recorder's filename like 20240320_092904)
+                // but use the extension that matches what we actually produced.
+                const originalExt = path.extname(recording.file);
+                const baseName = path.basename(recording.file, originalExt);
+                const servedName = `${baseName}${ext}`;
+                res.setHeader('Content-Type', contentType);
+                res.setHeader(
+                    'Content-Disposition',
+                    `attachment; filename="${servedName}"`
+                );
+                res.sendFile(file.path, function(err) {
+                    fs.unlink(file.path, () => {});
+                    if (err && !res.headersSent) return next(err);
+                });
+                return;
+            }
+
             res.download(file.path, recording.file, function() {
                 fs.unlink(file.path, () => {})
             });
-
-            if (get === 'audio') {
-                res.setHeader('content-type', query.format ? 'audio/wav' : 'audio/mpeg');
-                res.status(206);
-            }
         },
     };
 


### PR DESCRIPTION
## Problem

The audio download response advertises inconsistent metadata about
the served payload, causing strict clients to refuse decoding.

For e.g. `GET /legacy-api/project/<slug>/recordings/audio/<id>.flac`
the server currently returns:

| Where | What it says |
|---|---|
| URL extension | `.flac` |
| Status | **206** (with no `Range` request) |
| `Content-Type` | `audio/mpeg` (MP3) |
| `Content-Disposition` filename | `20240320_092904.WAV` (WAV) |
| First bytes of body | `49 44 33 04 …` → ASCII "ID3" v2.4 → actual file is **MP3** |

That's four pieces of metadata claiming three different formats with
a fourth thing in the body. Clients that select a decoder from URL
extension or `Content-Type` (`<audio>` tags, ffmpeg with
`--explicit-format flac`, anything strict) will refuse to decode.
The 206 is also invalid HTTP since no `Range` was requested and no
`Content-Range` is sent.

## Root cause

`returnType.file` in `app/routes/data-api/project/recordings.js`
called `res.download(file.path, recording.file, ...)` which
immediately writes headers using `recording.file` (the original
AudioMoth filename like `20240320_092904.WAV`) and sets
`Content-Type` by extension lookup. The subsequent
`if (get === 'audio')` block then partially patched the response by
overriding `Content-Type` to a hard-coded value and setting status
to 206 unconditionally.

## Fix

In the audio branch, compute the actually-served format from
`query.format` (which is also what `fetchAudioFile` honours when
deciding what to produce), set `Content-Type` + a normalized
`Content-Disposition` filename to match (e.g. `20240320_092904.mp3`
or `.wav`), then `sendFile` with the correct headers already in
place.

Non-audio paths (image / thumbnail) still use `res.download` with
the original filename. Those are server-generated PNGs so the
filename was already wrong for them, but that's out of scope here.

URL extension semantics unchanged: the `.flac` in
`/recordings/audio/<id>.flac` remains an opaque cache key; the
actually-served format is still controlled by `query.format`
(default MP3, `.wav` opt-in).

## Verification

| | Before | After |
|---|---|---|
| Status | 206 (with no Range req) | 200 |
| `Content-Type` | `audio/mpeg` regardless of body | `audio/mpeg` (MP3) or `audio/wav` matching body |
| `Content-Disposition` | `...WAV` | `...mp3` or `...wav` matching body |
| First body bytes | `49 44 33 04` (ID3 / MP3) | unchanged (MP3 by default) |

Backward-compat: the URL surface and default behaviour are unchanged.
Only response headers are corrected.