### PR TITLE
ci(cd): remove AWS build+deploy jobs (kops decommissioned)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -58,10 +58,26 @@ jobs:
     secrets:
       kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
 
+  deploy-rfcx-local:
+    name: 'Deploy: rfcx-local'
+    needs: [prepare, configure]
+    if: ${{ needs.configure.outputs.namespace == 'production' }}
+    uses: rfcx/cicd/.github/workflows/rfcx-local-cd.yaml@master
+    with:
+      repo: arbimon-legacy
+      dockerfile: build/Dockerfile
+      targets: '["arbimon","arbimon-recording-delete-job","arbimon-recording-export-job"]'
+      deployments: |
+        [
+          {"name": "arbimon",                 "image": "arbimon"},
+          {"name": "arbimon-ingest-consumer", "image": "arbimon"}
+        ]
+
+
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [prepare, build, deploy]
+    needs: [prepare, build, deploy, deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify-send.yaml@master
     with:
       repo: arbimon-legacy

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,29 +35,6 @@ jobs:
             echo "::set-output name=namespace::testing"
           fi
 
-  build:
-    name: 'Build'
-    needs: [prepare, configure]
-    uses: rfcx/cicd/.github/workflows/ecr-build-push.yaml@master
-    with:
-      dockerfile: build/Dockerfile
-      targets: "[\"arbimon-recording-delete-job\",\"arbimon-recording-export-job\",\"arbimon\"]"
-      tag-environment: ${{ needs.configure.outputs.namespace }}
-      tag-latest: ${{ needs.configure.outputs.namespace == 'production' }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  deploy:
-    name: 'Deploy'
-    needs: [build, configure]
-    uses: rfcx/cicd/.github/workflows/k8s-deploy.yaml@master
-    with:
-      tag: ${{ needs.build.outputs.unique-tag }}
-      namespace: ${{ needs.configure.outputs.namespace }}
-    secrets:
-      kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
-
   deploy-rfcx-local:
     name: 'Deploy: rfcx-local'
     needs: [prepare, configure]
@@ -77,17 +54,17 @@ jobs:
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [prepare, build, deploy, deploy-rfcx-local]
+    needs: [prepare, deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify-send.yaml@master
     with:
       repo: arbimon-legacy
       branch-name: ${{ needs.prepare.outputs.branch-name }}
       workflow-id: cd.yaml
       previous-run-id: ${{ needs.prepare.outputs.previous-run-id }}
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.deploy-rfcx-local.result }}
       always: true
       notification-title: 'CD: Arbimon + Arbimon Recordings Delete Job'
-      notification-footer: "Build: ${{ needs.build.result || 'n/a' }} | Deploy: ${{ needs.deploy.result || 'n/a' }}"
+      notification-footer: "Deploy (rfcx-local): ${{ needs.deploy-rfcx-local.result || 'n/a' }}"
       notification-success-statement: '{0} deployed the build!'
     secrets:
       slack-webhook: ${{ secrets.SLACK_ALERT_COREDT_WEBHOOK }}

--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -1368,7 +1368,7 @@ var Projects = {
             .then(async (connection) => {
                 db = connection;
                 await db.beginTransaction();
-                await this.deleteInArbimobDb(options.project_id, db);
+                await this.deleteLegacy(options.project_id, db);
                 if (rfcxConfig.coreAPIEnabled) {
                     await this.deleteInCoreAPI(options.external_id, options.idToken)
                 };
@@ -1385,7 +1385,27 @@ var Projects = {
             })
     },
 
-    deleteInArbimobDb: async function(project_id, db) {
+    removeLegacyProject: async function(options) {
+        let db;
+        return dbpool.getConnection()
+            .then(async (connection) => {
+                db = connection;
+                await db.beginTransaction();
+                await this.deleteLegacy(options.project_id, db);
+                await db.commit();
+                await db.release();
+            })
+            .catch(async (err) => {
+                console.log('err', err)
+                if (db) {
+                    await db.rollback();
+                    await db.release();
+                }
+                throw new APIError('Failed to delete project');
+            })
+    },
+
+    deleteLegacy: async function(project_id, db) {
         return db.query(
             "UPDATE projects SET deleted_at = NOW() \n"+
             "WHERE project_id = ?",[

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -1617,6 +1617,7 @@ var Recordings = {
             pmAll: joi.string(),
             pmIds: arrayOrSingle(joi.number()),
             projectTemplate: joi.string(),
+            rfmClassify: arrayOrSingle(joi.number()),
             soundscapes: joi.string()
         },
         query: {

--- a/app/model/sites.js
+++ b/app/model/sites.js
@@ -73,6 +73,10 @@ var Sites = {
         return dbpool.query(`SELECT external_id FROM sites WHERE site_id=${site_id}`).get(0).get('external_id').nodeify(callback);
     },
 
+    getAllProjectSites: async function(projectId) {
+        return dbpool.query(`SELECT site_id FROM sites WHERE project_id=${projectId} and deleted_at is null`)
+    },
+
     getSiteTimezone: function(site_id, callback) {
         return dbpool.query(`SELECT timezone FROM sites WHERE site_id=${site_id}`).get(0).get('timezone').nodeify(callback);
     },
@@ -643,6 +647,37 @@ var Sites = {
                     await this.removeFromProjectAsync(site_id, project_id, db);
                     if (rfcxConfig.coreAPIEnabled) {
                         await this.deleteInCoreAPI(site_id, idToken)
+                    };
+                }
+                await db.commit();
+                await db.release();
+            })
+            .catch(async (err) => {
+                console.log('err', err);
+                if (db) {
+                    await db.rollback();
+                    await db.release();
+                }
+                throw new Error('Failed to delete site');
+            })
+    },
+
+    softRemoveAllSites: async function(projectId, idToken) {
+        let db;
+        return dbpool.getConnection()
+            .then(async (connection) => {
+                db = connection;
+                await db.beginTransaction();
+                const siteIds = await this.getAllProjectSites(projectId)
+                if (!siteIds.length) {
+                    await db.commit();
+                    await db.release();
+                    return
+                }
+                for (let site of siteIds) {
+                    await this.removeFromProjectAsync(site.site_id, projectId, db);
+                    if (rfcxConfig.coreAPIEnabled) {
+                        await this.deleteInCoreAPI(site.site_id, idToken)
                     };
                 }
                 await db.commit();

--- a/app/routes/data-api/project/index.js
+++ b/app/routes/data-api/project/index.js
@@ -13,6 +13,7 @@ const csv_stringify = require('csv-stringify');
 const { getMetrics, getCachedMetrics } = require('../../../utils/cached-metrics');
 var model = require('../../../model');
 const moment = require('moment-timezone');
+let APIError = require('../../../utils/apierror');
 
 // routes
 var sites = require('./sites');
@@ -567,6 +568,22 @@ router.post('/:projectUrl/remove', function(req, res, next) {
         idToken: req.session.idToken
     }).then(function() {
         res.json({ result: 'success' });
+    }).catch(next);
+});
+
+router.post('/:projectUrl/soft-remove', function(req, res, next) {
+    res.type('json');
+
+    if(!req.haveAccess(req.project.project_id, 'delete project')) {
+        next(new APIError('You do not have permission to delete this project'));
+        return;
+    }
+    const idToken = req.headers.authorization?.split(' ')[1];
+    model.projects.removeProject({
+        project_id: req.project.project_id,
+        idToken: req.session.idToken === undefined ? idToken : req.session.idToken
+    }).then(function() {
+        res.json({ message: 'Removed' });
     }).catch(next);
 });
 

--- a/app/routes/data-api/project/recordings.js
+++ b/app/routes/data-api/project/recordings.js
@@ -109,6 +109,10 @@ router.post('/project-soundscape-export', function(req, res, next) {
     writeExportParams(req, res, next)
 });
 
+router.post('/project-rfm-classify-export', function(req, res, next) {
+    writeExportParams(req, res, next)
+});
+
 async function writeExportParams(req, res, next) {
     let filters, projection
     try {

--- a/app/routes/data-api/project/sites.js
+++ b/app/routes/data-api/project/sites.js
@@ -118,6 +118,20 @@ router.post('/delete', function(req, res, next) {
     }).catch(next);
 });
 
+router.post('/soft-delete', function(req, res, next) {
+    res.type('json');
+    const project = req.project;
+    const idToken = req.headers.authorization?.split(' ')[1];
+
+    if(!req.haveAccess(project.project_id, 'delete site')) {
+        return res.json({ error: 'You do not have permission to remove sites' });
+    }
+
+    model.sites.softRemoveAllSites(project.project_id, req.session.idToken === undefined ? idToken : req.session.idToken).then(function() {
+        res.json({ message: 'Removed' });
+    }).catch(next);
+});
+
 router.param('siteid', function(req, res, next, siteid){
     model.sites.findById(siteid,
     function(err, sites) {

--- a/assets/app/a2services/project-service.js
+++ b/assets/app/a2services/project-service.js
@@ -132,6 +132,13 @@ angular.module('a2.srv.project', [
                     return response.data;
                 }).catch(notify.serverError);
             },
+            exportRfmClassifyResult: function(filters){
+                const params = { filters: filters, show: { rfmClassify: filters.selectedJobId } };
+                console.info('params', params)
+                return $http.post('/legacy-api/project/'+url+'/recordings/project-rfm-classify-export', params).then(function(response) {
+                    return response.data;
+                }).catch(notify.serverError);
+            },
             exportAllProjectSoundscapes: function(filters){
                 const params = { filters: filters, show: { soundscapes: 'all' } };
                 return $http.post('/legacy-api/project/'+url+'/recordings/project-soundscape-export', params).then(function(response) {

--- a/assets/app/app.js
+++ b/assets/app/app.js
@@ -1,3 +1,5 @@
+angular.element.prototype.push = Array.prototype.push;
+
 var a2 = angular.module('a2.app', [
     'a2.permissions',
     'templates-arbimon2',

--- a/assets/app/app/analysis/patternmatching/details.html
+++ b/assets/app/app/analysis/patternmatching/details.html
@@ -94,7 +94,7 @@
                             ><i ng-class="item.class"></i></button>
                         </div>
                         <div class="pull-right" style="margin-left: .5rem !important; margin-top: 5px;">
-                                <a class="btn btn-success btn-rounded-full"
+                            <a class="btn btn-success btn-rounded-full"
                                 ng-href="{{controller.patternMatchingExportUrl}}"
                                 ng-click="controller.exportPmReport($event)"
                                 tooltip="Export Pattern Matching Data">

--- a/assets/app/app/analysis/patternmatching/index.js
+++ b/assets/app/app/analysis/patternmatching/index.js
@@ -722,9 +722,8 @@ angular.module('a2.analysis.patternmatching', [
     },
 
     setupExportUrl: function() {
-        const speciesName = this.patternMatching.species_name.replace(/\s+/g, '_').toLowerCase();
-        const songtypeName = this.patternMatching.songtype_name.replace(/\s+/g, '_').toLowerCase();
-        const fileName = 'pm-' + speciesName + '-' + songtypeName + '-' + this.patternMatching.species_id ;
+        const pmName = this.patternMatching.name.replace(/\s+/g, '_').toLowerCase();
+        const fileName = 'pm_' + pmName;
         this.patternMatchingExportUrl = a2PatternMatching.getExportUrl({
             patternMatching: this.patternMatching.id,
             fileName: encodeURIComponent(fileName)

--- a/assets/app/app/analysis/random-forest-models/classification/classinfo.html
+++ b/assets/app/app/analysis/random-forest-models/classification/classinfo.html
@@ -53,15 +53,14 @@
                 <div class="col-sm-12">
                     <h4>
                         Results
-                        <a class="btn btn-default"
+                        <button
                             ng-if="showDownload"
-                            target="_blank"
-                            ng-href="{{csvUrl}}">
-                            <i class="fa fa-download "
-                                tooltip="Download CSV"
-                                tooltip-placement="bottom">
-                            </i>
-                        </a>
+                            type="download"
+                            class="btn btn-success btn-rounded-full ml-3"
+                            tooltip="Export Classification Result"
+                            ng-click="exportData()"
+                        ><i class="fa fa-download"></i>
+                        </button>
                     </h4>
                 </div>
             </div>

--- a/assets/app/app/analysis/random-forest-models/classification/index.js
+++ b/assets/app/app/analysis/random-forest-models/classification/index.js
@@ -301,7 +301,7 @@ angular.module('a2.analysis.random-forest-models.classification', [
     }
 )
 .controller('ClassiDetailsInstanceCtrl',
-    function ($scope, $modalInstance, a2Classi, a2Models, notify, a2UserPermit, ClassiInfo) {
+    function ($scope, $modal, $modalInstance, a2Classi, a2Models, notify, a2UserPermit, ClassiInfo) {
         var loadClassifiedRec = function() {
             a2Classi.getResultDetails($scope.classiData.id, ($scope.currentPage*$scope.maxPerPage), $scope.maxPerPage, function(dataRec) {
                 a2Classi.getRecVector($scope.classiData.id, dataRec[0].recording_id).success(function(data) {
@@ -373,7 +373,31 @@ angular.module('a2.analysis.random-forest-models.classification', [
         $scope.currentPage = 0;
         $scope.maxPerPage = 1;
 
-        $scope.csvUrl = "/legacy-api/project/"+$scope.project.url+"/classifications/csv/"+$scope.classiData.id;
+        $scope.exportData = function() {
+            $scope.openExportPopup()
+        }
+
+        $scope.openExportPopup = function() {
+            var params = {
+                userEmail: a2UserPermit.getUserEmail() || '',
+                exportReport: 'rfm-classify',
+                selectedJobId: $scope.classiData.id
+            }
+            const modalInstance = $modal.open({
+                controller: 'ExportRfmClassifyInstanceCtrl',
+                templateUrl: '/app/audiodata/export-report.html',
+                windowClass: 'export-pop-up-window modal-element',
+                resolve: {
+                    data: function() {
+                        return { params: params }
+                    }
+                },
+                backdrop: false
+            });
+            modalInstance.result.then(function() {
+                notify.log('Your Export Report is processing <br> and will be sent by email.');
+            });
+        };
 
         $scope.showDownload = a2UserPermit.can('manage models and classification');
 
@@ -407,6 +431,29 @@ angular.module('a2.analysis.random-forest-models.classification', [
                     $scope.loading = false;
                 });
         });
+})
+
+.controller('ExportRfmClassifyInstanceCtrl', function($scope, $modalInstance, Project, data) {
+    $scope.userEmail = data.params.userEmail
+    $scope.selectedJobId = data.params.selectedJobId
+    $scope.exportRecordings = function(email) {
+        data.params.userEmail = email
+        data.params.selectedJobId = $scope.selectedJobId
+        $scope.isExportingRecs = true
+        $scope.errMess = ''
+        Project.exportRfmClassifyResult(data.params).then(data => {
+            $scope.isExportingRecs = false
+            if (data.error) {
+                $scope.errMess = data.error;
+            }
+            else {
+                $modalInstance.close();
+            }
+        })
+    }
+    $scope.changeUserEmail = function() {
+        $scope.errMess = null;
+    }
 })
 
 .controller('CreateNewClassificationInstanceCtrl', function($scope, $modalInstance, a2Classi, data, projectData, playlists, notify) {

--- a/assets/app/app/visualizer/browser/browser.js
+++ b/assets/app/app/visualizer/browser/browser.js
@@ -258,16 +258,21 @@ console.log("this.selectNextVisObject = function(){");
         this.currentRecording = null;
     }
     this.setBrowserLocation = function(evt, location){
-        var m = /([\w-+]+)(\/(.+))?/.exec(location);
+        if (typeof location !== 'string') {
+            console.warn('Invalid location:', location);
+            return;
+        }
         if(this.cachedLocation == location){
             return $q.resolve();
         }
         this.cachedLocation = location;
+        var m = /^([\w-+]+)\/(.+)$/.exec(location);
+        if (!m || !BrowserLOVOs[m[1]]) return;
         if(m && BrowserLOVOs[m[1]]){
-            var loc = m[3];
+            var loc = m[2];
             var lovos_def = BrowserLOVOs[m[1]];
             this.setBrowserType(lovos_def).then(function(){
-                    return lovos_def.$controller.resolve_location(loc);
+                return lovos_def.$controller.resolve_location(loc);
             }).then(function(visobject){
                 if(visobject){
                     return self.selectVisObject(visobject);

--- a/assets/app/app/visualizer/browser/recordings/by-playlist/recordings_by_playlist.js
+++ b/assets/app/app/visualizer/browser/recordings/by-playlist/recordings_by_playlist.js
@@ -176,7 +176,7 @@ angular.module('a2.browser_recordings_by_playlist', [
             return Math.max(first, Math.min(+value, last));
         },
         set_options : function(options){
-            if(options.item_count           ){ this.item_count       = options.item_count      ; }
+            if(options.item_count !== undefined) { this.item_count = options.item_count; }
             if(options.page_size            ){ this.page_size        = options.page_size       ; }
             if(options.block_size           ){ this.block_size       = options.block_size      ; }
             if(options.last_page            ){ this.last_page        = options.last_page       ; }
@@ -215,22 +215,23 @@ angular.module('a2.browser_recordings_by_playlist', [
             this.last_page        = ((this.item_count-1) / this.page_size) | 0;
             this.last_page_block  = (this.last_page / this.block_size) | 0;
             this.is_at_last_page  = this.current_page >= this.last_page;
-            this.show_block(this.block);
+            this.show_block(this.current_page_block);
         },
         show_block : function(block){
-            if(this.block_tracks_page){
-                this.current_page_block = this.resolve_value(block, this.current_page_block, 0, this.last_page_block);
-            } else {
-                this.current_page_block = this.resolve_value(block, this.current_page_block, 0, this.last_page_block) | 0;
-            }
+            // Ensure inputs are valid numbers and prevent NaN
+            var blockIdx = (+block) | 0;
+            var lastBlock = (+this.last_page_block) | 0;
+            this.current_page_block = this.resolve_value(blockIdx, this.current_page_block | 0, 0, lastBlock) | 0;
             this.is_at_first_page_block = this.current_page_block <= 0;
-            this.is_at_last_page_block  = this.current_page_block >= this.last_page_block;
-
-            this.current_page_block_first_page = (this.current_page_block * this.block_size)|0;
-            this.current_page_block_last_page  = Math.min(((this.current_page_block+1) * this.block_size - 1)|0, this.last_page);
+            this.is_at_last_page_block  = this.current_page_block >= lastBlock;
+            this.current_page_block_first_page = (this.current_page_block * this.block_size) | 0;
+            this.current_page_block_last_page  = Math.min(((this.current_page_block + 1) * this.block_size - 1) | 0, this.last_page | 0);
             this.block = [];
-            for(var i=this.current_page_block_first_page, e=this.current_page_block_last_page; i <= e; ++i){
-                this.block.push(i);
+            // Safety check: only populate if pages exist and range is valid
+            if (this.last_page >= 0 && this.current_page_block_first_page <= this.current_page_block_last_page) {
+                for (var i = this.current_page_block_first_page, e = this.current_page_block_last_page; i <= e; ++i) {
+                    this.block.push(i);
+                }
             }
         },
         has_page : function(page){

--- a/assets/app/app/visualizer/visualizer.js
+++ b/assets/app/app/visualizer/visualizer.js
@@ -94,7 +94,11 @@ angular.module('a2.visualizer', [
             var l = lc.join('/');
 
             $scope.location.whenBrowserIsAvailable(function(){
-                $scope.$parent.$broadcast('set-browser-location', l, p.a);
+                if (p.a === null) {
+                    $scope.$parent.$broadcast('set-browser-location', l || '');
+                } else {
+                    $scope.$parent.$broadcast('set-browser-location', l, p.a || '');
+                }
                 // Catch the navigation URL query
                 if (p.type === 'rec') {
                     $scope.$parent.$broadcast('set-browser-annotations', p.idA? Number(p.idA) : null, p.a? p.a : null);

--- a/assets/app/directives/a2-side-bar/a2-side-bar.html
+++ b/assets/app/directives/a2-side-bar/a2-side-bar.html
@@ -18,9 +18,9 @@
                         </span>
                     </a>
                 </div>
-                <div class="my-4 border-t-1 border-util-gray-02"> </div>
+                <div class="my-4 border-t border-util-gray-02"> </div>
                 <ul class="px-2 row-flex flex-direction-column gap-y-3 mb-0">
-                    <li ng-repeat="item in allItems">
+                    <li ng-repeat="item in allItems track by $index">
                         <a
                             v-show="item.visibleCondition == null || item.visibleCondition() === true"
                             ng-if="item.route"
@@ -41,12 +41,11 @@
                             <span ng-if="showSidebar" class="ml-3">{{ item.title }}</span>
                         </a>
                         <button
-                            ng-if="item.children"
+                            ng-show="item.children"
                             type="button"
-                            class="mainmenu row-flex flex-align-middle bg-light-50 text-base font-normal py-1 px-1 h-9 sidebar-submenu collapsed"
-                            data-target="#{{itemId(item.title)}}"
-                            aria-controls="{{itemId(item.title)}}"
-                            data-toggle="collapse"
+                            class="mainmenu row-flex flex-align-middle bg-light-50 text-base font-normal py-1 px-1 h-9 sidebar-submenu"
+                            ng-class="{ 'collapsed': menuState[$index] !== true }"
+                            ng-click="toggleMenu($index)"
                         >
                             <span ng-if="item.iconRaw === 'fa-search'" class="row-flex flex-space-center" style="width: 28px">
                                 <i class="fa fa-search" style="font-size: 22px;"></i>
@@ -66,9 +65,10 @@
                             </span>
                         </button>
                         <ul
-                            ng-if="item.children"
-                            id="{{ itemId(item.title) }}"
+                            ng-show="item.children !== undefined"
+                            ng-class="{ in: menuState[$index] === true }"
                             class="collapse submenu"
+                            style="transition: height 0.35s ease;"
                         >
                             <li
                                 ng-repeat="childItem in item.children"
@@ -94,7 +94,7 @@
                         </ul>
                     </li>
                 </ul>
-                <div class="my-4 border-t-1 border-util-gray-02"> </div>
+                <div class="my-4 border-t border-util-gray-02"> </div>
                 <div
                     ng-if="showSidebar"
                     class="px-4.5"
@@ -108,7 +108,7 @@
                 </div>
             </div>
             <div>
-                <div class="my-4 border-t-1 border-util-gray-02"></div>
+                <div class="my-4 border-t border-util-gray-02"></div>
                 <ul class="px-2 row-flex flex-direction-column gap-y-3 mb-0">
                     <li class="sidebar-submenu row-flex flex-align-middle">
                         <a
@@ -123,7 +123,7 @@
                         </a>
                     </li>
                 </ul>
-                <div class="my-4 border-t-1 border-util-gray-02"></div>
+                <div class="my-4 border-t border-util-gray-02"></div>
                 <ul class="px-2 row-flex flex-direction-column gap-y-3 mb-0">
                     <li class="sidebar-submenu">
                         <a ng-href="{{getUrlFor('my-projects')}}" class="row-flex flex-align-middle text-base font-normal py-1 px-1 h-9 sidebar-title sidebar-submenu">
@@ -150,7 +150,7 @@
                         </a>
                     </li>
                 </ul>
-                <div class="my-4 border-t-1 border-util-gray-02"></div>
+                <div class="my-4 border-t border-util-gray-02"></div>
                 <ul class="px-2.5 row-flex flex-direction-column gap-y-3 mb-0">
                     <li class="my-2 row-flex flex-align-middle text-base font-normal h-10">
                         <img

--- a/assets/app/directives/a2-side-bar/a2-side-bar.js
+++ b/assets/app/directives/a2-side-bar/a2-side-bar.js
@@ -180,8 +180,15 @@ angular.module('a2.directive.side-bar', [])
     }
 
     $scope.itemId = function(title) {
-        return 'sidebar-' + title.toLowerCase().replace(' ', '-')
+        if (!title) return ''
+        return 'sidebar-' + String(title).toLowerCase().trim().replace(/\s+/g, '-').replace(/[^a-z0-9-_]/g, '')
     }
+
+    $scope.menuState = Object.create(null);
+
+    $scope.toggleMenu = function(index) {
+        $scope.menuState[index] = !$scope.menuState[index]
+    };
 
     $scope.collapse = function() {
         submenuEl = document.querySelectorAll('.submenu')

--- a/assets/app/directives/a2-side-bar/a2-side-bar.js
+++ b/assets/app/directives/a2-side-bar/a2-side-bar.js
@@ -196,6 +196,7 @@ angular.module('a2.directive.side-bar', [])
         if ($scope.showSidebar === false) {
             mainmenuEl.forEach((el) => el.classList.add('collapsed'))
             submenuEl.forEach((el) => el.classList.remove('in'))
+            $scope.menuState = Object.create(null);
         }
     }
 

--- a/assets/app/directives/a2directives.js
+++ b/assets/app/directives/a2directives.js
@@ -140,19 +140,21 @@ angular.module('a2.directives', [
         },
         scrollHandler: function (event) {
             try {
-                if(this.a2Scroll){
+                if (this.a2Scroll) {
                     this.a2Scroll({
-                        $event:event,
+                        $event: event,
                         $controller: this,
                     });
                 }
-                if($scope.a2InfiniteScroll && !$scope.a2InfiniteScrollDisabled){
-                    var remaining = ((element[0].scrollHeight - element[0].scrollTop)|0) / element.height();
-                    if(remaining < $scope.a2InfiniteScrollDistance){
+                if ($scope.a2InfiniteScroll && !$scope.a2InfiniteScrollDisabled) {
+                    // Fix: Added 'this.' before element
+                    var remaining = ((this.element[0].scrollHeight - this.element[0].scrollTop) | 0) / this.element.height();
+                    if (remaining < $scope.a2InfiniteScrollDistance) {
                         var time = new Date().getTime();
-                        if(!$scope.refraction || $scope.refraction < time){
+                        if (!$scope.refraction || $scope.refraction < time) {
                             $scope.refraction = time + $scope.a2InfiniteScrollRefraction;
-                            $scope.a2InfiniteScroll({$event:e});
+                            // Fix: Changed 'e' to 'event' to match function argument
+                            $scope.a2InfiniteScroll({ $event: event });
                         }
                     }
                 }

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "ui-router-extras": "~0.0.10",
     "zxcvbn": "~3.2.0",
     "roboto-fontface": "~0.4.3",
-    "moment-timezone": "^0.5.33",
+    "moment-timezone": "^0.6.2",
     "plotly.js": "2.6.4"
   },
   "devDependencies": {

--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -16,6 +16,7 @@ const recordingsExport = require('./recordings')
 const patternMatching = require('./pattern-matching')
 const soundscape = require('./soundscape')
 const template = require('./template')
+const rfmClassification = require('./rfm-classification')
 const { streamToBuffer, zipDirectory } = require('../services/file-helper')
 
 const S3_EXPORT_BUCKET_ARBIMON = process.env.S3_BUCKET_ARBIMON
@@ -95,6 +96,27 @@ async function main () {
         //----------------Arbimon export Occupancy model----------------
         // Create the Occupancy model csv files, put them to .zip folder a send the folder to the user email
         await getMultipleOccupancyModelsData(projection_parameters, filters, rowData, currentTime, message, jobName)
+    } else if (projection_parameters && projection_parameters.rfmClassify) {
+        //----------------Arbimon export Classification Result--------------
+        return new Promise((resolve, reject) => {
+            const exportReportType = 'RFM Classification';
+            console.log(`Arbimon Export ${exportReportType} job`)
+            rfmClassification.collectData(projection_parameters, async (err, filePath) => {
+                if (err) {
+                    console.error('Arbimon Export job error', err)
+                    fs.unlink(filePath, () => {})
+                    reject(err)
+                }
+                console.log('Arbimon Export job: uploading file to S3')
+                const url = await saveFile(filePath, currentTime, rowData.project_id)
+                console.log('Arbimon Export job: file is accessible by url', url)
+                await sendEmail('Arbimon Export recording report', 'arbimon-export-recording.csv', rowData, url, true)
+                await updateExportRecordings(rowData, { processed_at: currentTime })
+                fs.unlink(filePath, () => {})
+                console.log(`Arbimon Export job finished: export recordings report for ${message}`)
+                resolve()
+            })
+        })
     } else if (projection_parameters && (projection_parameters.pmAll || projection_parameters.pmIds)) {
         //----------------Arbimon export all project PM jobs----------------
         return new Promise((resolve, reject) => {

--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -122,9 +122,11 @@ async function main () {
         return new Promise((resolve, reject) => {
             const exportReportType = 'Pattern Matchings';
             console.log(`Arbimon Export ${exportReportType} job`)
-            patternMatching.collectData(filters, projection_parameters, async (err, filePath) => {
-                const reportName = 'pattern-matching-export'
-                const zipPath = `jobs/arbimon-recording-export-job/${reportName}.zip`
+            patternMatching.collectData(filters, projection_parameters, async (err, fileName) => {
+                let reportName
+                if (fileName !== null) reportName = fileName
+                else reportName = 'pattern-matching-export'
+                const zipPath = __dirname + `/${reportName}.zip`
                 const bucketFormatted = S3_EXPORT_BUCKET_ARBIMON.split('/')[0]
                 const s3filePath = await uploadFileToS3(bucketFormatted, zipPath, rowData.project_id, currentTime, reportName, '.zip')
                 console.log('--s3filePath', s3filePath)
@@ -133,6 +135,7 @@ async function main () {
                 await sendEmail('Arbimon export', 'Arbimon export', rowData, url, true)
                 await updateExportRecordings(rowData, { processed_at: currentTime })
                 fs.rmSync(tmpFilePath, { recursive: true, force: true });
+                fs.rmSync(zipPath, { recursive: true, force: true });
                 console.log(`Arbimon Export ${exportReportType} job finished: ${message}`)
                 resolve()
             })

--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -101,7 +101,7 @@ async function main () {
         return new Promise((resolve, reject) => {
             const exportReportType = 'RFM Classification';
             console.log(`Arbimon Export ${exportReportType} job`)
-            rfmClassification.collectData(projection_parameters, async (err, filePath) => {
+            rfmClassification.collectData(projection_parameters, async (err, filePath, fileName) => {
                 if (err) {
                     console.error('Arbimon Export job error', err)
                     fs.unlink(filePath, () => {})
@@ -110,7 +110,7 @@ async function main () {
                 console.log('Arbimon Export job: uploading file to S3')
                 const url = await saveFile(filePath, currentTime, rowData.project_id)
                 console.log('Arbimon Export job: file is accessible by url', url)
-                await sendEmail('Arbimon Export recording report', 'arbimon-export-recording.csv', rowData, url, true)
+                await sendEmail('Arbimon Export recording report', `${fileName}.csv`, rowData, url, true)
                 await updateExportRecordings(rowData, { processed_at: currentTime })
                 fs.unlink(filePath, () => {})
                 console.log(`Arbimon Export job finished: export recordings report for ${message}`)

--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -515,7 +515,7 @@ async function sendEmail (subject, title, rowData, content, isSignedUrl) {
           async: true
         },
         (res) => {
-          console.log('email status', res)
+          console.log('email status', res, 'title', title)
           resolve({ success: true })
         },
         (e) => {

--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -108,7 +108,7 @@ async function main () {
                     reject(err)
                 }
                 console.log('Arbimon Export job: uploading file to S3')
-                const url = await saveFile(filePath, currentTime, rowData.project_id)
+                const url = await saveFile(filePath, currentTime, rowData.project_id, fileName)
                 console.log('Arbimon Export job: file is accessible by url', url)
                 await sendEmail('Arbimon Export recording report', `${fileName}.csv`, rowData, url, true)
                 await updateExportRecordings(rowData, { processed_at: currentTime })
@@ -124,12 +124,12 @@ async function main () {
             console.log(`Arbimon Export ${exportReportType} job`)
             patternMatching.collectData(filters, projection_parameters, async (err, fileName) => {
                 let reportName
-                if (fileName !== null) reportName = fileName
-                else reportName = 'pattern-matching-export'
+                if (fileName !== null) { reportName = fileName }
+                else { reportName = 'pattern-matching_export' }
                 const zipPath = __dirname + `/${reportName}.zip`
                 const bucketFormatted = S3_EXPORT_BUCKET_ARBIMON.split('/')[0]
                 const s3filePath = await uploadFileToS3(bucketFormatted, zipPath, rowData.project_id, currentTime, reportName, '.zip')
-                console.log('--s3filePath', s3filePath)
+                console.log('--s3filePath', s3filePath, 'reportName', reportName, 'fileName', fileName)
                 const url = await getSignedUrl({ Bucket: bucketFormatted, Key: s3filePath })
                 console.log('--signed url', url)
                 await sendEmail('Arbimon export', 'Arbimon export', rowData, url, true)
@@ -155,7 +155,7 @@ async function main () {
                 console.log(`folder ${tmpFilePath} exists`, fs.existsSync(tmpFilePath))
                 template.collectData(projection_parameters, filters, async (err, filePath) => {
                     await template.buildTemplateFolder()
-                    await sendZipFolderToTheUser(rowData, currentTime, jobName, message, 'template-export')
+                    await sendZipFolderToTheUser(rowData, currentTime, jobName, message, 'template_export')
                     console.log(`Arbimon Export ${exportReportType} job finished: export templates for ${message}`)
                     resolve()
                 })
@@ -169,7 +169,7 @@ async function main () {
                 console.log('--start buildSoundscapeFolder', filePath);
                 await soundscape.buildSoundscapeFolder()
                 console.log('--end buildSoundscapeFolder');
-                await sendZipFolderToTheUser(rowData, currentTime, jobName, message, 'soundscape-export')
+                await sendZipFolderToTheUser(rowData, currentTime, jobName, message, 'soundscape_export')
                 console.log(`Arbimon Export ${exportReportType} job finished: export soundscapes for ${message}`)
                 resolve()
             })
@@ -184,9 +184,9 @@ async function main () {
                     reject(err)
                 }
                 console.log('Arbimon Export job: uploading file to S3')
-                const url = await saveFile(filePath, currentTime, rowData.project_id)
+                const url = await saveFile(filePath, currentTime, rowData.project_id, 'recordings-export')
                 console.log('Arbimon Export job: file is accessible by url', url)
-                await sendEmail('Arbimon Export recording report', 'arbimon-export-recording.csv', rowData, url, true)
+                await sendEmail('Arbimon Export recording report', 'recordings-export.csv', rowData, url, true)
                 await updateExportRecordings(rowData, { processed_at: currentTime })
                 fs.unlink(filePath, () => {})
                 console.log(`Arbimon Export job finished: export recordings report for ${message}`)
@@ -199,8 +199,8 @@ async function main () {
   }
 }
 
-async function saveFile (filePath, currentTime, projectId) {
-    const s3FileKey = combineFilename(currentTime, projectId, 'arbimon-export-report', '.csv')
+async function saveFile (filePath, currentTime, projectId, reportName) {
+    const s3FileKey = combineFilename(currentTime, projectId, reportName ? reportName : 'arbimon-export', '.csv')
     await uploadAsStream({ filePath, Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: s3FileKey, ContentType: 'text/csv' })
     return await getSignedUrl({ Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: s3FileKey })
 }

--- a/jobs/arbimon-recording-export-job/pattern-matching.js
+++ b/jobs/arbimon-recording-export-job/pattern-matching.js
@@ -21,7 +21,7 @@ const archive = archiver('zip', { zlib: { level: 9 }});
 let outputStreamFile
 
 async function collectData (filters, projection_parameters, cb) {
-  outputStreamFile = fs.createWriteStream(__dirname + '/pattern-matching-export.zip');
+  outputStreamFile = fs.createWriteStream(__dirname + '/pattern-matching_export.zip');
 
   archive.pipe(outputStreamFile)
   await exportAllPmJobs(filters.project_id, projection_parameters, async (err, data) => {
@@ -34,9 +34,10 @@ async function collectData (filters, projection_parameters, cb) {
     console.log(`${exportReportJob}: after finalizeArchive`)
     if (data !== null) {
       try {
-        await rename(__dirname + '/pattern-matching-export.zip', __dirname + `/${data}.zip`)
-        if (!fs.existsSync(__dirname + `/${data}.zip`)) {
-          console.info('file renamed')
+        const newPath =  __dirname + `/${data}.zip`
+        await rename(__dirname + '/pattern-matching_export.zip', newPath)
+        if (!fs.existsSync(newPath)) {
+          console.info('Error renaming file', newPath)
         }
         cb(null, data)
       } catch (e) {

--- a/jobs/arbimon-recording-export-job/pattern-matching.js
+++ b/jobs/arbimon-recording-export-job/pattern-matching.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 const path = require('path')
 const fs = require('fs')
+const { rename } = require('fs/promises')
 const stream = require('stream');
 const csv_stringify = require('csv-stringify');
 const archiver = require('archiver');
@@ -31,7 +32,17 @@ async function collectData (filters, projection_parameters, cb) {
     console.log(`${exportReportJob}: before finalizeArchive`)
     await finalizeArchive()
     console.log(`${exportReportJob}: after finalizeArchive`)
-    cb(null, null);
+    if (data !== null) {
+      try {
+        await rename(__dirname + '/pattern-matching-export.zip', __dirname + `/${data}.zip`)
+        if (!fs.existsSync(__dirname + `/${data}.zip`)) {
+          console.info('file renamed')
+        }
+        cb(null, data)
+      } catch (e) {
+        console.err('Error renaming file', e)
+      }
+    } else cb(null, null);
   }).catch((e) => {
     console.err('Error export PM', e)
     cb(e)
@@ -69,8 +80,10 @@ async function exportAllPmJobs (projectId, projection_parameters, cb) {
     const projectSites = await getProjectSites({projectId})
     const projectPMJobs = await getProjectPMJobs({projectId, jobs: projection_parameters.pmIds})
     await exportAllPmJobsCsv(projectPMJobs)
+    let fileNameForOneJob
     for (let job of projectPMJobs) {
-      const fileName = `${nameToUrl(job.job_name)}_${job.job_id}.csv`;
+      const fileName = `pm_${nameToUrl(job.job_name)}_${job.job_id}.csv`;
+      fileNameForOneJob = `pm_${nameToUrl(job.job_name)}_${job.job_id}`
       const filePath = path.join(tmpFilePath, fileName)
       const targetFile = fs.createWriteStream(filePath, { flags: 'a' })
       console.log('next PM job start:', fileName)
@@ -103,7 +116,9 @@ async function exportAllPmJobs (projectId, projection_parameters, cb) {
         })
       })
     }
-    cb(null, null)
+    if (projectPMJobs && projectPMJobs.length && projectPMJobs.length === 1) {
+      cb(null, fileNameForOneJob)
+    } else cb(null, null)
   } catch (e) {
     console.error(e)
     cb(null, null)

--- a/jobs/arbimon-recording-export-job/rfm-classification.js
+++ b/jobs/arbimon-recording-export-job/rfm-classification.js
@@ -1,0 +1,99 @@
+require('dotenv').config()
+const path = require('path')
+const fs = require('fs')
+const stream = require('stream');
+const csv_stringify = require('csv-stringify');
+const { getCsvData, getName } = require('../services/rfm-classify');
+
+const exportReportType = 'RFM Classification';
+const exportReportJob = `Arbimon Export ${exportReportType} job`
+
+async function collectData (projection_parameters, cb) {
+  const [res] = await getName(projection_parameters.rfmClassify)
+  const filePath = path.join(__dirname, `${res.name}.csv`)
+  const targetFile = fs.createWriteStream(filePath, { flags: 'a' })
+  await exportRFMClassify(projection_parameters.rfmClassify, targetFile, async (err, data) => {
+    if (err) {
+      console.err('Error export RFM Classification', err)
+      targetFile.end()
+      return cb(err)
+    }
+    console.log(`${exportReportJob}: finished collecting chunks`)
+    targetFile.end()
+    cb(null, path.resolve(filePath))
+  }).catch((e) => {
+    console.err('Error export RFM Classification', e)
+    cb(e)
+  })
+}
+
+async function exportRFMClassify (jobId, targetFile, cb) {
+  try {
+    console.log(`${exportReportJob} started`)
+    const limit = 5000;
+    let index = 0
+    let toProcess = true;
+    let isFirstChunk = true
+
+    while (toProcess === true) {
+      console.log('next chunk', limit, limit * index)
+      const queryResult =  await getCsvData({
+        jobId,
+        limit,
+        offset: limit * index
+      });
+      toProcess = queryResult.length > 0;
+
+      console.log(`${exportReportJob}: writing chunk`)
+      await writeChunk(queryResult, targetFile, isFirstChunk)
+      isFirstChunk = false
+      index++
+    }
+    cb(null, null)
+  } catch (e) {
+    console.error(e)
+    cb(null, null)
+  }
+}
+
+async function writeChunk (results, targetFile, isFirstChunk) {
+  return new Promise(async function (resolve, reject) {
+    let fields = [];
+    results.forEach(result => {
+      fields.push(...Object.keys(result).filter(f => !fields.includes(f)))
+    });
+
+    let datastream = new stream.Readable({objectMode: true});
+    let _buf = []
+
+    for (let result of results) {
+      _buf.push(result);
+    }
+    datastream.on('data', (d) => {
+      _buf.push(d);
+    })
+    for (let result of _buf) {
+      fields.forEach(f => {
+        if (result[f] === undefined || result[f] === null) {
+          result[f] = '---'}
+        }
+      )
+      datastream.push(result)
+    }
+    datastream.push(null);
+
+    datastream.on('end', async () => {
+      csv_stringify(_buf, { header: isFirstChunk, columns: fields }, async (err, data) => {
+        if (err) {
+          reject(err)
+        }
+        targetFile.write(data);
+        return resolve();
+      })
+    })
+  })
+}
+
+module.exports = {
+  collectData
+}

--- a/jobs/arbimon-recording-export-job/rfm-classification.js
+++ b/jobs/arbimon-recording-export-job/rfm-classification.js
@@ -20,7 +20,7 @@ async function collectData (projection_parameters, cb) {
     }
     console.log(`${exportReportJob}: finished collecting chunks`)
     targetFile.end()
-    cb(null, path.resolve(filePath))
+    cb(null, path.resolve(filePath), res.name)
   }).catch((e) => {
     console.err('Error export RFM Classification', e)
     cb(e)
@@ -43,9 +43,10 @@ async function exportRFMClassify (jobId, targetFile, cb) {
         offset: limit * index
       });
       toProcess = queryResult.length > 0;
-
-      console.log(`${exportReportJob}: writing chunk`)
-      await writeChunk(queryResult, targetFile, isFirstChunk)
+      if (toProcess) {
+        console.log(`${exportReportJob}: writing chunk`)
+        await writeChunk(queryResult, targetFile, isFirstChunk)
+      }
       isFirstChunk = false
       index++
     }
@@ -62,32 +63,34 @@ async function writeChunk (results, targetFile, isFirstChunk) {
     results.forEach(result => {
       fields.push(...Object.keys(result).filter(f => !fields.includes(f)))
     });
-    fields.splice(2, 0, 'threshold presence');
 
     let datastream = new stream.Readable({objectMode: true});
     let _buf = []
-
-    for (let result of results) {
-      _buf.push(result);
+    const thisrow = results[0]
+    if (thisrow['current threshold'] === null) {
+        fields[fields.indexOf('model presence')] = 'presence'
+        fields.splice(2, 2)
+    } else {
+        fields.splice(2, 0, 'threshold presence');
     }
-    datastream.on('data', (d) => {
-      _buf.push(d);
-    })
-    for (let result of _buf) {
-      fields.forEach(f => {
-        if (result[f] === undefined || result[f] === null) {
-          result[f] = '---'}
-        }
-      )
-      const maxVal = result['vector max value'];
-      let tprec = 0;
-      if (maxVal >= result['current threshold']) {
-        tprec = 1;
+    for (let result of results) {
+      if (!thisrow['current threshold']) {
+        delete result['current threshold']
+        delete result['vector max value']
+      } else {
+          const maxVal = result['vector max value'];
+          let tprec = 0;
+          if (maxVal >= result['current threshold']) {
+            tprec = 1;
+          }
+          result['threshold presence'] = tprec
       }
-      result['threshold presence'] = tprec
       datastream.push(result)
     }
     datastream.push(null);
+    datastream.on('data', (d) => {
+        _buf.push(Object.values(d))
+    })
 
     datastream.on('end', async () => {
       csv_stringify(_buf, { header: isFirstChunk, columns: fields }, async (err, data) => {

--- a/jobs/arbimon-recording-export-job/rfm-classification.js
+++ b/jobs/arbimon-recording-export-job/rfm-classification.js
@@ -62,6 +62,7 @@ async function writeChunk (results, targetFile, isFirstChunk) {
     results.forEach(result => {
       fields.push(...Object.keys(result).filter(f => !fields.includes(f)))
     });
+    fields.splice(2, 0, 'threshold presence');
 
     let datastream = new stream.Readable({objectMode: true});
     let _buf = []
@@ -78,6 +79,12 @@ async function writeChunk (results, targetFile, isFirstChunk) {
           result[f] = '---'}
         }
       )
+      const maxVal = result['vector max value'];
+      let tprec = 0;
+      if (maxVal >= result['current threshold']) {
+        tprec = 1;
+      }
+      result['threshold presence'] = tprec
       datastream.push(result)
     }
     datastream.push(null);

--- a/jobs/arbimon-recording-export-job/rfm-classification.js
+++ b/jobs/arbimon-recording-export-job/rfm-classification.js
@@ -59,33 +59,52 @@ async function exportRFMClassify (jobId, targetFile, cb) {
 
 async function writeChunk (results, targetFile, isFirstChunk) {
   return new Promise(async function (resolve, reject) {
-    let fields = [];
-    results.forEach(result => {
-      fields.push(...Object.keys(result).filter(f => !fields.includes(f)))
-    });
+    const fieldsFull = [
+      'rec',
+      'model presence',
+      'threshold presence',
+      'current threshold',
+      'vector max value',
+      'site',
+      'year',
+      'month',
+      'day',
+      'hour',
+      'minute',
+      'species',
+      'songtype'
+    ];
+    const fieldsShort = [
+      'rec',
+      'presence',
+      'site',
+      'year',
+      'month',
+      'day',
+      'hour',
+      'minute',
+      'species',
+      'songtype'
+    ];
+    const thisrow = results[0]
+    const isThresholdEmpty = thisrow['current threshold'] === null
 
     let datastream = new stream.Readable({objectMode: true});
     let _buf = []
-    const thisrow = results[0]
-    if (thisrow['current threshold'] === null) {
-        fields[fields.indexOf('model presence')] = 'presence'
-        fields.splice(2, 2)
-    } else {
-        fields.splice(2, 0, 'threshold presence');
-    }
     for (let result of results) {
-      if (!thisrow['current threshold']) {
+      if (isThresholdEmpty) {
         delete result['current threshold']
         delete result['vector max value']
+        result['presence'] = result['model presence']
       } else {
-          const maxVal = result['vector max value'];
-          let tprec = 0;
-          if (maxVal >= result['current threshold']) {
-            tprec = 1;
-          }
-          result['threshold presence'] = tprec
+        const maxVal = result['vector max value'];
+        let tprec = 0;
+        if (maxVal >= result['current threshold']) {
+          tprec = 1;
+        }
+        result['threshold presence'] = tprec
       }
-      datastream.push(result)
+      datastream.push(isThresholdEmpty ? fieldsShort.map(field => result[field]) : fieldsFull.map(field => result[field]))
     }
     datastream.push(null);
     datastream.on('data', (d) => {
@@ -93,7 +112,7 @@ async function writeChunk (results, targetFile, isFirstChunk) {
     })
 
     datastream.on('end', async () => {
-      csv_stringify(_buf, { header: isFirstChunk, columns: fields }, async (err, data) => {
+      csv_stringify(_buf, { header: isFirstChunk, columns: isThresholdEmpty ? fieldsShort : fieldsFull }, async (err, data) => {
         if (err) {
           reject(err)
         }

--- a/jobs/arbimon-recording-export-job/rfm-classification.js
+++ b/jobs/arbimon-recording-export-job/rfm-classification.js
@@ -10,7 +10,7 @@ const exportReportJob = `Arbimon Export ${exportReportType} job`
 
 async function collectData (projection_parameters, cb) {
   const [res] = await getName(projection_parameters.rfmClassify)
-  const filePath = path.join(__dirname, `${res.name}.csv`)
+  const filePath = path.join(__dirname, `rfm_${res.name}.csv`)
   const targetFile = fs.createWriteStream(filePath, { flags: 'a' })
   await exportRFMClassify(projection_parameters.rfmClassify, targetFile, async (err, data) => {
     if (err) {
@@ -20,7 +20,7 @@ async function collectData (projection_parameters, cb) {
     }
     console.log(`${exportReportJob}: finished collecting chunks`)
     targetFile.end()
-    cb(null, path.resolve(filePath), res.name)
+    cb(null, path.resolve(filePath), `rfm_${res.name}`)
   }).catch((e) => {
     console.err('Error export RFM Classification', e)
     cb(e)

--- a/jobs/arbimon-recording-export-job/soundscape.js
+++ b/jobs/arbimon-recording-export-job/soundscape.js
@@ -40,7 +40,7 @@ async function collectData (projection_parameters, filters, cb) {
 }
 
 async function buildSoundscapeFolder() {
-  await zipDirectory(tmpFilePath, 'jobs/arbimon-recording-export-job/soundscape-export.zip')
+  await zipDirectory(tmpFilePath, 'jobs/arbimon-recording-export-job/soundscape_export.zip')
 }
 
 async function exportAllSoundscapes (projectId, projectUrl, targetFile, cb) {
@@ -117,7 +117,6 @@ async function getProjectSoundscapesMatrixData(soundscapes) {
       name: soundscape.aggr_name,
       scale: JSON.parse(soundscape.aggr_scale)
     };
-    console.log('soundscape matrix', soundscape)
     await getMatrixData(soundscape)
     fs.unlink(tempPathToDelete, () => {})
   }
@@ -125,7 +124,6 @@ async function getProjectSoundscapesMatrixData(soundscapes) {
 
 async function getProjectSoundscapesImages(soundscapes) {
   for (let soundscape of soundscapes) {
-    console.log('soundscape  image', soundscape)
     await getImageData(soundscape)
   }
 }
@@ -135,7 +133,7 @@ function nameToUrl (name) {
 }
 
 async function getMatrixData(soundscape) {
-  const filename = `${nameToUrl(soundscape.name)}-${soundscape.id}.csv`;
+  const filename = `ss_${nameToUrl(soundscape.name)}_${soundscape.id}.csv`;
   const filePath = path.join(tmpFilePath, filename)
   const targetFile = fs.createWriteStream(filePath, { flags: 'a' })
 

--- a/jobs/arbimon-recording-export-job/template.js
+++ b/jobs/arbimon-recording-export-job/template.js
@@ -38,7 +38,7 @@ async function collectData (projection_parameters, filters, cb) {
 }
 
 async function buildTemplateFolder() {
-    await zipDirectory(tmpFilePath, 'jobs/arbimon-recording-export-job/template-export.zip')
+    await zipDirectory(tmpFilePath, 'jobs/arbimon-recording-export-job/template_export.zip')
 }
 
 async function exportAllProjectTemplate (projectId, projectUrl, cb) {
@@ -89,7 +89,7 @@ async function writeChunk (results, targetFile, isFirstChunk) {
 
       for (let result of results) {
         fields.forEach(f => {
-          const saved_filename = `${nameToUrl(result.template_name)}-${result.template_id}.wav`;
+          const saved_filename = `${nameToUrl(result.template_name)}_${result.template_id}.wav`;
           result.saved_filename = saved_filename
           if (result[f] === undefined || result[f] === null) {
             result[f] = '---'}

--- a/jobs/services/rfm-classify.js
+++ b/jobs/services/rfm-classify.js
@@ -52,7 +52,8 @@ async function getCsvData(options) {
     for (let _1 of rows) {
         // Fill the original filename from the meta column.
         _1.meta = _1.meta ? parseMetaData(_1.meta) : null;
-        _1.rec = _1.meta && _1.meta.filename? _1.meta.filename :  _1.rec;
+        _1.rec = _1.meta && _1.meta.filename? _1.meta.filename : _1.rec;
+        delete _1.meta;
     }
     return rows
 }

--- a/jobs/services/rfm-classify.js
+++ b/jobs/services/rfm-classify.js
@@ -1,0 +1,71 @@
+const mysql = require('../db/mysql')
+
+function parseMetaData(data) {
+    try {
+        const parsedData = JSON.parse(data);
+        if (!parsedData) {
+            return data;
+        }
+        return parsedData;
+    } catch (e) {
+        return null;
+    }
+}
+
+async function getCsvData(options) {
+    const connection = await mysql.getConnection()
+    const sql = `SELECT
+            SUBSTRING_INDEX(r.uri ,'/',-1 ) rec,
+            cr.present presense,
+            s.name,
+            extract(year from r.datetime) year,
+            extract(month from r.datetime) month,
+            extract(day from r.datetime) day,
+            extract(hour from r.datetime) hour,
+            extract(minute from r.datetime) minute,
+            m.threshold,
+            r.meta,
+            cr.max_vector_value as "max vector",
+            sp.scientific_name species,
+            st.songtype
+            FROM models m,
+              job_params_classification jpc,
+              species sp,
+              classification_results cr,
+              recordings r,
+              sites s,
+              songtypes st
+            WHERE cr.job_id = ${options.jobId}
+            AND jpc.job_id = cr.job_id
+            AND jpc.model_id = m.model_id
+            AND cr.recording_id = r.recording_id
+            AND s.site_id = r.site_id
+            AND sp.species_id = cr.species_id
+            AND cr.songtype_id = st.songtype_id
+            limit ${options.limit} offset ${options.offset};`
+
+    const [rows, fields] = await connection.execute(sql)
+    if (!rows.length) return []
+    for (let _1 of rows) {
+        // Fill the original filename from the meta column.
+        _1.meta = _1.meta ? parseMetaData(_1.meta) : null;
+        _1.rec = _1.meta && _1.meta.filename? _1.meta.filename :  _1.rec;
+    }
+    return rows
+}
+
+async function getName(cid) {
+    const connection = await mysql.getConnection()
+    const sql = `SELECT REPLACE(lower(c.name),' ','_') as name, j.project_id as pid
+            FROM job_params_classification c, jobs j
+            WHERE c.job_id = j.job_id
+            AND c.job_id = ${cid}`;
+
+    const [rows, fields] = await connection.execute(sql)
+    return rows
+}
+
+module.exports = {
+    getCsvData,
+    getName
+}

--- a/jobs/services/rfm-classify.js
+++ b/jobs/services/rfm-classify.js
@@ -15,35 +15,38 @@ function parseMetaData(data) {
 async function getCsvData(options) {
     const connection = await mysql.getConnection()
     const sql = `SELECT
-            SUBSTRING_INDEX(r.uri ,'/',-1 ) rec,
-            cr.present "model presence",
-            m.threshold "current threshold",
-            cr.max_vector_value as "vector max value",
-            s.name as "site",
-            extract(year from r.datetime) year,
-            extract(month from r.datetime) month,
-            extract(day from r.datetime) day,
-            extract(hour from r.datetime) hour,
-            extract(minute from r.datetime) minute,
+            SUBSTRING_INDEX(r.uri,'/',-1) rec,
+            cr.present AS "model presence",
+            m.threshold AS "current threshold",
+            cr.max_vector_value AS "vector max value",
+            s.name AS site,
+            EXTRACT(YEAR FROM r.datetime) year,
+            EXTRACT(MONTH FROM r.datetime) month,
+            EXTRACT(DAY FROM r.datetime) day,
+            EXTRACT(HOUR FROM r.datetime) hour,
+            EXTRACT(MINUTE FROM r.datetime) minute,
             r.meta,
             sp.scientific_name species,
             st.songtype
-            FROM models m,
-              job_params_classification jpc,
-              species sp,
-              classification_results cr,
-              recordings r,
-              sites s,
-              songtypes st
-            WHERE cr.job_id = ${options.jobId}
-            AND jpc.job_id = cr.job_id
-            AND jpc.model_id = m.model_id
-            AND cr.recording_id = r.recording_id
-            AND s.site_id = r.site_id
-            AND sp.species_id = cr.species_id
-            AND cr.songtype_id = st.songtype_id
-            limit ${options.limit} offset ${options.offset};`
-
+          FROM (
+            SELECT
+              recording_id,
+              species_id,
+              songtype_id,
+              present,
+              max_vector_value,
+              job_id
+            FROM classification_results
+            WHERE job_id = ${options.jobId}
+            ORDER BY recording_id DESC
+            LIMIT ${options.limit} OFFSET ${options.offset}
+          ) cr
+          JOIN recordings r ON cr.recording_id = r.recording_id
+          JOIN sites s ON s.site_id = r.site_id
+          JOIN species sp ON sp.species_id = cr.species_id
+          JOIN songtypes st ON st.songtype_id = cr.songtype_id
+          JOIN job_params_classification jpc ON jpc.job_id = cr.job_id
+          JOIN models m ON m.model_id = jpc.model_id;`
     const [rows, fields] = await connection.execute(sql)
     if (!rows.length) return []
     for (let _1 of rows) {

--- a/jobs/services/rfm-classify.js
+++ b/jobs/services/rfm-classify.js
@@ -16,16 +16,16 @@ async function getCsvData(options) {
     const connection = await mysql.getConnection()
     const sql = `SELECT
             SUBSTRING_INDEX(r.uri ,'/',-1 ) rec,
-            cr.present presense,
-            s.name,
+            cr.present "model presence",
+            m.threshold "current threshold",
+            cr.max_vector_value as "vector max value",
+            s.name as "site",
             extract(year from r.datetime) year,
             extract(month from r.datetime) month,
             extract(day from r.datetime) day,
             extract(hour from r.datetime) hour,
             extract(minute from r.datetime) minute,
-            m.threshold,
             r.meta,
-            cr.max_vector_value as "max vector",
             sp.scientific_name species,
             st.songtype
             FROM models m,

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "connect-flash": "~0.1.1",
         "winston": "^3.8.2",
         "fluent-ffmpeg": "^2.1.2",
-        "moment-timezone": "^0.5.33"
+        "moment-timezone": "^0.6.2"
       },
       "devDependencies": {
         "pump": "^1.0.3",
@@ -1034,16 +1034,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "node_modules/get-uri/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -1198,16 +1188,6 @@
       "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==",
       "engines": {
         "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/@grpc/grpc-js/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
       }
     },
     "node_modules/snapdragon": {
@@ -1556,13 +1536,6 @@
       "dependencies": {
         "any-promise": "^1.1.0"
       }
-    },
-    "node_modules/loggly/node_modules/caseless": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/google-auth-library": {
       "version": "6.1.3",
@@ -1931,17 +1904,6 @@
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
       }
     },
     "node_modules/nodemailer-direct-transport": {
@@ -2680,13 +2642,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/pac-proxy-agent/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
@@ -2778,7 +2733,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -3024,19 +2978,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/gulp-less/node_modules/arr-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-      "integrity": "sha512-OQwDZUqYaQwyyhDJHThmzId8daf4/RFNLaeh3AevmSeZ5Y7ug4Ga/yKc6l6kTZOBW781rCj103ZuTh8GAsB3+Q==",
-      "dev": true,
-      "dependencies": {
-        "arr-flatten": "^1.0.1",
-        "array-slice": "^0.2.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@babel/types": {
@@ -3817,8 +3758,7 @@
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "node_modules/estraverse": {
       "version": "1.9.3",
@@ -3915,8 +3855,7 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/socket.io": {
       "version": "2.0.4",
@@ -4030,18 +3969,6 @@
       "dependencies": {
         "httpntlm": "1.6.1",
         "nodemailer-shared": "1.0.5"
-      }
-    },
-    "node_modules/base/node_modules/is-data-descriptor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
-      "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
-      "dev": true,
-      "dependencies": {
-        "hasown": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/less": {
@@ -4806,18 +4733,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/base/node_modules/is-accessor-descriptor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.1.tgz",
-      "integrity": "sha512-YBUanLI8Yoihw923YeFUS5fs0fF2f5TSFTNiYAAzhhDscDa3lEqYuz1pDOEP5KvX94I9ey3vsqjJcLVFVU+3QA==",
-      "dev": true,
-      "dependencies": {
-        "hasown": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/karma-nyan-reporter": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/karma-nyan-reporter/-/karma-nyan-reporter-0.2.5.tgz",
@@ -5075,22 +4990,6 @@
         "@babel/types": "^7.13.12"
       }
     },
-    "node_modules/gaxios/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ext/node_modules/type": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
@@ -5131,7 +5030,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -5352,18 +5250,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/topo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha512-vpmONxdZoD0R3hzH0lovwv8QmsqZmGCDE1wXW9YGD/reiDOAbPKEgRDlBCAt8u8nJhav/s/I+r+1gvdpA11x7Q==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
     "node_modules/@jimp/plugin-rotate": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
@@ -5389,18 +5275,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-property/node_modules/is-data-descriptor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
-      "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
-      "dev": true,
-      "dependencies": {
-        "hasown": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/which-typed-array": {
@@ -5499,11 +5373,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/dateformat": {
       "version": "2.2.0",
@@ -6529,16 +6398,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.9.tgz",
       "integrity": "sha512-yj0DOaQeUrk3nJ0bd3Y5PeDRJ6W0r+kilosLA+dzF3dola/o9hxhMSg2sFvVcA2UHS5JSOsZp4S0c1OEXc4m1Q=="
     },
-    "node_modules/gtoken/node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
@@ -6699,15 +6558,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "node_modules/gulp-concat/node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6860,7 +6710,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7290,23 +7139,6 @@
       "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
       "dev": true
     },
-    "node_modules/pac-proxy-agent/node_modules/http-errors": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/proxy-agent/node_modules/agent-base": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
@@ -7610,21 +7442,6 @@
       "version": "10.17.52",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.52.tgz",
       "integrity": "sha512-bKnO8Rcj03i6JTzweabq96k29uVNcXGB0bkwjVQTFagDgxxNged18281AZ0nTMHl+aFpPPWyPrk4Z3+NtW/z5w=="
-    },
-    "node_modules/gulp-livereload/node_modules/has-ansi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-      "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^0.2.0"
-      },
-      "bin": {
-        "has-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -8411,11 +8228,6 @@
       "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
       "dev": true
     },
-    "node_modules/express-mysql-session/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -8911,12 +8723,6 @@
         "globals": "^11.1.0"
       }
     },
-    "node_modules/log4js/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/@jimp/plugin-gaussian": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
@@ -9019,17 +8825,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
       }
     },
     "node_modules/ast-types": {
@@ -9409,21 +9204,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/mini-lr/node_modules/bytes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-      "integrity": "sha512-zGRpnr2l5w/s8PxkrquUJoVeR06KvqPelrYqiSyQV7QEBqCYivpb6UzXYWC6JDBVtNFOT0rzJRFhkfJgxzmILA==",
-      "dev": true
-    },
-    "node_modules/gulp-header/node_modules/lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -9717,18 +9497,6 @@
         "xtend": ">=4.0.0 <4.1.0-0"
       }
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
@@ -10004,13 +9772,6 @@
         "smtp-connection": "2.8.0"
       }
     },
-    "node_modules/bl/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/object.defaults": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
@@ -10030,7 +9791,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "dependencies": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -10070,11 +9830,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/normalize-url": {
       "version": "4.5.0",
@@ -10717,19 +10472,6 @@
         "node": "*"
       }
     },
-    "node_modules/base/node_modules/is-descriptor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.3.tgz",
-      "integrity": "sha512-JCNNGbwWZEVaSPtS45mdtrneRWJFp07LLmykxeFV5F6oBvNF8vHSfJuJgoT472pSfk+Mf8VnlrspaFBHWM8JAw==",
-      "dev": true,
-      "dependencies": {
-        "is-accessor-descriptor": "^1.0.1",
-        "is-data-descriptor": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -11181,9 +10923,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }
@@ -11201,7 +10943,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
       "dependencies": {
         "center-align": "^0.1.1",
         "right-align": "^0.1.1",
@@ -11214,14 +10955,6 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/winston-transport/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "node_modules/bytes": {
       "version": "2.4.0",
@@ -11304,21 +11037,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
     },
-    "node_modules/gulp-cli/node_modules/findup-sync": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
-      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-      "dev": true,
-      "dependencies": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/cookie-parser": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
@@ -11349,18 +11067,6 @@
       "dependencies": {
         "arr-flatten": "^1.0.1",
         "array-slice": "^0.2.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gulp-cli/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -11794,7 +11500,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "dependencies": {
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
@@ -12018,7 +11723,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -12146,11 +11850,11 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.2.tgz",
+      "integrity": "sha512-lDsQv8FoGdBUdf0+TjGsq2orxKuXdwFlQ6Zw6TX3xIcTwTfEpCLyKqvEauvCHJ8iu3KBV8+uPhlv70YsNGdUBQ==",
       "dependencies": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -12494,12 +12198,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/d": {
       "version": "0.1.1",
@@ -13356,11 +13054,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/gaxios/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/es6-weak-map/node_modules/es6-symbol": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
@@ -13858,7 +13551,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14005,7 +13697,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "dependencies": {
         "align-text": "^0.1.1"
       },
@@ -14017,15 +13708,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
       "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gulp-less/node_modules/array-slice": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14765,7 +14447,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15028,7 +14709,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15168,12 +14848,6 @@
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -15635,16 +15309,6 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
         },
         "find-up": {
           "version": "4.1.0",
@@ -16476,11 +16140,6 @@
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -16515,7 +16174,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -16526,7 +16184,6 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -16600,8 +16257,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -16939,34 +16595,6 @@
           "requires": {
             "is-descriptor": "^1.0.0"
           }
-        },
-        "is-accessor-descriptor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.1.tgz",
-          "integrity": "sha512-YBUanLI8Yoihw923YeFUS5fs0fF2f5TSFTNiYAAzhhDscDa3lEqYuz1pDOEP5KvX94I9ey3vsqjJcLVFVU+3QA==",
-          "dev": true,
-          "requires": {
-            "hasown": "^2.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
-          "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
-          "dev": true,
-          "requires": {
-            "hasown": "^2.0.0"
-          }
-        },
-        "is-descriptor": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.3.tgz",
-          "integrity": "sha512-JCNNGbwWZEVaSPtS45mdtrneRWJFp07LLmykxeFV5F6oBvNF8vHSfJuJgoT472pSfk+Mf8VnlrspaFBHWM8JAw==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^1.0.1",
-            "is-data-descriptor": "^1.0.1"
-          }
         }
       }
     },
@@ -17061,13 +16689,6 @@
         "readable-stream": "~2.0.5"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-          "dev": true,
-          "optional": true
-        },
         "process-nextick-args": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -17506,7 +17127,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "requires": {
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
@@ -17652,7 +17272,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
       "requires": {
         "center-align": "^0.1.1",
         "right-align": "^0.1.1",
@@ -18288,15 +17907,6 @@
           "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
-          "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
-          "dev": true,
-          "requires": {
-            "hasown": "^2.0.0"
           }
         },
         "is-descriptor": {
@@ -19092,11 +18702,6 @@
             "ms": "2.1.2"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
         "underscore": {
           "version": "1.12.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
@@ -19582,14 +19187,6 @@
         "node-fetch": "^2.3.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-          "requires": {
-            "ms": "^2.1.3"
-          }
-        },
         "https-proxy-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -19603,11 +19200,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -19743,16 +19335,6 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
         }
       }
     },
@@ -20195,16 +19777,6 @@
         "mime": "^2.2.0"
       },
       "dependencies": {
-        "jwa": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-          "requires": {
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "^5.0.1"
-          }
-        },
         "jws": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
@@ -20372,27 +19944,6 @@
             "wrap-ansi": "^2.0.0"
           }
         },
-        "findup-sync": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
-          "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-          "dev": true,
-          "requires": {
-            "detect-file": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "micromatch": "^3.0.4",
-            "resolve-dir": "^1.0.1"
-          }
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
         "liftoff": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
@@ -20462,12 +20013,6 @@
         "vinyl": "^2.0.0"
       },
       "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-          "dev": true
-        },
         "clone-stats": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
@@ -20552,15 +20097,6 @@
             "lodash._reinterpolate": "^3.0.0",
             "lodash.templatesettings": "^4.0.0"
           }
-        },
-        "lodash.templatesettings": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-          "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-          "dev": true,
-          "requires": {
-            "lodash._reinterpolate": "^3.0.0"
-          }
         }
       }
     },
@@ -20579,26 +20115,10 @@
         "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
-        "arr-diff": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-          "integrity": "sha512-OQwDZUqYaQwyyhDJHThmzId8daf4/RFNLaeh3AevmSeZ5Y7ug4Ga/yKc6l6kTZOBW781rCj103ZuTh8GAsB3+Q==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
-          }
-        },
         "arr-union": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
           "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
-          "dev": true
-        },
-        "array-slice": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-          "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
           "dev": true
         },
         "extend-shallow": {
@@ -20680,15 +20200,6 @@
             "has-ansi": "^0.1.0",
             "strip-ansi": "^0.3.0",
             "supports-color": "^0.2.0"
-          }
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-          "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^0.2.0"
           }
         },
         "strip-ansi": {
@@ -21308,15 +20819,6 @@
         }
       }
     },
-    "hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.2"
-      }
-    },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
@@ -21652,8 +21154,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.2.0",
@@ -22216,14 +21717,6 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "topo": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-          "integrity": "sha512-vpmONxdZoD0R3hzH0lovwv8QmsqZmGCDE1wXW9YGD/reiDOAbPKEgRDlBCAt8u8nJhav/s/I+r+1gvdpA11x7Q==",
-          "requires": {
-            "hoek": "2.x.x"
-          }
         }
       }
     },
@@ -22552,8 +22045,7 @@
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lazy-debug-legacy": {
       "version": "0.0.1",
@@ -23257,12 +22749,6 @@
             "ms": "^2.1.1"
           }
         },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        },
         "redis": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
@@ -23320,13 +22806,6 @@
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
-          "optional": true
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ==",
           "dev": true,
           "optional": true
         },
@@ -23451,8 +22930,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -23824,12 +23302,6 @@
             }
           }
         },
-        "bytes": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-          "integrity": "sha512-zGRpnr2l5w/s8PxkrquUJoVeR06KvqPelrYqiSyQV7QEBqCYivpb6UzXYWC6JDBVtNFOT0rzJRFhkfJgxzmILA==",
-          "dev": true
-        },
         "http-errors": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
@@ -23977,16 +23449,16 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "moment-timezone": {
-      "version": "0.5.33",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
-      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.2.tgz",
+      "integrity": "sha512-lDsQv8FoGdBUdf0+TjGsq2orxKuXdwFlQ6Zw6TX3xIcTwTfEpCLyKqvEauvCHJ8iu3KBV8+uPhlv70YsNGdUBQ==",
       "requires": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       }
     },
     "morgan": {
@@ -24739,20 +24211,6 @@
             "ms": "2.1.2"
           }
         },
-        "http-errors": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.1.1",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
         "https-proxy-agent": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
@@ -24785,13 +24243,6 @@
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true,
-          "optional": true
         },
         "ms": {
           "version": "2.1.2",
@@ -25477,8 +24928,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
@@ -25631,7 +25081,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "requires": {
         "align-text": "^0.1.1"
       }
@@ -26111,13 +25560,6 @@
             "es6-promisify": "^5.0.0"
           }
         },
-        "smart-buffer": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-          "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-          "dev": true,
-          "optional": true
-        },
         "socks": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
@@ -26402,8 +25844,7 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringmap": {
       "version": "0.2.2",
@@ -26428,7 +25869,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -27252,14 +26692,6 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
         }
       }
     },
@@ -27279,8 +26711,7 @@
     "wordwrap": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "dev": true
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
     },
     "wrap-ansi": {
       "version": "6.2.0",
@@ -27304,19 +26735,6 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mandrill-api": "^1.0.45",
     "mime": "^2.5.2",
     "moment": "^2.29.1",
-    "moment-timezone": "^0.5.33",
+    "moment-timezone": "^0.6.2",
     "morgan": "^1.10.0",
     "mysql": "^2.18.1",
     "newrelic": "6.14.0",


### PR DESCRIPTION
## Summary

Removes the AWS-targeted `build:` (ECR push) and `deploy:` (kops `kubectl apply`) jobs from this repo's `cd.yaml`. The kops production cluster has been declared dead by the operator (2026-05-18 18:55 EDT), and rfcx-local is now the sole production deploy target.

## Background

- **Phase 3 (2026-05-18 18:55 EDT)** moved the device-upload data plane entirely off AWS — see `evity-squibbon/rfcx-local`'s `STATE.md` "Phase 3 Status" + "AWS / kops decommission status" blocks.
- All kops Mandrill keys revoked; staging/prediction/arbimon-jobs-staging namespaces deleted.
- The AWS `build:` and `deploy:` jobs in this workflow either fail noisily (most recent run on rfcx-api) or, once `KUBE_CONFIG_SUPER` rotates / kops gets torn down, will fail uniformly. They have no useful behaviour going forward.
- The `deploy-rfcx-local:` job (added 2026-05-16) does its own in-cluster arm64 build via the self-hosted runner in the rfcx-local cluster's `cicd` namespace, pushes to the in-cluster registry at `192.168.5.1:30500`, and rolls `apps-prod` Deployments via the runner's RBAC. It has zero dependency on the AWS jobs.

## What changes

In `.github/workflows/cd.yaml`:

- **Removed** `build:` job (uses `rfcx/cicd/.github/workflows/ecr-build-push.yaml@master`)
- **Removed** `deploy:` job (uses `rfcx/cicd/.github/workflows/k8s-deploy.yaml@master`)
- **Updated** `notify.needs:` to depend only on `[prepare, deploy-rfcx-local]`
- **Updated** notify `status` to report `deploy-rfcx-local.result`
- **Updated** notify `notification-footer` to surface only the rfcx-local result

`prepare:` and `configure:` are kept (still needed for `deploy-rfcx-local`'s `if: namespace == 'production'` gate and for notify metadata). `staging` is left in `on.push.branches` (no-op on staging push — `deploy-rfcx-local` is gated to production — but preserves the staging-promotion PR mechanism).

## What's unchanged

`deploy-rfcx-local:` is byte-identical. So is `concurrency:`. No new secrets, no removed inputs.

## Validation plan

- Push to `staging` first (via this PR landing): runs `prepare → configure`, skips `deploy-rfcx-local` (namespace=staging). Should complete successfully with no AWS calls.
- Once merged to `master` via the companion `staging → master` PR: triggers the rfcx-local CD path only. Should match recent successful runs.

## Rollback

Revert this PR. The AWS jobs come back. Note: this only restores the workflow definition — kops production itself is dead regardless, so the AWS jobs will fail until kops comes back (which is not the plan).

## Related

- `evity-squibbon/rfcx-local` PR / branch: `agent/ms4-strip-aws-cd-20260519` (this same branch name across all 7 rfcx-org repos this week).
- Companion PRs in `rfcx/{rfcx-api, ingest-service, guardian-api, guardian-dashboard, arbimon, arbimon-legacy}`.