### PR TITLE
ci(cd): align staging cd.yaml with master (strip AWS)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,43 +35,36 @@ jobs:
             echo "::set-output name=namespace::testing"
           fi
 
-  build:
-    name: 'Build'
+  deploy-rfcx-local:
+    name: 'Deploy: rfcx-local'
     needs: [prepare, configure]
-    uses: rfcx/cicd/.github/workflows/ecr-build-push.yaml@master
+    if: ${{ needs.configure.outputs.namespace == 'production' }}
+    uses: rfcx/cicd/.github/workflows/rfcx-local-cd.yaml@master
     with:
+      repo: arbimon-legacy
       dockerfile: build/Dockerfile
-      targets: "[\"arbimon-recording-delete-job\",\"arbimon-recording-export-job\",\"arbimon\"]"
-      tag-environment: ${{ needs.configure.outputs.namespace }}
-      tag-latest: ${{ needs.configure.outputs.namespace == 'production' }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      targets: '["arbimon","arbimon-recording-delete-job","arbimon-recording-export-job"]'
+      deployments: |
+        [
+          {"name": "arbimon",                 "image": "arbimon"},
+          {"name": "arbimon-ingest-consumer", "image": "arbimon"}
+        ]
 
-  deploy:
-    name: 'Deploy'
-    needs: [build, configure]
-    uses: rfcx/cicd/.github/workflows/k8s-deploy.yaml@master
-    with:
-      tag: ${{ needs.build.outputs.unique-tag }}
-      namespace: ${{ needs.configure.outputs.namespace }}
-    secrets:
-      kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
 
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [prepare, build, deploy]
+    needs: [prepare, deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify-send.yaml@master
     with:
       repo: arbimon-legacy
       branch-name: ${{ needs.prepare.outputs.branch-name }}
       workflow-id: cd.yaml
       previous-run-id: ${{ needs.prepare.outputs.previous-run-id }}
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.deploy-rfcx-local.result }}
       always: true
       notification-title: 'CD: Arbimon + Arbimon Recordings Delete Job'
-      notification-footer: "Build: ${{ needs.build.result || 'n/a' }} | Deploy: ${{ needs.deploy.result || 'n/a' }}"
+      notification-footer: "Deploy (rfcx-local): ${{ needs.deploy-rfcx-local.result || 'n/a' }}"
       notification-success-statement: '{0} deployed the build!'
     secrets:
       slack-webhook: ${{ secrets.SLACK_ALERT_COREDT_WEBHOOK }}


### PR DESCRIPTION
## Summary

Aligns `staging` branch's `cd.yaml` with the post-strip `master` version. Avoids the conflict that would otherwise hit the next big `staging → master` promotion.

## Background

Earlier today (~02:13 EDT) the AWS `build:`/`deploy:` jobs were stripped from `master`'s `cd.yaml` in this repo as part of the kops-decommission sweep (kops production declared dead by operator 2026-05-18 18:55 EDT). For repos where `staging` is a per-cycle promotion branch (`rfcx-api`, `ingest-service`, `device-api`, `guardian-api`, `guardian-dashboard`), the strip went through `feat → staging → master` cleanly.

**For this repo, `staging` is an active dev branch** (diverged from master with significant unmerged work). So the strip targeted `master` directly there, leaving `staging` still carrying the AWS-only `cd.yaml`.

That leaves two problems:
1. Pushes to `staging` continue to try to run the AWS pipeline (will fail noisily once `KUBE_CONFIG_SUPER` rotates / kops is fully torn down).
2. The next big `staging → master` promotion will hit a one-file conflict on `cd.yaml`.

## What changes

Copies `cd.yaml` from `master` (post-strip) onto `staging`. That's the only file in the diff. Net effect:

- Pushes to `staging` run `prepare → configure → notify`, with `deploy-rfcx-local:` skipped (it's gated `if: namespace == 'production'`). Effectively a no-op-but-workflow-validates run on staging push.
- The `deploy-rfcx-local:` job is added to staging so it's the same shape as master. Doesn't actually fire on staging pushes (namespace gate), but is present and consistent.
- AWS jobs gone, AWS secrets no longer referenced.

## What this does NOT do

- Doesn't touch any other dev work on staging.
- Doesn't promote anything to master.
- Doesn't trigger a production deploy (CD on staging push is no-op-deploy).

## Validation

Generated `cd.yaml` is byte-identical to the version already running on `master` in this repo (which has been validated by the in-progress and recently-completed master CD runs). YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`).

## Rollback

Revert this PR. Brings the AWS pipeline back on staging push (which will then start failing noisily again).

## Related

- Master strip PR for this repo (merged earlier today): see commit on `master`.
- Companion staging-strip PR in the sibling repo (`arbimon` ↔ `arbimon-legacy`).
- `evity-squibbon/rfcx-local`: `STATE.md` "AWS / kops decommission status", `runbooks/ACTIVE-SESSIONS.md`, `~/.evity/workspace/memory/2026-05-19-cd-wave-complete.md`.