### PR TITLE
feat: centralize arbimon2 public URL construction in asset-url helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Arbimon Release Notes
 
+## Unreleased
+
+Infrastructure 🛠
+
+- Centralize public `arbimon2` bucket URL construction in
+  `app/utils/asset-url.js` (and a jobs-tree duplicate at
+  `jobs/services/asset-url.js`). All 15 emission sites that previously
+  built `https://${bucketName}.s3.${region}.amazonaws.com/...` (or the
+  two hardcoded `s3.amazonaws.com/arbimon2/...` /
+  `arbimon2.s3.us-east-1.amazonaws.com/...` strings) now go through the
+  helper, which reads `ARBIMON2_PUBLIC_URL_BASE` and defaults to
+  `https://s3.arbimon.org/arbimon2`. Lets the deployment point at any
+  S3-compatible endpoint (e.g. the in-cluster Cloudflare/MinIO/B2
+  fronted `s3.arbimon.org`) by setting one env var.
+
 ## v4.1.0 - xx xx, 2024
 
 Enhancements ✨

--- a/app/model/app-listings.js
+++ b/app/model/app-listings.js
@@ -2,6 +2,7 @@ var q = require('q');
 var config = require('../config'); 
 var aws = require('aws-sdk');
 var debug = require('debug')('arbimon2:models:app-listings');
+var { arbimon2PublicUrl } = require('../utils/asset-url');
 // var s3 = new aws.S3();
 
 
@@ -32,7 +33,7 @@ var AppListings = {
                     var m = /([^\/]+)-(\d+\.\d+\.\d+)\.(msi|deb|dmg)$/.exec(item.Key);
                     if(m){
                         (_[app] || (_[app] = [])).push({
-                            url : 'https://' + config('aws').bucketName + '.s3.' + config('aws').region + '.amazonaws.com/' + item.Key,
+                            url : arbimon2PublicUrl(item.Key),
                             file : m[0],
                             version : m[2],
                             type : AppListings.types[m[3]]

--- a/app/model/models.js
+++ b/app/model/models.js
@@ -6,6 +6,7 @@ const joi = require('joi');
 const dbpool = require('../utils/dbpool');
 const config = require('../config');
 const recordings = require('./recordings');
+const { arbimon2PublicUrl } = require('../utils/asset-url');
 const k8sConfig = config('k8s');
 const jsonTemplates = require('../utils/json-templates');
 const { Client } = require('kubernetes-client');
@@ -171,14 +172,10 @@ module.exports = {
             
             let data = rows[0];
             data.json = JSON.parse(data.json);
-            const isProd = process.env.NODE_ENV === 'production';
-            const jobDate = moment.utc(data.trainingSetcreated).valueOf();
-            const bucketUpdateDate = moment.utc('2024-11-22 00:00:00').valueOf();
-            const isOldJob = jobDate < bucketUpdateDate;
-            const awsConfig = (isProd || isOldJob) ? config('aws') : config('aws_rfcx');
-            const patternBucket = (isProd || isOldJob) ? awsConfig.bucketName : awsConfig.bucketNameStaging;
-            const patternRegion = isProd ? awsConfig.region : awsConfig.region;
-            const patternThumbnail = 'https://' + patternBucket + '.s3.' + patternRegion + '.amazonaws.com/' + data.json.roipng;
+            // Public thumbnail URL: arbimon2 bucket via s3.arbimon.org.
+            // (NODE_ENV / bucketUpdateDate logic remains in this file
+            // for actual SDK calls; only the public URL is centralized.)
+            const patternThumbnail = arbimon2PublicUrl(data.json.roipng);
             
             let model = {
                 id: data.model_id,

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -13,6 +13,7 @@ const Templates = require('./templates');
 const models = require("./index");
 const lambda = new AWS.Lambda();
 const { getSignedUrl } = require('../utils/storage')
+const { arbimon2PublicUrl } = require('../utils/asset-url')
 
 // exports
 var PatternMatchings = {
@@ -895,7 +896,8 @@ var PatternMatchings = {
     combineRoiUrl: function(opts) {
         const detectionsFolder = process.env.NODE_ENV === 'production' ? 'detections' : 'detections_dev'
         const {projectId, jobId, uriParam1, uriParam2} = opts
-        return `https://s3.amazonaws.com/arbimon2/project_${projectId}/${detectionsFolder}/${jobId}/${uriParam1}${uriParam2 !== null ? '_' + uriParam2 : ''}.png`;
+        const key = `project_${projectId}/${detectionsFolder}/${jobId}/${uriParam1}${uriParam2 !== null ? '_' + uriParam2 : ''}.png`;
+        return arbimon2PublicUrl(key);
     },
 
     JOB_SCHEMA : joi.object().keys({

--- a/app/model/playlists.js
+++ b/app/model/playlists.js
@@ -12,6 +12,7 @@ var APIError = require('../utils/apierror');
 // TODO remove circular dependencies
 var model = require('../model');
 var config = require('../config');
+var { arbimon2PublicUrl } = require('../utils/asset-url');
 
 // local variables
 var s3;
@@ -114,7 +115,7 @@ var Playlists = {
                     if(sr){
                         playlist.region     = sr.region;
                         playlist.soundscape = sr.soundscape;
-                        playlist.soundscape_thumbnail = 'https://' + config('aws').bucketName + '.s3.' + config('aws').region + '.amazonaws.com/' + sr.uri;
+                        playlist.soundscape_thumbnail = arbimon2PublicUrl(sr.uri);
                     }
                 });
             } else if(/union|intersection|subtraction/.test(playlist.type) && playlist.metadata){

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -18,6 +18,7 @@ const projectModel = require('./projects')
 const classificationsModel = require('./classifications')
 const tagsModel = require('./tags')
 const soundscapeCompositionModel = require('./soundscape-composition')
+const { arbimon2PublicUrl } = require('../utils/asset-url')
 
 var config       = require('../config');
 var SQLBuilder  = require('../utils/sqlbuilder');
@@ -1266,7 +1267,7 @@ var Recordings = {
         }
         const legacy = this.isLegacy(recording)
         if (legacy) {
-            recording.thumbnail = 'https://' + config('aws').bucketName + '.s3.' + config('aws').region + '.amazonaws.com/' + encodeURIComponent(recording.uri.replace(/\.([^.]*)$/, '.thumbnail.png'));
+            recording.thumbnail = arbimon2PublicUrl(encodeURIComponent(recording.uri.replace(/\.([^.]*)$/, '.thumbnail.png')));
         }
         else {
             const momentStart = moment.utc(recording.datetime_utc ? recording.datetime_utc : recording.datetime)

--- a/app/model/soundscapes.js
+++ b/app/model/soundscapes.js
@@ -12,6 +12,7 @@ let arrays       = require('../utils/arrays');
 let config       = require('../config');
 let arrays_util  = require('../utils/arrays');
 let tmpfilecache = require('../utils/tmpfilecache');
+const { arbimon2PublicUrl } = require('../utils/asset-url');
 const k8sConfig = config('k8s');
 const jsonTemplates = require('../utils/json-templates');
 const { Client } = require('kubernetes-client');
@@ -629,11 +630,10 @@ let Soundscapes = {
     },
 
     __compute_thumbnail_path : function(soundscape, callback) {
-        const isProd = process.env.NODE_ENV === 'production';
-        const awsConfig = isProd ? config('aws') : config('aws_rfcx');
-        const soundscapeBucket = isProd ? awsConfig.bucketName : awsConfig.bucketNameStaging;
-        const soundscapeRegion = isProd ? awsConfig.region : awsConfig.region;
-        soundscape.thumbnail = 'https://' + soundscapeBucket + '.s3.' + soundscapeRegion + '.amazonaws.com/' + soundscape.uri;
+        // Public thumbnail URL: arbimon2 bucket via s3.arbimon.org
+        // (the SDK still uses NODE_ENV-keyed bucket choice for actual
+        // S3 writes; only the public URL emission is centralized here).
+        soundscape.thumbnail = arbimon2PublicUrl(soundscape.uri);
         callback();
     },
     __compute_region_tags : function(region, callback){

--- a/app/model/templates.js
+++ b/app/model/templates.js
@@ -11,6 +11,7 @@ const config = require('../config');
 const dbpool = require('../utils/dbpool');
 const Recordings = require('./recordings');
 const { isArray } = require('lodash');
+const { arbimon2PublicUrl, arbimon2PublicUrlBase } = require('../utils/asset-url');
 
 let s3;
 
@@ -34,7 +35,7 @@ var Templates = {
             "T.`species_id` as species",
             "T.`songtype_id` as songtype",
             "T.`name`",
-            "CONCAT('https://"+config('aws').bucketName+".s3."+config('aws').region+".amazonaws.com/', T.`uri`) as `uri`",
+            "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `uri`",
             "T.`x1`", "T.`y1`", "T.`x2`", "T.`y2`",
             "T.`date_created`",
             "T.user_id",
@@ -202,7 +203,7 @@ var Templates = {
                 "T.`species_id` as species",
                 "T.`songtype_id` as songtype",
                 "T.`name`",
-                "CONCAT('https://"+config('aws').bucketName+".s3."+config('aws').region+".amazonaws.com/', T.`uri`) as `uri`",
+                "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `uri`",
                 "T.`x1`", "T.`y1`", "T.`x2`", "T.`y2`",
                 "T.`date_created`",
                 "T.user_id",
@@ -345,7 +346,7 @@ var Templates = {
      */
     createTemplateImage : function (template){
         const s3key = 'project_'+template.project+'/templates/'+template.id+'.png';
-        template.uri = 'https://' + config('aws').bucketName + '.s3.' + config('aws').region + '.amazonaws.com/' + s3key;
+        template.uri = arbimon2PublicUrl(s3key);
         let rec_data, rec_stats, spec_data, isLegacy;
         return Recordings.findByUrlMatch(template.recording, 0, {limit:1})
         .then(data => rec_data = data[0])

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -22,6 +22,7 @@ var sqlutil      = require('../utils/sqlutil');
 var dbpool       = require('../utils/dbpool');
 var Recordings   = require('./recordings');
 var Projects     = require('./projects');
+var { arbimon2PublicUrl, arbimon2PublicUrlBase } = require('../utils/asset-url');
 
 // local variables
 var s3;
@@ -497,7 +498,7 @@ TrainingSets.types.roi_set = {
     create_data_image : function (training_set, rdata, callback){
         debug('create_data_image');
         var s3key = 'project_'+training_set.project+'/training_sets/'+training_set.id+'/'+rdata.id+'.png';
-        rdata.uri = 'https://' + config('aws').bucketName + '.s3.' + config('aws').region + '.amazonaws.com/' + s3key;
+        rdata.uri = arbimon2PublicUrl(s3key);
         let rec_data, rec_stats, spec_data, isLegacy;
 
         return Recordings.findByUrlMatch(rdata.recording, 0, {limit:1})
@@ -597,7 +598,7 @@ TrainingSets.types.roi_set = {
         ], callback);
     },
     get_rois : function(training_set, options, callback) {
-        var uri_prefix = 'https://' + config('aws').bucketName + '.s3.' + config('aws').region + '.amazonaws.com/';
+        var uri_prefix = arbimon2PublicUrlBase() + '/';
         var fields=["TSD.roi_set_data_id as id"];
         var tables=["training_set_roi_set_data TSD"];
         if(options && options.resolveIds){
@@ -664,7 +665,7 @@ TrainingSets.types.roi_set = {
                 "SELECT TSD.roi_set_data_id as id, TSD.recording_id as recording,\n"+
                 "   TSD.species_id as species, TSD.songtype_id as songtype,  \n" +
                 "   TSD.x1, TSD.y1, TSD.x2, TSD.y2 , \n"+
-                "   CONCAT('https://"+config('aws').bucketName+".s3."+config('aws').region+".amazonaws.com/',TSD.uri) as uri \n" +
+                "   CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ",TSD.uri) as uri \n" +
                 "FROM "   + tables.join(" \n" +
                 "JOIN ")+ " \n" +
                 "WHERE " + constraints.join(" \n" +
@@ -687,7 +688,7 @@ TrainingSets.types.roi_set = {
                     "   TSD.species_id as species, TS.name, TSD.songtype_id as songtype, \n" +
                     "   SP.scientific_name as species_name, ST.songtype as songtype_name, \n" +
                     "   TSD.x1, TSD.y1, TSD.x2, TSD.y2 , \n"+
-                    "   CONCAT('https://"+config('aws').bucketName+".s3."+config('aws').region+".amazonaws.com/',TSD.uri) as uri \n" +
+                    "   CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ",TSD.uri) as uri \n" +
                     "FROM "   + tables.join(" \n" +
                     "JOIN ")+ " \n" +
                     "WHERE " + constraints.join(" \n" +

--- a/app/routes/data-api/models.js
+++ b/app/routes/data-api/models.js
@@ -9,6 +9,7 @@ const q = require('q');
 const model = require('../../model');
 const pokeDaMonkey = require('../../utils/monkey');
 const config = require('../../config');
+const { arbimon2PublicUrl } = require('../../utils/asset-url');
 const APIError = require('../../utils/apierror');
 const router = express.Router();
 const s3 = new AWS.S3();
@@ -268,8 +269,7 @@ async function getModelsData(validationUri, limit, offset) {
                 let recUrl;
                 if (recording.uri.startsWith('project_')) {
                     const thumbnailUri = recording.uri.replace('.flac', '.thumbnail.png');
-                    const recThumbnail = 'https://' + awsBucket + '.s3.' + awsRegion + '.amazonaws.com/' + thumbnailUri;
-                    recUrl = recThumbnail;
+                    recUrl = arbimon2PublicUrl(thumbnailUri);
                 }
                 else {
                     const momentStart = moment.utc(recording.datetime_utc ? recording.datetime_utc : recording.datetime)

--- a/app/routes/data-api/project/classifications.js
+++ b/app/routes/data-api/project/classifications.js
@@ -7,6 +7,7 @@ const AWS = require('aws-sdk');
 const config = require('../../../config');
 const model = require('../../../model');
 const pokeDaMonkey = require('../../../utils/monkey');
+const { arbimon2PublicUrl } = require('../../../utils/asset-url');
 const router = express.Router();
 const moment = require('moment');
 const { httpErrorHandler } = require('@rfcx/http-utils');
@@ -70,7 +71,7 @@ router.get('/:classiId/more/:from/:total', function(req, res, next) {
                 const site = await model.sites.findByIdAsync(recording.site_id)
                 if (recording.uri.startsWith('project_')) {
                     const thumbnail = classiInfo.uri.replace('.flac', '.thumbnail.png');
-                    classiInfo.rec_image_url = 'https://' + config('aws').bucketName + '.s3.' + config('aws').region + '.amazonaws.com/' + thumbnail;
+                    classiInfo.rec_image_url = arbimon2PublicUrl(thumbnail);
                 }
                 else {
                     const momentStart = moment.utc(recording.datetime_utc ? recording.datetime_utc : recording.datetime)

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -1,0 +1,74 @@
+/**
+ * Public URL helper for the `arbimon2` S3 bucket.
+ *
+ * Historically the arbimon-legacy codebase emitted ~15 distinct URL
+ * strings that pointed directly at AWS S3 for assets stored in the
+ * `arbimon2` bucket — most via the env-derived
+ *     `https://${config('aws').bucketName}.s3.${config('aws').region}.amazonaws.com/<key>`
+ * pattern, with two literal hardcodes (`s3.amazonaws.com/arbimon2/...`
+ * in `pattern_matchings.js` and `arbimon2.s3.us-east-1.amazonaws.com/...`
+ * in `jobs/services/template.js`).
+ *
+ * Those URLs are served to the browser via JSON API responses
+ * (template thumbnails, ROI thumbnails, recording thumbnails,
+ * soundscape thumbnails, training-set images, app-listing downloads,
+ * etc.) and also embedded in SQL responses via `CONCAT(...)`.
+ *
+ * As part of the AWS retirement / rfcx-local migration, the operator
+ * stood up `s3.arbimon.org` (cloudflared → in-cluster `s3-proxy`
+ * nginx → `s3-reader` cache → B2 primary + AWS read-only fallback)
+ * as the durable replacement for `arbimon2.s3.us-east-1.amazonaws.com`.
+ * See `runbooks/s3-bucket-inventory-2026-05-18.md` and
+ * `runbooks/phase-2-s3-cutback-2026-05-18.md` in the rfcx-local repo.
+ *
+ * This module is the single chokepoint that constructs public URLs
+ * for arbimon2 assets, so changing the destination is one env var,
+ * not 15 string edits.
+ *
+ * Configuration:
+ *   - `ARBIMON2_PUBLIC_URL_BASE` env var (no trailing slash).
+ *   - Defaults to `https://s3.arbimon.org/arbimon2` which is the
+ *     in-cluster + Cloudflare-fronted replacement endpoint.
+ *
+ * Why a base+key split:
+ *   - `arbimon2PublicUrl(key)` is the modern API for JS interpolations.
+ *   - `arbimon2PublicUrlBase()` preserves the half-dozen call sites
+ *     that build SQL `CONCAT('${base}/', T.uri)` queries; rewriting
+ *     those into post-query mapping would touch enough query shapes
+ *     to be worth a separate PR.
+ */
+
+const DEFAULT_BASE = 'https://s3.arbimon.org/arbimon2';
+
+function trimTrailingSlash (s) {
+    return typeof s === 'string' ? s.replace(/\/+$/, '') : s;
+}
+
+/**
+ * Returns the public URL base (no trailing slash) for the arbimon2
+ * bucket. Read from `ARBIMON2_PUBLIC_URL_BASE` or, if unset, falls
+ * back to the rfcx-local default.
+ */
+function arbimon2PublicUrlBase () {
+    const fromEnv = process.env.ARBIMON2_PUBLIC_URL_BASE;
+    if (fromEnv && fromEnv.trim()) {
+        return trimTrailingSlash(fromEnv.trim());
+    }
+    return DEFAULT_BASE;
+}
+
+/**
+ * Returns a full public URL for `<key>` in the arbimon2 bucket.
+ * `key` is expected to be the S3 object key (no leading slash);
+ * a leading slash is tolerated and stripped.
+ */
+function arbimon2PublicUrl (key) {
+    if (typeof key !== 'string') return key;
+    const k = key.replace(/^\/+/, '');
+    return `${arbimon2PublicUrlBase()}/${k}`;
+}
+
+module.exports = {
+    arbimon2PublicUrl,
+    arbimon2PublicUrlBase
+};

--- a/jobs/services/asset-url.js
+++ b/jobs/services/asset-url.js
@@ -1,0 +1,35 @@
+/**
+ * Public URL helper for the `arbimon2` S3 bucket — jobs-tree copy.
+ *
+ * `jobs/` is a separate npm package from the main `app/`, so it cannot
+ * `require('../../app/utils/asset-url')` cleanly. This file is the
+ * jobs-side duplicate of `app/utils/asset-url.js`; both read the same
+ * `ARBIMON2_PUBLIC_URL_BASE` env var and default to the same
+ * `https://s3.arbimon.org/arbimon2` rfcx-local endpoint. Keep the two
+ * in sync if either ever changes.
+ */
+
+const DEFAULT_BASE = 'https://s3.arbimon.org/arbimon2';
+
+function trimTrailingSlash (s) {
+    return typeof s === 'string' ? s.replace(/\/+$/, '') : s;
+}
+
+function arbimon2PublicUrlBase () {
+    const fromEnv = process.env.ARBIMON2_PUBLIC_URL_BASE;
+    if (fromEnv && fromEnv.trim()) {
+        return trimTrailingSlash(fromEnv.trim());
+    }
+    return DEFAULT_BASE;
+}
+
+function arbimon2PublicUrl (key) {
+    if (typeof key !== 'string') return key;
+    const k = key.replace(/^\/+/, '');
+    return `${arbimon2PublicUrlBase()}/${k}`;
+}
+
+module.exports = {
+    arbimon2PublicUrl,
+    arbimon2PublicUrlBase
+};

--- a/jobs/services/template.js
+++ b/jobs/services/template.js
@@ -1,5 +1,6 @@
 const mysql = require('../db/mysql')
 const config_hosts = require('../../config/hosts');
+const { arbimon2PublicUrlBase } = require('./asset-url');
 
 async function getProjectTemplate (options = {}) {
   const connection = await mysql.getConnection()
@@ -27,7 +28,7 @@ async function getTemplateDataForAudio (options = {}) {
   const connection = await mysql.getConnection()
   const sql = `
     SELECT T.template_id as id, T.project_id as project, T.recording_id as recording, T.species_id as species,
-      T.songtype_id as songtype, T.name template_name, CONCAT('https://arbimon2.s3.us-east-1.amazonaws.com/', T.uri) as uri,
+      T.songtype_id as songtype, T.name template_name, CONCAT('${arbimon2PublicUrlBase()}/', T.uri) as uri,
       T.x1, T.y1, T.x2, T.y2, T.date_created, T.user_id, T.disabled, R.uri as recUri, R.site_id as recSiteId,
       R.sample_rate, R.datetime, R.datetime_utc, S.external_id
     FROM templates T


### PR DESCRIPTION
**This is a sibling PR.** The canonical review thread is on #1713 (target: develop). This PR targets `master` so the same commit can land directly without waiting for a separate develop→staging→master promotion sweep (develop and master are currently at the same commit, so this is functionally equivalent to a fast-forward promotion).

See #1713 for the full rationale, file list, and verification steps.

Merge plan: review and merge on whichever target reaches consensus first; close the others. The rfcx-local CD workflow on `master` (`deploy-rfcx-local` job) will roll the new image into the arbimon + arbimon-ingest-consumer Deployments automatically on push to master.