### PR TITLE
feat(storage): honor AWS_S3_ENDPOINT in app/utils/storage.js + jobs/services/storage.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Infrastructure 🛠
 
+- Honor `AWS_S3_ENDPOINT` + `AWS_S3_FORCE_PATH_STYLE` in `app/utils/storage.js`
+  and `jobs/services/storage.js` (both aws-sdk v2 `AWS.S3` clients and the v3
+  `S3Client` used for multipart uploads). Lets the deployment route SDK writes
+  / signed URL issuance / deletes through an S3-compatible proxy (e.g.
+  rfcx-local `s3.arbimon.org`). No-op when the env vars are unset (default
+  AWS S3 endpoint, as before).
 - Centralize public `arbimon2` bucket URL construction in
   `app/utils/asset-url.js` (and a jobs-tree duplicate at
   `jobs/services/asset-url.js`). All 15 emission sites that previously

--- a/app/utils/storage.js
+++ b/app/utils/storage.js
@@ -7,12 +7,29 @@ const clients = {
   rfcx: new S3(getS3ClientConfig('aws_rfcx'))
 }
 
+// Honor AWS_S3_ENDPOINT / AWS_S3_FORCE_PATH_STYLE so deployments can
+// route the SDK through an S3-compatible proxy/cache (e.g. the rfcx-local
+// `s3.arbimon.org` endpoint, which fronts a B2-primary + AWS read-only
+// chain for the arbimon2 and rfcx-streams-production buckets).
+//
+// When these env vars are unset, the SDK falls back to the default AWS
+// S3 endpoint for the configured region — i.e. the pre-existing
+// behavior. So this change is a no-op for any deployment that doesn't
+// set the override.
 function getS3ClientConfig (type) {
-  return {
+  const cfg = {
       accessKeyId: config(type).accessKeyId,
       secretAccessKey: config(type).secretAccessKey,
       region: config(type).region
   }
+  const endpoint = process.env.AWS_S3_ENDPOINT
+  if (endpoint && endpoint.trim()) {
+    cfg.endpoint = endpoint.trim()
+  }
+  if (String(process.env.AWS_S3_FORCE_PATH_STYLE || '').toLowerCase() === 'true') {
+    cfg.s3ForcePathStyle = true
+  }
+  return cfg
 }
 
 function getClient (type) {

--- a/jobs/services/storage.js
+++ b/jobs/services/storage.js
@@ -4,30 +4,51 @@ const AWS = require('aws-sdk');
 const { createReadStream } = require("fs");
 const fs = require('fs')
 
-const export_s3 = new AWS.S3({
+// Honor AWS_S3_ENDPOINT / AWS_S3_FORCE_PATH_STYLE on every S3 client
+// here so the deployment can route through an S3-compatible proxy
+// (e.g. rfcx-local `s3.arbimon.org`). Unset = upstream behavior
+// (default AWS S3 endpoint for the configured region).
+const envEndpoint = (process.env.AWS_S3_ENDPOINT || '').trim() || undefined
+const envForcePathStyle = String(process.env.AWS_S3_FORCE_PATH_STYLE || '').toLowerCase() === 'true'
+
+function withEndpointV2 (cfg) {
+    const out = { ...cfg }
+    if (envEndpoint) out.endpoint = envEndpoint
+    if (envForcePathStyle) out.s3ForcePathStyle = true
+    return out
+}
+
+const export_s3 = new AWS.S3(withEndpointV2({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_KEY,
     region: process.env.AWS_REGION_ID
-})
+}))
 
-const legacy_s3 = new AWS.S3({
+const legacy_s3 = new AWS.S3(withEndpointV2({
     accessKeyId: process.env.AWS_ACCESSKEYID,
     secretAccessKey: process.env.AWS_SECRETACCESSKEY,
     region: process.env.AWS_REGION
-})
+}))
 
-const rfcx_s3 = new AWS.S3({
+const rfcx_s3 = new AWS.S3(withEndpointV2({
     accessKeyId: process.env.AWS_RFCX_ACCESSKEYID,
     secretAccessKey: process.env.AWS_RFCX_SECRETACCESSKEY,
     region: process.env.AWS_RFCX_REGION
-})
+}))
+
+// @aws-sdk/client-s3 (v3) uses different option names: `endpoint` and
+// `forcePathStyle`. Apply the same env-driven override.
+const v3Endpoint = envEndpoint ? { endpoint: envEndpoint } : {}
+const v3ForcePathStyle = envForcePathStyle ? { forcePathStyle: true } : {}
 
 const multipart_upload_s3 = new S3Client({
     region: process.env.AWS_REGION_ID,
     credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_KEY
-    }
+    },
+    ...v3Endpoint,
+    ...v3ForcePathStyle
 });
 
 // Function to upload a file to S3 in chunks


### PR DESCRIPTION
## Summary

Plumbs the env vars `AWS_S3_ENDPOINT` and `AWS_S3_FORCE_PATH_STYLE` into every S3 client constructor in:

- `app/utils/storage.js` (aws-sdk v2 `AWS.S3`, used for upload/delete/signed-URL on the arbimon2 bucket)
- `jobs/services/storage.js` (aws-sdk v2 + `@aws-sdk/client-s3` v3, used by the arbimon-recording-export-job)

No-op when the env vars are unset (default AWS S3 endpoint, same as today).

When the env vars are set (rfcx-local already sets them in `arbimon-prod-overrides` and `arbimon-ingest-consumer-prod-overrides`), the SDK routes through the configured endpoint — so SDK writes / signed-URL issuance / deletes / multipart uploads go through `s3.arbimon.org` → in-cluster s3-proxy / s3-writer chain → B2 (primary) + AWS-readonly fallback.

## Why

Today's PR #1713 fixed the *URL-emission* side (URLs in JSON API responses now point at `s3.arbimon.org/arbimon2`). But the SDK-write side was still bypassing the cache: `storage.js` constructed clients with only `accessKeyId/secretAccessKey/region`, so the SDK derived the hostname from the region and hit `arbimon2.s3.us-east-1.amazonaws.com` directly. That made the AWS bucket the actual write target whenever a user uploaded a training-set image / template / playlist soundscape, which contradicts the rfcx-local s3-bucket-inventory plan to treat AWS arbimon2 as an immutable historical snapshot.

This PR closes that loop.

## Out of scope

- The five route-file copies of `getS3ClientConfig` in `app/routes/data-api/{models,project/classifications,project/recordings,project/soundscapes}.js` and the seven bare `new AWS.S3()` calls in `app/model/*.js`. They're read paths against `rfcx-streams-production` and other buckets whose byte-source migration to MinIO/B2 isn't complete yet (`runbooks/phase-2-s3-cutback-2026-05-18.md`). Flipping them now would risk repeating the media-api incident. They get their own follow-up once the relevant byte syncs land.

## Verification plan

- `node --check` passes on both files.
- After merge + CD rolls, in-pod test: call `storage.getSignedUrl({...})` and verify the returned URL host is `s3.arbimon.org` instead of `arbimon2.s3.us-east-1.amazonaws.com`.
- Smoke a real upload via the legacy UI's training-set creation flow and verify the object lands in MinIO (and gets fanned out to B2 via s3-writer's writeThrough).

## Promotion

Same convention as #1713: develop -> staging -> master, with CD on master rolling automatically.