### PR TITLE
Promote staging -> master (honor AWS_S3_ENDPOINT in storage.js)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Infrastructure 🛠
 
+- Honor `AWS_S3_ENDPOINT` + `AWS_S3_FORCE_PATH_STYLE` in `app/utils/storage.js`
+  and `jobs/services/storage.js` (both aws-sdk v2 `AWS.S3` clients and the v3
+  `S3Client` used for multipart uploads). Lets the deployment route SDK writes
+  / signed URL issuance / deletes through an S3-compatible proxy (e.g.
+  rfcx-local `s3.arbimon.org`). No-op when the env vars are unset (default
+  AWS S3 endpoint, as before).
 - Centralize public `arbimon2` bucket URL construction in
   `app/utils/asset-url.js` (and a jobs-tree duplicate at
   `jobs/services/asset-url.js`). All 15 emission sites that previously

--- a/app/utils/storage.js
+++ b/app/utils/storage.js
@@ -7,12 +7,29 @@ const clients = {
   rfcx: new S3(getS3ClientConfig('aws_rfcx'))
 }
 
+// Honor AWS_S3_ENDPOINT / AWS_S3_FORCE_PATH_STYLE so deployments can
+// route the SDK through an S3-compatible proxy/cache (e.g. the rfcx-local
+// `s3.arbimon.org` endpoint, which fronts a B2-primary + AWS read-only
+// chain for the arbimon2 and rfcx-streams-production buckets).
+//
+// When these env vars are unset, the SDK falls back to the default AWS
+// S3 endpoint for the configured region — i.e. the pre-existing
+// behavior. So this change is a no-op for any deployment that doesn't
+// set the override.
 function getS3ClientConfig (type) {
-  return {
+  const cfg = {
       accessKeyId: config(type).accessKeyId,
       secretAccessKey: config(type).secretAccessKey,
       region: config(type).region
   }
+  const endpoint = process.env.AWS_S3_ENDPOINT
+  if (endpoint && endpoint.trim()) {
+    cfg.endpoint = endpoint.trim()
+  }
+  if (String(process.env.AWS_S3_FORCE_PATH_STYLE || '').toLowerCase() === 'true') {
+    cfg.s3ForcePathStyle = true
+  }
+  return cfg
 }
 
 function getClient (type) {

--- a/jobs/services/storage.js
+++ b/jobs/services/storage.js
@@ -4,30 +4,51 @@ const AWS = require('aws-sdk');
 const { createReadStream } = require("fs");
 const fs = require('fs')
 
-const export_s3 = new AWS.S3({
+// Honor AWS_S3_ENDPOINT / AWS_S3_FORCE_PATH_STYLE on every S3 client
+// here so the deployment can route through an S3-compatible proxy
+// (e.g. rfcx-local `s3.arbimon.org`). Unset = upstream behavior
+// (default AWS S3 endpoint for the configured region).
+const envEndpoint = (process.env.AWS_S3_ENDPOINT || '').trim() || undefined
+const envForcePathStyle = String(process.env.AWS_S3_FORCE_PATH_STYLE || '').toLowerCase() === 'true'
+
+function withEndpointV2 (cfg) {
+    const out = { ...cfg }
+    if (envEndpoint) out.endpoint = envEndpoint
+    if (envForcePathStyle) out.s3ForcePathStyle = true
+    return out
+}
+
+const export_s3 = new AWS.S3(withEndpointV2({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_KEY,
     region: process.env.AWS_REGION_ID
-})
+}))
 
-const legacy_s3 = new AWS.S3({
+const legacy_s3 = new AWS.S3(withEndpointV2({
     accessKeyId: process.env.AWS_ACCESSKEYID,
     secretAccessKey: process.env.AWS_SECRETACCESSKEY,
     region: process.env.AWS_REGION
-})
+}))
 
-const rfcx_s3 = new AWS.S3({
+const rfcx_s3 = new AWS.S3(withEndpointV2({
     accessKeyId: process.env.AWS_RFCX_ACCESSKEYID,
     secretAccessKey: process.env.AWS_RFCX_SECRETACCESSKEY,
     region: process.env.AWS_RFCX_REGION
-})
+}))
+
+// @aws-sdk/client-s3 (v3) uses different option names: `endpoint` and
+// `forcePathStyle`. Apply the same env-driven override.
+const v3Endpoint = envEndpoint ? { endpoint: envEndpoint } : {}
+const v3ForcePathStyle = envForcePathStyle ? { forcePathStyle: true } : {}
 
 const multipart_upload_s3 = new S3Client({
     region: process.env.AWS_REGION_ID,
     credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_KEY
-    }
+    },
+    ...v3Endpoint,
+    ...v3ForcePathStyle
 });
 
 // Function to upload a file to S3 in chunks


### PR DESCRIPTION
Promotes #1718 from staging to master. Same change as #1718.

**On merge, CD will:**
1. Build `arbimon:rfcx-local-prod-<sha>` + the two job images.
2. Roll arbimon + arbimon-ingest-consumer Deployments.
3. New pods will have storage.js routing every S3 SDK call through `AWS_S3_ENDPOINT=https://s3.arbimon.org` (already in their override ConfigMap).

After rollout: SDK writes to the arbimon2 bucket stop going to AWS S3 direct; they go through the in-cluster s3-proxy / s3-writer chain to B2.