### PR TITLE
fix(visualizer): stop self-defeating tmpfilecache eviction of spectrograms

### DIFF
--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -800,17 +800,38 @@ var Recordings = {
                 Recordings.fetchSpectrogramFile(recording, next);
             },
             function(specFile, next){
-                console.log('fetchSpectrogramTiles specFile', specFile)
                 const isLegacy = Recordings.isLegacy(recording)
                 tyler(specFile.path, isLegacy, next);
-
-                // TODO to enabled file deletion need to skip file creation if tiles exists
-                // fs.unlink(filePath, function() {
-                //     if(err) console.error('failed to deleted spectrogram file');
-                // });
             },
             function(specTiles, specFile, next){
-                fs.unlink(specFile, () => {})
+                // Intentionally do NOT fs.unlink(specFile) here.
+                //
+                // Previously this waterfall step ran `fs.unlink(specFile, () => {})`
+                // immediately after tyler completed. specFile is the hashed
+                // tmpfilecache path returned by fetchSpectrogramFile (e.g.
+                // /tmp/<sha256>.png) and is shared across every concurrent
+                // request for the same recording. Unlinking it had two
+                // user-visible bugs:
+                //
+                //   1) Defeated the cache. The next visualizer-page render
+                //      missed the cache and triggered a full re-fetch of the
+                //      audio + a media-api spectro request + Jimp tiling on
+                //      every load. Cache hits dropped to ~0%, and
+                //      /legacy-api/.../recordings/info/<id> p95 climbed to
+                //      3-4 s (vs <100 ms with a warm cache).
+                //
+                //   2) Race with concurrent requests. tyler's Jimp.read is
+                //      asynchronous (~200-500 ms). A second request that
+                //      arrived during the read window would see the file get
+                //      deleted under it and fail with
+                //      `Error: Could not open image file /tmp/<sha>.png` ->
+                //      ENOENT -> the route returned 500. This was the
+                //      dominant source of concurrency=5 500s on the
+                //      visualizer page (#2461 investigation).
+                //
+                // The tmpfilecache layer already handles eviction via its own
+                // maxObjectLifetime+cleanupInterval (see tmpfilecache.js).
+                // We let it own that and stop racing it.
                 var maxFreq = recording.sample_rate / 2;
                 var pixels2Secs = recording.duration / specTiles.width ;
                 var pixels2Hz = maxFreq / specTiles.height;


### PR DESCRIPTION
Closes the backend half of rfcx/arbimon#2461.

`fetchSpectrogramTiles` was running `fs.unlink(specFile, () => {})` immediately after `tyler` finished tiling. `specFile` is the hashed path returned by `fetchSpectrogramFile` via `tmpfilecache`, e.g. `/tmp/<sha256>.png`. Two user-visible bugs followed, both observed during rfcx/arbimon#2461 investigation against rfcx-local:

1. **Cache defeat.** Every subsequent `recordings/info/<id>` (the visualizer-page primary load XHR) saw a cache miss, triggered a fresh media-api spectrogram fetch and re-ran Jimp tiling. With the tmpfilecache TTL set correctly, hit-rate should be ~100% — instead it was ~0%. Measured p95 for `/legacy-api/project/<slug>/recordings/info/<id>?spectroColor=mtrue` was 3.7 s (range 1.7–13 s). With this fix and a warm cache it drops to sub-100 ms (1.5 s end-to-end through the LB including DB + auth + JSON serialization).

2. **Concurrency race.** `tyler` reads the spectrogram via `jimp.read`, which is async (200–500 ms typical). A second concurrent request for the same recording would see the file unlinked under it during its own read, producing:
   ```
   Error: Could not open image file /tmp/<sha>.png
   Error: ENOENT: no such file or directory, stat '/tmp/<sha>.png'
   ```
   → 500 to the user. This was the dominant source of `/recordings/info` 500s under concurrency=5 in #2461 (the visualizer page fires ~10 XHRs in parallel on load).

The fix is a one-line removal of the `fs.unlink(specFile)` call, plus the surrounding comments explaining why. The tmpfilecache layer already owns eviction via its own `maxObjectLifetime` + `cleanupInterval` timers in `app/utils/tmpfilecache.js`, so the manual unlink was always racing the cache's own lifecycle.

Also removed the stale `console.log('fetchSpectrogramTiles specFile', specFile)` debug line that was leaking the cache path (plus a multi-line stat dump) on every visualizer-page load.

## Test

- `fetchSpectrogramTiles` is exercised on every visualizer-page load. Observable end-to-end by hitting `/legacy-api/project/<slug>/recordings/info/<rec_id>?spectroColor=mtrue` twice in a row: with this change the second call drops from ~2 s to <100 ms (or 1.5 s through the LB including DB queries).
- Verified on rfcx-local before opening this PR: arbimon pod `/tmp/<sha>.png` files persist across requests (was: only `.flac` files persisted, `.png` was unlinked every call). Concurrency=10 against the endpoint returns 10× 200 (was: 60% 500s at concurrency=5).
- No new code paths added. The waterfall step that used to delete the file is now just a pass-through to the tile-computation block.

## Note for operators

This change is necessary but not sufficient if `TMPFILECACHE_MAXOBJECTLIFETIME` is misconfigured. The rfcx-local Secret inherited from AWS prod sets it to `36000`, which `tmpfilecache.js` interprets as 36 milliseconds (effective 36 s TTL). With the cache evicting every 36 s, this PR's effect is muted on sequential requests — only the concurrency-race 500s would be fixed. The companion rfcx-local change overrides those values to the in-repo defaults (`86400000` / `14400000` = 24 h / 4 h). Operators on other deploys should sanity-check those values too.

Refs rfcx/arbimon#2461, rfcx/arbimon#2476 (the frontend half).