### PR TITLE
Promote: analysis-job jobqueue dispatch (PM + AED) develop->master

### DIFF
--- a/app/model/audio-event-detections-clustering.js
+++ b/app/model/audio-event-detections-clustering.js
@@ -194,11 +194,56 @@ let AudioEventDetectionsClustering = {
                 'Max Frequency': data.params.maxFrequency
             }
         )
-        return q.ninvoke(joi, 'validate', data, AudioEventDetectionsClustering.JOB_SCHEMA).then(() => lambda.invoke({
-            FunctionName: config('lambdas').audio_event_detections,
-            InvocationType: 'Event',
-            Payload: payload,
-        }).promise());
+        return q.ninvoke(joi, 'validate', data, AudioEventDetectionsClustering.JOB_SCHEMA).then(() => {
+            // rfcx-local: when ANALYSIS_DISPATCH=jobqueue, create the job +
+            // job_params rows directly (what the AWS aed conductor Lambda
+            // did) so the in-cluster jobqueue-dispatcher picks it up,
+            // instead of invoking AWS Lambda. Falls back to lambda.invoke
+            // otherwise (no-op for AWS deployments).
+            if (config('lambdas').dispatch === 'jobqueue' || process.env.ANALYSIS_DISPATCH === 'jobqueue') {
+                return AudioEventDetectionsClustering.enqueueAEDClusteringJob(data);
+            }
+            return lambda.invoke({
+                FunctionName: config('lambdas').audio_event_detections,
+                InvocationType: 'Event',
+                Payload: payload,
+            }).promise();
+        });
+    },
+
+    /** rfcx-local: enqueue an AED-for-clustering job by inserting the `jobs`
+     * (job_type_id=8, state='waiting') + job_params_audio_event_detection_clustering
+     * rows, mirroring the AWS aed conductor. The jobqueue-dispatcher then
+     * claims it and runs the in-cluster aed worker. No AWS Lambda involved.
+     */
+    enqueueAEDClusteringJob: function(data){
+        const params = {
+            'Amplitude Threshold': Number(data.params.amplitudeThreshold),
+            'Duration Threshold': Number(data.params.durationThreshold),
+            'Bandwidth Threshold': Number(data.params.bandwidthThreshold),
+            'Area Threshold': Number(data.params.areaThreshold),
+            'Filter Size': Number(data.params.filterSize),
+        };
+        return dbpool.query(
+            'SELECT project_id FROM playlists WHERE playlist_id = ?', [data.playlist_id]
+        ).then(function(rows){
+            if (!rows.length) { throw new Error('Playlist not found'); }
+            const projId = rows[0].project_id;
+            return dbpool.query(
+                'INSERT INTO `jobs` (`job_type_id`,`date_created`,`last_update`,`project_id`,`user_id`,`state`,`progress`,`completed`,`progress_steps`,`hidden`,`ncpu`,`uri`,`remarks`) ' +
+                "VALUES (8, now(), now(), ?, ?, 'waiting', 0, 0, 1, 0, 1, '', '')",
+                [projId, data.user_id]
+            ).then(function(jres){
+                const jobId = jres.insertId;
+                return dbpool.query(
+                    'INSERT INTO `job_params_audio_event_detection_clustering` (`name`,`project_id`,`job_id`,`date_created`,`parameters`,`playlist_id`,`user_id`) ' +
+                    'VALUES (?, ?, ?, now(), ?, ?, ?)',
+                    [data.name, projId, jobId, JSON.stringify(params), data.playlist_id, data.user_id]
+                ).then(function(){
+                    return { job_id: jobId, dispatch: 'jobqueue' };
+                });
+            });
+        });
     },
 };
 

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -917,22 +917,71 @@ var PatternMatchings = {
     requestNewPatternMatchingJob: function(data){
         const isPrivileged = data.user && data.user.email && data.user.email.endsWith('@rfcx.org') ? 1 : 0
         data.user = data.user.id
-        return q.ninvoke(joi, 'validate', data, PatternMatchings.JOB_SCHEMA).then(() => lambda.invoke({
-            FunctionName: config('lambdas').pattern_matching,
-            InvocationType: 'Event',
-            Payload: JSON.stringify({
-                project_id: data.project,
-                user_id: data.user,
-                is_privileged: isPrivileged,
-                playlist_id: data.playlist,
-                template_id: data.template,
-                name: data.name,
-                N: data.params.N,
-                persite: data.params.persite,
-                threshold: data.params.threshold,
-                citizen_scientist: data.params.citizen_scientist | 0,
-            }),
-        }).promise());
+        return q.ninvoke(joi, 'validate', data, PatternMatchings.JOB_SCHEMA).then(() => {
+            // rfcx-local: when ANALYSIS_DISPATCH=jobqueue, create the job +
+            // pattern_matchings rows directly (what the AWS tm_driver Lambda
+            // used to do) so the in-cluster jobqueue-dispatcher picks it up,
+            // instead of invoking AWS Lambda. Falls back to the original
+            // lambda.invoke path otherwise (reversible).
+            if (config('lambdas').dispatch === 'jobqueue' || process.env.ANALYSIS_DISPATCH === 'jobqueue') {
+                return PatternMatchings.enqueuePatternMatchingJob(data);
+            }
+            return lambda.invoke({
+                FunctionName: config('lambdas').pattern_matching,
+                InvocationType: 'Event',
+                Payload: JSON.stringify({
+                    project_id: data.project,
+                    user_id: data.user,
+                    is_privileged: isPrivileged,
+                    playlist_id: data.playlist,
+                    template_id: data.template,
+                    name: data.name,
+                    N: data.params.N,
+                    persite: data.params.persite,
+                    threshold: data.params.threshold,
+                    citizen_scientist: data.params.citizen_scientist | 0,
+                }),
+            }).promise();
+        });
+    },
+
+    /** rfcx-local: enqueue a Pattern Matching job by inserting the `jobs`
+     * (job_type_id=6, state='waiting') + `pattern_matchings` rows, mirroring
+     * the AWS tm_driver. The jobqueue-dispatcher then claims it and runs the
+     * in-cluster pattern-matching worker. No AWS Lambda / SQS involved.
+     */
+    enqueuePatternMatchingJob: function(data){
+        const citizen = data.params.citizen_scientist | 0;
+        const params = (data.params.persite !== undefined && data.params.persite !== null)
+            ? { threshold: Number(data.params.threshold), N: data.params.N, persite: data.params.persite }
+            : { threshold: Number(data.params.threshold), N: data.params.N };
+        return dbpool.query(
+            'SELECT project_id FROM playlists WHERE playlist_id = ?', [data.playlist]
+        ).then(function(rows){
+            if (!rows.length) { throw new Error('Playlist not found'); }
+            const projId = rows[0].project_id;
+            return dbpool.query(
+                'SELECT species_id, songtype_id FROM templates WHERE template_id = ?', [data.template]
+            ).then(function(trows){
+                if (!trows.length) { throw new Error('Template not found'); }
+                const speciesId = trows[0].species_id;
+                const songtypeId = trows[0].songtype_id;
+                return dbpool.query(
+                    'INSERT INTO `jobs` (`job_type_id`,`date_created`,`last_update`,`project_id`,`user_id`,`state`,`progress`,`completed`,`progress_steps`,`hidden`,`ncpu`,`uri`,`remarks`) ' +
+                    "VALUES (6, now(), now(), ?, ?, 'waiting', 0, 0, 1, 0, 1, '', '')",
+                    [projId, data.user]
+                ).then(function(jres){
+                    const jobId = jres.insertId;
+                    return dbpool.query(
+                        'INSERT INTO `pattern_matchings` (`name`,`project_id`,`job_id`,`timestamp`,`species_id`,`songtype_id`,`parameters`,`playlist_id`,`template_id`,`citizen_scientist`) ' +
+                        'VALUES (?, ?, ?, now(), ?, ?, ?, ?, ?, ?)',
+                        [data.name, projId, jobId, speciesId, songtypeId, JSON.stringify(params), data.playlist, data.template, citizen]
+                    ).then(function(pres){
+                        return { job_id: jobId, pattern_matching_id: pres.insertId, dispatch: 'jobqueue' };
+                    });
+                });
+            });
+        });
     },
 };
 


### PR DESCRIPTION
Promotes #1724 to master to trigger rfcx-local CD. Pattern Matching + AED dispatch via the in-cluster jobqueue-dispatcher when ANALYSIS_DISPATCH=jobqueue (set in apps-prod arbimon override); falls back to AWS lambda.invoke when unset (no-op for AWS). Local worker images + dispatcher already deployed and validated end-to-end (PM 16 dets, AED 614 dets, all smoke tests green). Part of rfcx-local AWS-zero Phase D-ANALYSIS.