### PR TITLE
fix(assets): serve spectrogram images inline + immutable (stop repeat re-downloads)

### DIFF
--- a/app/routes/data-api/ingest.js
+++ b/app/routes/data-api/ingest.js
@@ -108,9 +108,46 @@ router.post('/recordings/delete', verifyToken(), hasRole(['systemUser']), async 
 router.get('/recordings/:attr', async function(req, res) {
   const token = await auth0Service.getToken();
   const apiUrl = `${rfcxConfig.mediaBaseUrl}/internal/assets/streams/${req.params.attr}`;
-  request.get(apiUrl, {
+  // Proxy the media-api asset. media-api pipes its response headers through
+  // verbatim (Content-Disposition: attachment + a short Cache-Control),
+  // which makes browsers treat inline spectrogram <img> resources as file
+  // downloads and re-fetch/re-render them on every page view. These asset
+  // URLs are CONTENT-ADDRESSED (every render param is encoded in
+  // req.params.attr), so for images we rewrite the headers to serve INLINE
+  // + immutable so browsers and the CDN cache them. Audio keeps download
+  // semantics. We must use res.writeHead (not setHeader + request.pipe)
+  // because the 'request' lib copies the upstream headers onto res during
+  // pipe, which would clobber our Content-Disposition.
+  const attr = req.params.attr || '';
+  const isImage = /\.(png|jpe?g|webp)$/i.test(attr);
+  const upstream = request.get(apiUrl, {
     headers: { 'Authorization': `Bearer ${token}` }
-  }).pipe(res);
+  });
+  upstream.on('error', () => {
+    if (!res.headersSent) res.status(502);
+    res.end();
+  });
+  upstream.on('response', (upRes) => {
+    const h = {};
+    const passthrough = ['content-type', 'content-length', 'accept-ranges',
+      'content-range', 'rfcx-stream-next-timestamp', 'rfcx-stream-gaps',
+      'access-control-expose-headers', 'last-modified', 'etag'];
+    passthrough.forEach((k) => {
+      if (upRes.headers[k] !== undefined) h[k] = upRes.headers[k];
+    });
+    if (isImage) {
+      if (!h['content-type']) h['content-type'] = 'image/png';
+      h['content-disposition'] = `inline; filename="${attr}"`;
+      h['cache-control'] = 'public, max-age=31536000, immutable';
+    } else {
+      if (upRes.headers['content-disposition']) h['content-disposition'] = upRes.headers['content-disposition'];
+      if (upRes.headers['cache-control']) h['cache-control'] = upRes.headers['cache-control'];
+    }
+    res.writeHead(upRes.statusCode, h);
+    upRes.on('data', (chunk) => res.write(chunk));
+    upRes.on('end', () => res.end());
+    upRes.on('error', () => { try { res.end(); } catch (e) {} });
+  });
 })
 
 module.exports = router;

--- a/app/routes/data-api/project/recordings.js
+++ b/app/routes/data-api/project/recordings.js
@@ -424,6 +424,26 @@ router.get('/:get/:oneRecUrl?', function(req, res, next) {
                 return;
             }
 
+            // Spectrogram images + thumbnails are CONTENT-ADDRESSED (every
+            // render param is encoded in the request URL/filename), so they
+            // are immutable and safe to cache aggressively. Serve them
+            // INLINE (not as an attachment download) with a long-lived
+            // Cache-Control + an ETag (res.sendFile adds Last-Modified/ETag)
+            // so browsers and the CDN reuse them instead of re-fetching /
+            // re-rendering on every page view. (Previously res.download set
+            // Content-Disposition: attachment with no cache headers, which
+            // defeats inline <img> caching.)
+            if (get === 'image' || get === 'thumbnail') {
+                res.setHeader('Content-Type', 'image/png');
+                res.setHeader('Content-Disposition', `inline; filename="${recording.file}"`);
+                res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+                res.sendFile(file.path, function(err) {
+                    fs.unlink(file.path, () => {});
+                    if (err && !res.headersSent) return next(err);
+                });
+                return;
+            }
+
             res.download(file.path, recording.file, function() {
                 fs.unlink(file.path, () => {})
             });


### PR DESCRIPTION
## Problem
Visualizer pages (e.g. the AOOS visualizer) re-download regenerated spectrogram PNGs **multiple times per page view** without taking advantage of caching.

Root cause: the `/ingest/recordings/:attr` proxy (`app/routes/data-api/ingest.js`) pipes media-api's response headers through verbatim, including `Content-Disposition: attachment` and a short `Cache-Control`. Browsers treat an `attachment`-flagged `<img>` resource as a file download and do **not** reuse it from cache; the CDN edge also cannot cache it effectively.

## Fix
These asset URLs are **content-addressed** — every render parameter (timestamps, gain, zoom, dimensions, color, etc.) is encoded in the request path/filename — so the response is immutable. For image assets (`png`/`jpg`/`webp`) the ingest proxy now rewrites headers to:
- `Content-Disposition: inline`
- `Cache-Control: public, max-age=31536000, immutable`

Implementation note: uses `res.writeHead()` rather than `setHeader()` + `request.pipe()`, because the `request` library copies upstream headers onto the response during `.pipe()` and would clobber our `Content-Disposition`. Audio assets keep their download semantics.

The parallel `data-api/project` recordings `image`/`thumbnail` handler (which previously fell through to `res.download`) is fixed the same way.

## Verification
Verified on the live rfcx-local production deploy (manual build of this change):
- `GET .../recordings/<...>_fspec_...png` now returns `Content-Disposition: inline` + `Cache-Control: public, max-age=31536000, immutable`
- Valid PNG body (e.g. 420×154 grayscale spectrogram)
- After a CDN purge, Cloudflare serves the corrected, cacheable response

## Deploy
On merge to `master`, the existing `deploy-rfcx-local` CD job rebuilds the `arbimon` image and rolls `arbimon` + `arbimon-ingest-consumer` in the rfcx-local cluster.