### PR TITLE
clustering (type 9): route AED-clustering job creation through the jobqueue

### DIFF
--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -277,10 +277,18 @@ let ClusteringJobs = {
             "    `date_created`, `parameters`\n" +
             ") SELECT ?, ?, ?, ?, ?, NOW(), ?";
 
+        // rfcx-local: when ANALYSIS_DISPATCH=jobqueue, insert the job as
+        // 'waiting' so the in-cluster jobqueue-dispatcher claims it (type 9 ->
+        // aed-clustering worker) instead of posting a k8s Job directly to AWS
+        // EKS. Falls back to the legacy 'processing' + direct-post when unset.
+        const useJobqueue = (config('lambdas') && config('lambdas').dispatch === 'jobqueue')
+            || process.env.ANALYSIS_DISPATCH === 'jobqueue';
+        const initialState = useJobqueue ? 'waiting' : 'processing';
+
         return q.ninvoke(joi, 'validate', payload, ClusteringJobs.JOB_SCHEMA)
             .then(() => dbpool.query(
                 jobQuery, [
-                    9, data.project_id, data.user_id, 'processing', 0, 0, 4, 0, 0
+                    9, data.project_id, data.user_id, initialState, 0, 0, 4, 0, 0
                 ]
             ).then(result => {
                 data.id = job_id = result.insertId;
@@ -296,6 +304,12 @@ let ClusteringJobs = {
                     ]
                 )
                 ).then(async () => {
+                // rfcx-local: skip the direct AWS-EKS k8s Job post when the
+                // jobqueue dispatcher owns dispatch (it claims the 'waiting'
+                // row above and runs the aed-clustering worker in-cluster).
+                if (useJobqueue) {
+                    return;
+                }
                 data.kubernetesJobName = `aed-clustering-${new Date().getTime()}`;
                 let jobParam = jsonTemplates.getAEDJobTemplate('aed-clustering', 'job', {
                     kubernetesJobName: data.kubernetesJobName,


### PR DESCRIPTION
Localizes AED Clustering (job_type_id 9) dispatch for rfcx-local, mirroring the PM (#1724) and AED-for-clustering jobqueue routing.

**Problem:** `requestNewClusteringJob` inserted the job as `state='processing'` then posted a k8s Job **directly to AWS EKS** (`k8sClient.jobs.post` with the AED image), bypassing the in-cluster jobqueue entirely. On rfcx-local that worker doesn't exist there, so clustering jobs never ran (they stuck as zombie `processing` rows with no worker).

**Change (env-gated, reversible):** when `ANALYSIS_DISPATCH=jobqueue` (the running arbimon pod already carries this, same as PM/AED), insert the job as `state='waiting'` and **skip** the direct EKS post. The in-cluster `jobqueue-dispatcher` then claims it (type 9 → `aed-clustering` worker, `cluster_run_job.py`). Legacy AWS path (processing + direct post) preserved when the flag is unset. Insert columns/params unchanged, so the worker + frontend read contract is identical.

The in-cluster worker (rfcx/arbimon-clustering, AWS-free) + dispatcher wiring are already built, deployed, and validated end-to-end (DBSCAN+PaCMAP+LDA, result JSONs at `audio_events/<env>/clustering/<job>/<job>_{lda,aed_info}.json`). `node --check` passes.

Once this CD-builds the arbimon image, real UI clustering submissions flow through the jobqueue.