### PR TITLE
feat(project-classes): return species aliases (other/former names)

### DIFF
--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -516,7 +516,11 @@ var Projects = {
             "pc.songtype_id as songtype",
             "st.taxon",
             "sp.scientific_name as species_name",
-            "so.songtype as songtype_name"
+            "so.songtype as songtype_name",
+            // Other names (common names + superseded scientific names) for this
+            // species. Correlated subquery keeps row cardinality unchanged so it
+            // is safe alongside the conditional countValidations GROUP BY below.
+            "(SELECT GROUP_CONCAT(sa.alias SEPARATOR ', ') FROM species_aliases sa WHERE sa.species_id = pc.species_id AND sa.alias <> '') as aliases"
         ];
         let from_clause = [
             "project_classes AS pc",


### PR DESCRIPTION
## What
`getProjectClasses` (the `/legacy-api/project/:slug/classes` endpoint) now returns an `aliases` field per class — a cleaned, comma-joined list of the species' aliases from `species_aliases` (common names + superseded scientific names, blanks excluded).

## Why
Enables the website's project species list to show an **"Also known as"** column. This matters after an in-place species rename: e.g. `Tyto alba furcata` was renamed to `Tyto furcata pratincola` (carrying all its analysis history via the species_id FK). The former name is preserved as an alias, but was invisible in the UI — projects that already track the bird saw the name change with no breadcrumb. This surfaces the former name.

## How
Correlated subquery in the SELECT (not JOIN+GROUP_CONCAT) so row cardinality is unchanged and it coexists safely with the conditional `countValidations` GROUP BY path. Verified against live data: both query paths return the alias list correctly.

## Deploy
Master → rfcx-local CD builds `arbimon` image, rolls `arbimon` + `arbimon-ingest-consumer`. Pairs with rfcx/arbimon website PR (Also known as column). **Merge this first** so the field exists before the website renders the column.