### PR TITLE
feat(recordings/species): safe server-side sort by whitelisted columns

### DIFF
--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -570,14 +570,43 @@ var Projects = {
             groupby_clause.push("pc.species_id", "pc.songtype_id");
         }
 
+        // Safe, whitelisted ORDER BY for the project-species list. The client
+        // sends a stable sort key (column key from the website table); we map
+        // it to a vetted SQL expression so the raw value never reaches SQL.
+        // Default preserves the historical scientific-name ordering.
+        const order_clause = Projects.resolveSpeciesSort(options && options.sortBy, options && options.sortRev);
+
         return q.nfcall(queryHandler, dbpool.format(
             "SELECT " + select_clause.join(", \n") + "\n" +
             "FROM " + from_clause.join("\n") + "\n" +
             "WHERE (" + where_clause.join(") AND (") + ")" +
-            (groupby_clause.length ? "\nGROUP BY " + groupby_clause.join(",") : ""),
+            (groupby_clause.length ? "\nGROUP BY " + groupby_clause.join(",") : "") +
+            "\nORDER BY " + order_clause,
             params) +
             (options.limit ? ("\nLIMIT " + Number(options.limit) + " OFFSET " + Number(options.offset)) : "")
         ).get(0).nodeify(callback);
+    },
+
+    /**
+     * Whitelist of user-selectable sort columns for the project-species list,
+     * mapping a stable client key to a SAFE SQL expression. Anything not in
+     * the map falls back to the default scientific-name ordering. Keys match
+     * the website's species table column keys.
+     */
+    SPECIES_SORT_COLUMNS: {
+        species_name:  'sp.scientific_name',
+        taxon:         'st.taxon',
+        songtype_name: 'so.songtype'
+    },
+
+    resolveSpeciesSort: function(sortBy, sortRev) {
+        const dir = sortRev ? 'DESC' : 'ASC';
+        const expr = sortBy != null ? Projects.SPECIES_SORT_COLUMNS[String(sortBy).trim()] : undefined;
+        if (!expr) {
+            // Historical default order.
+            return 'sp.scientific_name ASC, so.songtype ASC';
+        }
+        return expr + ' ' + dir + ', sp.scientific_name ' + dir;
     },
 
     getProjectClassesAsync: function(projectId, classId, options) {

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -1319,6 +1319,49 @@ var Recordings = {
         return dbpool.query(q);
     },
 
+    /**
+     * Whitelist of user-selectable sort columns for the recordings list.
+     * Maps a stable client-facing sort key to a SAFE, fully-qualified SQL
+     * expression. The client must never be able to inject arbitrary SQL into
+     * the ORDER BY clause, so anything not in this map falls back to the
+     * historical default order (site_id DESC, datetime DESC).
+     *
+     * Only columns backed by an index on `recordings` (or cheap to filesort
+     * within a single project's scope) are exposed — see the index audit:
+     *   datetime      -> datetime_idx / recordings_site_datetime_idx
+     *   upload_time   -> recs_by_upload_time / recordings_upload_time_*
+     *   uri (filename)-> uri
+     *   site_id       -> site_id
+     * `recorder` has no dedicated index but is acceptable as a per-project
+     * filesort. Free-text `comments`/`meta` are intentionally NOT sortable.
+     */
+    RECORDING_SORT_COLUMNS: {
+        site:        'r.site_id',
+        site_id:     'r.site_id',
+        datetime:    'r.datetime',
+        filename:    'r.uri',
+        uri:         'r.uri',
+        upload_time: 'r.upload_time',
+        recorder:    'r.recorder'
+    },
+
+    /**
+     * Resolve a requested (sortBy, sortRev) pair into a safe ORDER BY body for
+     * the recordings list query. Returns an object with `clause` (the SQL
+     * fragment, without the leading "ORDER BY") and `usingDefault` (true when
+     * the request did not map to a whitelisted column).
+     */
+    resolveRecordingSort: function(sortBy, sortRev) {
+        const dir = sortRev ? 'DESC' : 'ASC';
+        const expr = sortBy != null ? Recordings.RECORDING_SORT_COLUMNS[String(sortBy).trim()] : undefined;
+        if (!expr) {
+            // Historical default: keep recordings grouped by site, newest first.
+            return { clause: 'r.site_id DESC, r.datetime DESC', usingDefault: true };
+        }
+        // Tie-break on recording_id for a stable, deterministic page order.
+        return { clause: expr + ' ' + dir + ', r.recording_id ' + dir, usingDefault: false };
+    },
+
     /** finds a set of recordings given some search criteria.
      * @param {Object} params - search parameters
      * @param {Function} callback - callback function (optional)
@@ -1503,9 +1546,10 @@ var Recordings = {
                         where_clause
                     ];
                     if(output === 'list') {
-                        const sortBy = parameters.sortBy || 'r.datetime';
-                        const sortRev = parameters.sortRev ? 'DESC' : '';
-                        query.push('ORDER BY ' + sortBy + ' ' + sortRev);
+                        // Safe, whitelisted ORDER BY — never interpolate the raw
+                        // client sortBy string into SQL (injection guard).
+                        const sort = Recordings.resolveRecordingSort(parameters.sortBy, parameters.sortRev);
+                        query.push('ORDER BY ' + sort.clause);
                         if(limit_clause){
                             query.push("LIMIT " + limit_clause);
                         }
@@ -1519,6 +1563,13 @@ var Recordings = {
                 // Get recording data for the output='list'
                 const listIndex = outputs.findIndex(item => item === 'list')
                 if (outputs.includes('list') && results[listIndex][0].length && !outputs.includes('sql')) {
+                    // The page of recording_ids was already selected in the
+                    // requested (whitelisted) order by the list query above.
+                    // This re-fetch must PRESERVE that exact order — previously
+                    // it hardcoded `site_id DESC, datetime DESC`, which silently
+                    // overrode any user-selected sort. Use ORDER BY FIELD(...)
+                    // to replay the id order from the first query.
+                    const orderedIds = results[listIndex][0].map(item => item.id);
                     const sql = `SELECT r.recording_id AS id,
                         SUBSTRING_INDEX(r.uri,'/',-1) as file,
                         r.uri,
@@ -1532,8 +1583,8 @@ var Recordings = {
                         r.sample_rate,
                         r.meta,
                         r.site_id
-                        FROM recordings r WHERE r.recording_id IN (${results[listIndex][0].map(item => item.id)})
-                        ORDER BY r.site_id DESC, r.datetime DESC
+                        FROM recordings r WHERE r.recording_id IN (${orderedIds})
+                        ORDER BY FIELD(r.recording_id, ${orderedIds})
                     `
                     let queryResult = await dbpool.query({
                         sql,

--- a/app/routes/data-api/project/index.js
+++ b/app/routes/data-api/project/index.js
@@ -275,6 +275,8 @@ router.get('/:projectUrl/classes', function(req, res, next) {
         q: req.query.q,
         limit: req.query.limit,
         offset: req.query.offset,
+        sortBy: req.query.sortBy,
+        sortRev: req.query.sortRev === 'true' || req.query.sortRev === true,
     };
 
     if(req.query.validations) {


### PR DESCRIPTION
Adds true server-side sorting (whole-list, not just the current page) for the **recordings** and **species** lists, driven by the new arbimon website column-header sort. Paired with rfcx/arbimon PR (frontend).

## Problem
The website `audiodata` lists let users click a column header to sort, but the API only ever sorted *which rows land on a page* — not their displayed order:

1. **Recordings (`/recordings/search` → `findProjectRecordings`)** interpolated the raw client `sortBy` string directly into `ORDER BY` (**SQL-injection risk**), and then a *second* query that re-fetches the full row data **hardcoded** `ORDER BY r.site_id DESC, r.datetime DESC` — silently overriding any requested sort.
2. **Species (`/classes` → `getProjectClasses`)** had **no** sort support at all.

## Fix
- **Recordings:** `RECORDING_SORT_COLUMNS` whitelist + `resolveRecordingSort()` mapping stable client keys (`site|datetime|filename|upload_time|recorder`) → safe SQL. Unknown/garbage keys fall back to the historical default (`site_id DESC, datetime DESC`). The full-row re-fetch now **preserves** the selected page order via `ORDER BY FIELD(recording_id, …)`. Tie-break on `recording_id` for deterministic paging.
- **Species:** `SPECIES_SORT_COLUMNS` whitelist + `resolveSpeciesSort()` (`species_name|taxon|songtype_name`), threaded from the `/classes` route (`sortBy`/`sortRev`). Default preserves scientific-name order.

## Safety / performance
- **Injection-safe:** client strings never reach SQL; only vetted expressions do (verified: garbage/`"…; DROP TABLE…"` → safe default).
- **Indexed columns only** for recordings (`datetime_idx`, `recs_by_upload_time`, `uri`, `site_id`) on a ~273M-row table; `recorder` is an accepted per-project filesort. Free-text `comments`/`meta` intentionally not sortable.
- **Backward compatible:** callers that send no `sortBy` (legacy AngularJS visualizer `findRecordings`) keep todays order. No joi schema change (`sortBy`/`sortRev` already permitted).

## Test
Pure resolver logic verified out-of-band (whitelist hit/miss, trimming, injection → default, asc/desc + tie-break). Repo has no unit-test harness for models (mocha+DB only), so no test files added.

## Deploy
Layer-A repo: lands via `develop → staging → master`; master CD builds `arbimon` image + rolls `arbimon` / `arbimon-ingest-consumer`. **Merge the rfcx/arbimon frontend PR together** (frontend sends the new `sortBy` keys / `sortRev`).

🤖 drafted by an agent session (ms4); see rfcx-local `runbooks/ACTIVE-SESSIONS.md`.