### PR TITLE
feat(recordings/species): safe server-side sort by whitelisted columns

### DIFF
--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -570,14 +570,43 @@ var Projects = {
             groupby_clause.push("pc.species_id", "pc.songtype_id");
         }
 
+        // Safe, whitelisted ORDER BY for the project-species list. The client
+        // sends a stable sort key (column key from the website table); we map
+        // it to a vetted SQL expression so the raw value never reaches SQL.
+        // Default preserves the historical scientific-name ordering.
+        const order_clause = Projects.resolveSpeciesSort(options && options.sortBy, options && options.sortRev);
+
         return q.nfcall(queryHandler, dbpool.format(
             "SELECT " + select_clause.join(", \n") + "\n" +
             "FROM " + from_clause.join("\n") + "\n" +
             "WHERE (" + where_clause.join(") AND (") + ")" +
-            (groupby_clause.length ? "\nGROUP BY " + groupby_clause.join(",") : ""),
+            (groupby_clause.length ? "\nGROUP BY " + groupby_clause.join(",") : "") +
+            "\nORDER BY " + order_clause,
             params) +
             (options.limit ? ("\nLIMIT " + Number(options.limit) + " OFFSET " + Number(options.offset)) : "")
         ).get(0).nodeify(callback);
+    },
+
+    /**
+     * Whitelist of user-selectable sort columns for the project-species list,
+     * mapping a stable client key to a SAFE SQL expression. Anything not in
+     * the map falls back to the default scientific-name ordering. Keys match
+     * the website's species table column keys.
+     */
+    SPECIES_SORT_COLUMNS: {
+        species_name:  'sp.scientific_name',
+        taxon:         'st.taxon',
+        songtype_name: 'so.songtype'
+    },
+
+    resolveSpeciesSort: function(sortBy, sortRev) {
+        const dir = sortRev ? 'DESC' : 'ASC';
+        const expr = sortBy != null ? Projects.SPECIES_SORT_COLUMNS[String(sortBy).trim()] : undefined;
+        if (!expr) {
+            // Historical default order.
+            return 'sp.scientific_name ASC, so.songtype ASC';
+        }
+        return expr + ' ' + dir + ', sp.scientific_name ' + dir;
     },
 
     getProjectClassesAsync: function(projectId, classId, options) {

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -1315,6 +1315,49 @@ var Recordings = {
         return dbpool.query(q);
     },
 
+    /**
+     * Whitelist of user-selectable sort columns for the recordings list.
+     * Maps a stable client-facing sort key to a SAFE, fully-qualified SQL
+     * expression. The client must never be able to inject arbitrary SQL into
+     * the ORDER BY clause, so anything not in this map falls back to the
+     * historical default order (site_id DESC, datetime DESC).
+     *
+     * Only columns backed by an index on `recordings` (or cheap to filesort
+     * within a single project's scope) are exposed — see the index audit:
+     *   datetime      -> datetime_idx / recordings_site_datetime_idx
+     *   upload_time   -> recs_by_upload_time / recordings_upload_time_*
+     *   uri (filename)-> uri
+     *   site_id       -> site_id
+     * `recorder` has no dedicated index but is acceptable as a per-project
+     * filesort. Free-text `comments`/`meta` are intentionally NOT sortable.
+     */
+    RECORDING_SORT_COLUMNS: {
+        site:        'r.site_id',
+        site_id:     'r.site_id',
+        datetime:    'r.datetime',
+        filename:    'r.uri',
+        uri:         'r.uri',
+        upload_time: 'r.upload_time',
+        recorder:    'r.recorder'
+    },
+
+    /**
+     * Resolve a requested (sortBy, sortRev) pair into a safe ORDER BY body for
+     * the recordings list query. Returns an object with `clause` (the SQL
+     * fragment, without the leading "ORDER BY") and `usingDefault` (true when
+     * the request did not map to a whitelisted column).
+     */
+    resolveRecordingSort: function(sortBy, sortRev) {
+        const dir = sortRev ? 'DESC' : 'ASC';
+        const expr = sortBy != null ? Recordings.RECORDING_SORT_COLUMNS[String(sortBy).trim()] : undefined;
+        if (!expr) {
+            // Historical default: keep recordings grouped by site, newest first.
+            return { clause: 'r.site_id DESC, r.datetime DESC', usingDefault: true };
+        }
+        // Tie-break on recording_id for a stable, deterministic page order.
+        return { clause: expr + ' ' + dir + ', r.recording_id ' + dir, usingDefault: false };
+    },
+
     /** finds a set of recordings given some search criteria.
      * @param {Object} params - search parameters
      * @param {Function} callback - callback function (optional)
@@ -1499,9 +1542,10 @@ var Recordings = {
                         where_clause
                     ];
                     if(output === 'list') {
-                        const sortBy = parameters.sortBy || 'r.datetime';
-                        const sortRev = parameters.sortRev ? 'DESC' : '';
-                        query.push('ORDER BY ' + sortBy + ' ' + sortRev);
+                        // Safe, whitelisted ORDER BY — never interpolate the raw
+                        // client sortBy string into SQL (injection guard).
+                        const sort = Recordings.resolveRecordingSort(parameters.sortBy, parameters.sortRev);
+                        query.push('ORDER BY ' + sort.clause);
                         if(limit_clause){
                             query.push("LIMIT " + limit_clause);
                         }
@@ -1515,6 +1559,13 @@ var Recordings = {
                 // Get recording data for the output='list'
                 const listIndex = outputs.findIndex(item => item === 'list')
                 if (outputs.includes('list') && results[listIndex][0].length && !outputs.includes('sql')) {
+                    // The page of recording_ids was already selected in the
+                    // requested (whitelisted) order by the list query above.
+                    // This re-fetch must PRESERVE that exact order — previously
+                    // it hardcoded `site_id DESC, datetime DESC`, which silently
+                    // overrode any user-selected sort. Use ORDER BY FIELD(...)
+                    // to replay the id order from the first query.
+                    const orderedIds = results[listIndex][0].map(item => item.id);
                     const sql = `SELECT r.recording_id AS id,
                         SUBSTRING_INDEX(r.uri,'/',-1) as file,
                         r.uri,
@@ -1528,8 +1579,8 @@ var Recordings = {
                         r.sample_rate,
                         r.meta,
                         r.site_id
-                        FROM recordings r WHERE r.recording_id IN (${results[listIndex][0].map(item => item.id)})
-                        ORDER BY r.site_id DESC, r.datetime DESC
+                        FROM recordings r WHERE r.recording_id IN (${orderedIds})
+                        ORDER BY FIELD(r.recording_id, ${orderedIds})
                     `
                     let queryResult = await dbpool.query({
                         sql,

--- a/app/routes/data-api/project/index.js
+++ b/app/routes/data-api/project/index.js
@@ -275,6 +275,8 @@ router.get('/:projectUrl/classes', function(req, res, next) {
         q: req.query.q,
         limit: req.query.limit,
         offset: req.query.offset,
+        sortBy: req.query.sortBy,
+        sortRev: req.query.sortRev === 'true' || req.query.sortRev === true,
     };
 
     if(req.query.validations) {


### PR DESCRIPTION
Server-side whole-list sorting for the **recordings** and **species** lists. Paired with rfcx/arbimon (frontend). Targets **master** directly (production runs master HEAD; this commit is byte-identical cherry-pick of the develop work, which only touched these regions that are identical across master/develop).

## Problem
The website audiodata lists let users click a column header to sort, but the API only sorted *which rows land on a page*, not their displayed order:
1. **Recordings (`findProjectRecordings`)** interpolated the raw client `sortBy` into `ORDER BY` (**SQL-injection**), then a second full-row re-fetch **hardcoded** `ORDER BY r.site_id DESC, r.datetime DESC`, silently overriding the requested sort.
2. **Species (`getProjectClasses`)** had no sort support.

## Fix
- Recordings: `RECORDING_SORT_COLUMNS` whitelist + `resolveRecordingSort()` (`site|datetime|filename|upload_time|recorder`); unknown keys → historical default. Full-row re-fetch now preserves page order via `ORDER BY FIELD(recording_id, …)`; tie-break on `recording_id`.
- Species: `SPECIES_SORT_COLUMNS` + `resolveSpeciesSort()` (`species_name|taxon|songtype_name`), threaded from `/classes` route.

## Safety / perf
- Injection-safe (client strings never reach SQL; verified garbage/`"…;DROP…"` → default).
- Indexed columns only on the ~273M-row `recordings` table (`datetime`, `upload_time`, `uri`, `site_id`); `recorder` = accepted per-project filesort. Free-text comments not sortable.
- Backward compatible: no `sortBy` (legacy AngularJS visualizer) keeps todays order. No joi schema change.

## Deploy
Layer-A; **master push triggers CD** → builds `arbimon` image → rolls `arbimon` + `arbimon-ingest-consumer`. **Merge this BEFORE the rfcx/arbimon frontend PR** so the API can serve sorted pages first.

🤖 agent session (ms4); see rfcx-local runbooks/ACTIVE-SESSIONS.md.