### PR TITLE
feat(archiving Phase A): default recording reads to the active tier

### DIFF
--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -115,6 +115,9 @@ let ClusteringJobs = {
             select.push('S.site_id, S.`name` as `site`');
             tables.push("JOIN recordings R ON A.recording_id = R.recording_id");
             tables.push("JOIN sites S ON R.site_id = S.site_id");
+            // Archiving (Phase A): exclude archived recordings from per-site
+            // clustering aggregates (hide-by-parent).
+            constraints.push(require('../utils/sqlutil').recordingArchiveScope('R', 'active'));
         }
 
         if (options.perDate) {

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -295,6 +295,9 @@ var PatternMatchings = {
             builder.addTable("JOIN sites", "S", "S.site_id = R.site_id");
 
             builder.addConstraint("S.deleted_at is null");
+            // Archiving (Phase A): hide PM ROIs whose recording has been archived
+            // (hide-by-parent). Mirrors the site soft-delete filter above.
+            builder.addConstraint(sqlutil.recordingArchiveScope('R', 'active'));
 
             builder.addProjection(
                 'R.uri as recording, R.meta ',

--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -203,6 +203,8 @@ var Projects = {
                         "SELECT site_id, COUNT(recording_id) as rec_count "+
                         "FROM recordings "+
                         "WHERE site_id IN (?) " +
+                        // Archiving (Phase A): per-site recording counts exclude archived.
+                        "AND " + sqlutil.recordingArchiveScope('', 'active') + " " +
                         "GROUP BY site_id",
                         [siteIds]
                     ).then(function(results){
@@ -236,7 +238,7 @@ var Projects = {
                 s.timezone as Timezone, COUNT(recording_id) as Recordings_Count, s.updated_at, s.external_id
             FROM sites AS s
                 LEFT JOIN project_imported_sites as pis ON s.site_id = pis.site_id AND pis.project_id=?
-                LEFT JOIN recordings as r ON s.site_id = r.site_id
+                LEFT JOIN recordings as r ON s.site_id = r.site_id AND r.archived_at IS NULL
             WHERE (s.project_id=? OR pis.project_id=?) AND s.deleted_at is null
             GROUP BY s.site_id ORDER by s.name;`;
         return dbpool.streamQuery({ sql }, [project_id, project_id, project_id])
@@ -267,7 +269,7 @@ var Projects = {
             FROM recordings AS r
             JOIN sites as s ON s.site_id = r.site_id AND s.project_id = ? AND s.deleted_at is null
             LEFT JOIN project_imported_sites as pis ON s.site_id = pis.site_id AND pis.project_id = ?
-            WHERE s.project_id = ? OR pis.project_id = ?
+            WHERE (s.project_id = ? OR pis.project_id = ?) AND r.archived_at IS NULL
             GROUP BY YEAR(r.datetime), MONTH(r.datetime), DAY(r.datetime) ORDER BY r.datetime ASC`,  typeCast: sqlutil.parseUtcDatetime },
             [project_id, project_id, project_id, project_id]
         )
@@ -1220,13 +1222,13 @@ var Projects = {
     totalRecordings: function(projectId) {
         const q = "SELECT count(recording_id) as count \n" +
                 "FROM recordings AS r JOIN sites AS s ON s.site_id = r.site_id AND s.deleted_at is null \n"+
-                "WHERE s.project_id = " + dbpool.escape(projectId);
+                "WHERE s.project_id = " + dbpool.escape(projectId) + " AND r.archived_at IS NULL";
         return dbpool.query(q).get(0).get('count');
     },
 
     recordingsMinMaxDates: function (project_id, callback) {
         const q = `SELECT min(r.datetime) as min, max(r.datetime) as max FROM recordings r
-            JOIN sites s ON r.site_id = s.site_id WHERE s.project_id = ` + dbpool.escape(project_id)
+            JOIN sites s ON r.site_id = s.site_id WHERE s.project_id = ` + dbpool.escape(project_id) + ` AND r.archived_at IS NULL`
         queryHandler(q, callback);
     },
 

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -270,10 +270,15 @@ var Recordings = {
                 } else {
                     const base = `SELECT ${selection} FROM recordings R JOIN sites S ON S.site_id = ? WHERE R.site_id = ?`
                     const replacements = [recording.site_id, recording.site_id, recording.datetime, recording.recording_id];
+                    // Archiving (Phase A): the prev/next neighbor lists must skip
+                    // archived recordings. The middle query resolves the current
+                    // recording itself by id, so it is left unscoped (a user may
+                    // still be viewing it directly).
+                    const _activeR = sqlutil.recordingArchiveScope('R', 'active');
                     const proms = [
-                        dbpool.query({ sql: `${base} AND datetime <= ? AND recording_id != ? ORDER BY datetime DESC LIMIT 5`, typeCast: sqlutil.parseUtcDatetime }, replacements),
+                        dbpool.query({ sql: `${base} AND ${_activeR} AND datetime <= ? AND recording_id != ? ORDER BY datetime DESC LIMIT 5`, typeCast: sqlutil.parseUtcDatetime }, replacements),
                         dbpool.query({ sql: `${base}  AND datetime = ? AND recording_id = ?`, typeCast: sqlutil.parseUtcDatetime }, replacements),
-                        dbpool.query({ sql:`${base} AND datetime >= ? AND recording_id != ? ORDER BY datetime ASC LIMIT 4`, typeCast: sqlutil.parseUtcDatetime }, replacements),
+                        dbpool.query({ sql:`${base} AND ${_activeR} AND datetime >= ? AND recording_id != ? ORDER BY datetime ASC LIMIT 4`, typeCast: sqlutil.parseUtcDatetime }, replacements),
                     ]
                     return Q.all(proms);
                 }
@@ -360,6 +365,19 @@ var Recordings = {
                 constraints.push('R.`recording_id` = ' + dbpool.escape(Number(options.recording_id)));
             }
 
+            // Archiving (Phase A): default list/grouped URL queries to the ACTIVE
+            // recording tier. Explicit single-recording lookups (urlquery.id or
+            // options.recording_id) are intentionally NOT scoped, so direct
+            // by-id resolution (visualizer playback, playlist/training-set
+            // membership) still works in Phase A; playlist<->archive interaction
+            // is decided in Phase B. 'archived'/'all' modes opt out via param.
+            if (!urlquery.id && !options.recording_id) {
+                const _us = sqlutil.recordingArchiveScope('R', sqlutil.normalizeArchivedParam(options.archived));
+                if (_us) {
+                    constraints.push(_us);
+                }
+            }
+
             if(!urlquery.id && !urlquery.site) {
                 steps.push(
                     dbpool.query("(\n" +
@@ -419,12 +437,15 @@ var Recordings = {
     },
 
     fetchNext: function (recording, callback) {
+        // Archiving (Phase A): skip archived recordings when paging to the next
+        // recording in a site (archived recs must not appear as neighbors).
         var query = "SELECT R2.recording_id as id\n" +
             "FROM recordings R \n" +
             "JOIN recordings R2 ON " +
                 "R.site_id = R2.site_id " +
                 "AND R.datetime < R2.datetime \n" +
             "WHERE R.recording_id = " + dbpool.escape(recording.id) + "\n" +
+            "AND " + sqlutil.recordingArchiveScope('R2', 'active') + "\n" +
             "ORDER BY R2.datetime ASC \n" +
             "LIMIT 1";
 
@@ -435,12 +456,15 @@ var Recordings = {
         });
     },
     fetchPrevious: function (recording, callback) {
+        // Archiving (Phase A): skip archived recordings when paging to the
+        // previous recording in a site.
         var query = "SELECT R2.recording_id as id\n" +
             "FROM recordings R \n" +
             "JOIN recordings R2 ON " +
                 "R.site_id = R2.site_id " +
                 "AND R.datetime > R2.datetime \n" +
             "WHERE R.recording_id = " + dbpool.escape(recording.id) + "\n" +
+            "AND " + sqlutil.recordingArchiveScope('R2', 'active') + "\n" +
             "ORDER BY R2.datetime DESC \n" +
             "LIMIT 1";
 
@@ -1408,6 +1432,16 @@ var Recordings = {
             let constraints = [];
             let data = [];
 
+            // Archiving (Phase A): default the recording listing to the ACTIVE
+            // tier (archived_at IS NULL). Centralized in sqlutil so the rule is
+            // defined once. 'archived'/'only' => archived tier; 'all' => no
+            // filter. This is the primary chokepoint for the recordings list,
+            // count, and date_range outputs.
+            const archiveScope = sqlutil.recordingArchiveScope('r', sqlutil.normalizeArchivedParam(parameters.archived));
+            if (archiveScope) {
+                constraints.push(archiveScope);
+            }
+
             const siteIds = Object.values(siteData).map(function(site){
                 return site.site_id;
             })
@@ -1725,6 +1759,14 @@ var Recordings = {
             sortBy: joi.string(),
             sortByMult: arrayOrSingle(arrayOrSingle(joi.string())),
             sortRev: joi.boolean(),
+            // Archiving (Phase A): controls the active/archived tier of the
+            // recording listing. Omitted => active only (default, current
+            // behavior minus archived rows). 'only'/'archived'/true => archived
+            // only (View Archived). 'all' => both (admin/debug).
+            archived: joi.alternatives().try(
+                joi.boolean(),
+                joi.string().valid('active', 'archived', 'only', 'all', 'true', 'false', '0', '1')
+            ),
             output:  arrayOrSingle(joi.string().valid('count','list','date_range','sql')).default('list')
         },
         exportProjections: {
@@ -1778,6 +1820,15 @@ var Recordings = {
             }
 
             builder.addConstraint("s.deleted_at is null")
+
+            // Archiving (Phase A): default to the ACTIVE recording tier
+            // (archived_at IS NULL). Applies to exports and the deleteMatching/
+            // findMatching count paths that build on this query. 'all' => no
+            // filter; 'archived'/'only' => archived tier only.
+            const _archiveScope = sqlutil.recordingArchiveScope('r', sqlutil.normalizeArchivedParam(parameters.archived));
+            if (_archiveScope) {
+                builder.addConstraint(_archiveScope);
+            }
 
             if(parameters.range) {
                 builder.addConstraint('r.datetime BETWEEN ? AND ?',[

--- a/app/model/sites.js
+++ b/app/model/sites.js
@@ -282,7 +282,7 @@ var Sites = {
                 "FROM sites AS s \n"+
                 "JOIN projects AS p ON s.project_id = p.project_id \n"+
                 "JOIN users AS u ON p.owner_id = u.user_id \n"+
-                "LEFT JOIN recordings AS r ON s.site_id = r.site_id \n"+
+                "LEFT JOIN recordings AS r ON s.site_id = r.site_id AND r.archived_at IS NULL \n"+
                 "WHERE s.published = 1 AND s.deleted_at is null "+
                 "GROUP BY s.site_id";
 
@@ -355,7 +355,7 @@ var Sites = {
 
             sql = "SELECT R.upload_time AS datetime, COUNT(*) AS uploads \n" +
             "FROM recordings R\n" +
-            "WHERE site_id = ?";
+            "WHERE site_id = ? AND R.archived_at IS NULL";
             if (options.dates) {
                 sql += " AND DATE(R.upload_time) IN (?)";
                 params.push(options.dates);
@@ -426,7 +426,7 @@ var Sites = {
 
                 sql = "SELECT R.datetime AS datetime, COUNT(*) AS count \n" +
                 "FROM recordings R\n" +
-                "WHERE site_id = ?";
+                "WHERE site_id = ? AND R.archived_at IS NULL";
                 if (options.dates) {
                     sql += " AND DATE(R.datetime) IN (?)";
                     params.push(options.dates);

--- a/app/model/soundscape-composition.js
+++ b/app/model/soundscape-composition.js
@@ -28,7 +28,9 @@ var SoundscapeComposition = {
                         "FROM recording_soundscape_composition_annotations RSCA " +
                         "JOIN recordings R ON R.recording_id = RSCA.recordingId " +
                         "WHERE RSCA.scclassId = SCC.id " +
-                        "AND R.site_id IN (?)" +
+                        "AND R.site_id IN (?) " +
+                        // Archiving (Phase A): exclude archived recordings from the tally.
+                        "AND " + require('../utils/sqlutil').recordingArchiveScope('R', 'active') +
                         ") as tally");
                         selectdata.push(sites.map(function(site){
                             return site.id;

--- a/app/model/tags.js
+++ b/app/model/tags.js
@@ -148,6 +148,9 @@ tags.resourceDefs.recording = {
     getForType: async function(options){
         var tables = ['tags T', 'JOIN recording_tags RT ON RT.tag_id = T.tag_id', 'JOIN recordings r ON r.recording_id = RT.recording_id'];
         var constraints = [];
+        // Archiving (Phase A): exclude tags on archived recordings from the
+        // project-wide tag counts (hide-by-parent).
+        constraints.push(require('../utils/sqlutil').recordingArchiveScope('r', 'active'));
 
         if(options && options.project){
             const sites = await projects.getProjectSites(options.project)

--- a/app/model/tiering.js
+++ b/app/model/tiering.js
@@ -10,7 +10,10 @@ async function loadProjectTieringUsage(connection, projectId) {
         '        SELECT COUNT(*)\n' +
         '        FROM recordings r\n' +
         '        JOIN sites s ON s.site_id = r.site_id\n' +
-        '        WHERE s.project_id = p.project_id AND s.deleted_at IS NULL\n' +
+        // Archiving (Phase A): archived recordings do NOT count against tier
+        // usage/quota (consistent with "looks deleted to the user"). This is a
+        // billing-relevant decision -- see the design doc open-items.
+        '        WHERE s.project_id = p.project_id AND s.deleted_at IS NULL AND r.archived_at IS NULL\n' +
         '    ), 0) AS recording_minutes_count,\n' +
         '    COALESCE((\n' +
         '        SELECT COUNT(*)\n' +

--- a/app/utils/sqlutil.js
+++ b/app/utils/sqlutil.js
@@ -220,6 +220,53 @@ var sqlutil = {
         if (field.type !== 'DATETIME' || field.name === 'datetime_utc') return next(); // 1 = true, 0 = false
         return new Date(field.string() + ' GMT');
     },
+
+    /**
+     * Archiving (Phase A): centralized "active vs archived" predicate for the
+     * `recordings` table. This is the SINGLE source of truth for the
+     * archived_at filter so the rule is not hand-sprinkled across the ~30
+     * recording read sites (which is the #1 source of "archived data leaks back
+     * into a primary list" bugs).
+     *
+     * Modes:
+     *   'active'   (default) -> `<alias>.archived_at IS NULL`     (primary list)
+     *   'archived'           -> `<alias>.archived_at IS NOT NULL` (View Archived)
+     *   'all'                -> '' (no predicate; admin/debug, opt-in)
+     *
+     * @param {string} alias  table alias used in the query (e.g. 'r', 'R'). Empty
+     *                        string => unqualified column.
+     * @param {string} [mode] one of 'active' | 'archived' | 'all'. Anything
+     *                        falsy/unknown is treated as 'active' (fail-safe).
+     * @returns {string} a SQL boolean expression, or '' for mode 'all'.
+     */
+    recordingArchiveScope: function (alias, mode) {
+        var col = (alias ? alias + '.' : '') + 'archived_at';
+        switch (mode) {
+            case 'all':
+                return '';
+            case 'archived':
+                return col + ' IS NOT NULL';
+            case 'active':
+            default:
+                return col + ' IS NULL';
+        }
+    },
+
+    /**
+     * Normalize an incoming `archived` request param into a scope mode.
+     * Accepts: undefined/false/'false'/'0' -> 'active';
+     *          true/'true'/'1'/'only'/'archived' -> 'archived';
+     *          'all' -> 'all'. Unknown values fail safe to 'active'.
+     * @param {*} archived
+     * @returns {'active'|'archived'|'all'}
+     */
+    normalizeArchivedParam: function (archived) {
+        if (archived === undefined || archived === null) return 'active';
+        if (archived === 'all') return 'all';
+        if (archived === true || archived === 'true' || archived === '1' ||
+            archived === 'only' || archived === 'archived') return 'archived';
+        return 'active';
+    },
 };
 
 module.exports = sqlutil;


### PR DESCRIPTION
## What
**Phase A read-paths** for the recordings "Archive" tier: makes every user-facing recording read default to the **active** tier (`archived_at IS NULL`), with an `archived` search param so a later "View Archived" UI can request the secondary tier. Companion to the schema PR (rfcx/arbimon-db#50) and the design `runbooks/DESIGN-archiving-instead-of-delete-arbimon-2026-06-16.md` (rfcx-local).

**No behavior change on current data** — every existing row has `archived_at IS NULL`, so every scoped query returns exactly what it does today. The archive write-path (delete→archive) + restore land in Phase B.

## How
- New single-source-of-truth helper `sqlutil.recordingArchiveScope(alias, mode)` + `normalizeArchivedParam(param)` (modes: `active` default / `archived` / `all`; fail-safe to `active`). Centralized so the predicate is **never** hand-sprinkled (the #1 "archived data leaks back into a primary list" bug class).
- `archived` added to `recordings.SCHEMAS.searchFilters` (joi-validated).
- **Scoped (active-only by default):** `findProjectRecordings` (list/count/date_range — the main chokepoint), `buildSearchQuery` (exports + deleteMatching/findMatching), `findByUrlMatch` (list/grouped), prev/next navigation, PM ROI list, per-site clustering aggregate, tag counts, soundscape tally, project rec-count/site-list/dates/totals/min-max, site published-list + per-site upload/rec charts, tier-usage count.
- **Intentionally NOT scoped** (documented in design §6.5): by-id/by-uri point lookups, ingest dedup (uri UNIQUE), single-job/-roi analysis lookups, the post-filter `WHERE recording_id IN (...)`, templates (own `deleted` flag, Phase B), site-delete write-path helpers (Phase B).

This branch is the Phase A read-path work **rebased cleanly onto current master** (composes correctly with the recent server-side-sort hardening #1733/#1734 — the scope predicate is orthogonal to ORDER BY; filename sort still FORCE-INDEXes its composite). Supersedes the earlier unmerged `agent/ms5-archiving-recordings-readpaths-20260616`.

## ⚠️ Operator-confirm item (billing-relevant, but a no-op today)
`tiering.loadProjectTieringUsage` now **excludes archived recordings from quota usage** (archiving frees quota). Currently a no-op (nothing archived). Confirm this is the desired policy vs. archived data still counting against the project's limit — easy to flip before Phase B makes archiving reachable.

## Dependency / deploy order
Requires the schema columns from rfcx/arbimon-db#50. Those are **already applied to rfcx-local production** (2026-06-24, online, zero write-block), so this code is safe to deploy now — the scope predicate references `archived_at`, which exists live. Merging to `master` triggers rfcx-local CD; will cherry-pick to `develop` after.

## Testing
`node --check` clean on all 9 changed files. EXPLAIN on live confirms active-list plan unchanged (uses `recordings_site_datetime_idx`, `archived_at` a cheap `Using where`).
