### PR TITLE
feat(tiering): enforce + surface 12,000 recordings-per-job limit (free projects)

### DIFF
--- a/app/model/audio-event-detections-clustering.js
+++ b/app/model/audio-event-detections-clustering.js
@@ -195,6 +195,10 @@ let AudioEventDetectionsClustering = {
             }
         )
         return q.ninvoke(joi, 'validate', data, AudioEventDetectionsClustering.JOB_SCHEMA).then(() => {
+            // Tier reframe (2026-06-29): per-job recording (playlist size) cap
+            // for free projects (project resolved from the playlist). Fail-open.
+            return require('./tiering').assertJobRecordingLimit(data.project_id, data.playlist_id);
+        }).then(() => {
             // rfcx-local: when ANALYSIS_DISPATCH=jobqueue, create the job +
             // job_params rows directly (what the AWS aed conductor Lambda
             // did) so the in-cluster jobqueue-dispatcher picks it up,

--- a/app/model/jobs.js
+++ b/app/model/jobs.js
@@ -192,6 +192,15 @@ var Jobs = {
                     return q.ninvoke(joi, 'validate', params, job_type.schema);
                 }
         }).then(function(){
+            // Tier reframe (2026-06-29): enforce the per-job recording (playlist
+            // size) cap for free projects on playlist-driven analyses
+            // (soundscape, classification, ...). PM has its own guard at its
+            // dedicated entrypoint. No-op when the job has no playlist (e.g.
+            // training) or when uncapped/bio-api-unreachable (fail-open).
+            if (params.playlist !== undefined && params.playlist !== null && params.project) {
+                return require('./tiering').assertJobRecordingLimit(params.project, params.playlist);
+            }
+        }).then(function(){
             return q.ninvoke(dbpool, 'getConnection');
         }).then(function start_transaction(connection){
             var tx = new sqlutil.transaction(db = connection);

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -921,6 +921,11 @@ var PatternMatchings = {
         const isPrivileged = data.user && data.user.email && data.user.email.endsWith('@rfcx.org') ? 1 : 0
         data.user = data.user.id
         return q.ninvoke(joi, 'validate', data, PatternMatchings.JOB_SCHEMA).then(() => {
+            // Tier reframe (2026-06-29): enforce the per-job recording (playlist
+            // size) cap for free projects (uncapped for premium). Limit owned by
+            // bio-api; fail-open if bio-api is unreachable.
+            return require('./tiering').assertJobRecordingLimit(data.project, data.playlist);
+        }).then(() => {
             // rfcx-local: when ANALYSIS_DISPATCH=jobqueue, create the job +
             // pattern_matchings rows directly (what the AWS tm_driver Lambda
             // used to do) so the in-cluster jobqueue-dispatcher picks it up,

--- a/app/model/tiering.js
+++ b/app/model/tiering.js
@@ -2,6 +2,89 @@
 "use strict";
 
 const dbpool = require('../utils/dbpool');
+const request = require('request');
+const config = require('../config');
+const debug = require('debug')('arbimon2:tiering');
+
+// Tier reframe (2026-06-29): per-job recording (playlist size) cap. The limit
+// itself is OWNED by bio-api (Bio Postgres `insights`.project_type_limit), which
+// legacy can't read directly (different DB). bio-api exposes an unauthenticated
+// entitlement endpoint keyed by project slug; we ask it for the project's
+// `limits.jobRecordingCount` (null = uncapped) and enforce it at job-create
+// time. Fail-OPEN on any bio-api error so a transient bio-api issue can't block
+// production analysis.
+const BIO_API_BASE_URL = (config('hosts').bioApi || '').replace(/\/$/, '');
+
+function fetchProjectEntitlement(slug) {
+    return new Promise(function (resolve) {
+        if (!BIO_API_BASE_URL) { resolve(null); return; }
+        request({
+            method: 'GET',
+            url: `${BIO_API_BASE_URL}/projects/${encodeURIComponent(slug)}/entitlement-summary`,
+            json: true,
+            timeout: 5000
+        }, function (err, resp, body) {
+            if (err || !resp || resp.statusCode !== 200 || !body) {
+                debug('entitlement lookup failed (fail-open) for %s: %s', slug, err || (resp && resp.statusCode));
+                resolve(null);
+                return;
+            }
+            resolve(body);
+        });
+    });
+}
+
+async function getProjectSlugById(projectId) {
+    const rows = await dbpool.query('SELECT url FROM projects WHERE project_id = ? LIMIT 1', [projectId]);
+    return rows.length ? rows[0].url : null;
+}
+
+/**
+ * Count the recordings in a playlist.
+ */
+async function getPlaylistRecordingCount(playlistId) {
+    const rows = await dbpool.query(
+        'SELECT COUNT(*) AS c FROM playlist_recordings WHERE playlist_id = ?', [playlistId]
+    );
+    return rows.length ? Number(rows[0].c || 0) : 0;
+}
+
+/**
+ * Enforce the per-job recording (playlist size) cap for the given project.
+ * Throws an Error (surfaced to the user) when the playlist exceeds the project's
+ * jobRecordingCount limit. No-op when uncapped, when bio-api is unreachable
+ * (fail-open), or when the project/playlist can't be resolved.
+ *
+ * @param {Integer} projectId
+ * @param {Integer} playlistId
+ */
+async function getProjectSlugByPlaylistId(playlistId) {
+    const rows = await dbpool.query(
+        'SELECT p.url FROM playlists pl JOIN projects p ON p.project_id = pl.project_id WHERE pl.playlist_id = ? LIMIT 1',
+        [playlistId]
+    );
+    return rows.length ? rows[0].url : null;
+}
+
+async function assertJobRecordingLimit(projectId, playlistId) {
+    if (playlistId === undefined || playlistId === null) return;
+    const slug = projectId
+        ? await getProjectSlugById(projectId)
+        : await getProjectSlugByPlaylistId(playlistId);
+    if (!slug) return;
+    const entitlement = await fetchProjectEntitlement(slug);
+    const limit = entitlement && entitlement.limits ? entitlement.limits.jobRecordingCount : null;
+    if (limit === null || limit === undefined) return; // uncapped
+    const count = await getPlaylistRecordingCount(playlistId);
+    if (count > Number(limit)) {
+        const err = new Error(
+            `This analysis would run on ${count.toLocaleString()} recordings, but ${entitlement.projectType || 'free'} projects are limited to ${Number(limit).toLocaleString()} recordings per analysis. Upgrade to Pro for unlimited recordings per analysis, or run on a smaller playlist.`
+        );
+        err.status = 403;
+        err.http_code = 403;
+        throw err;
+    }
+}
 
 async function loadProjectTieringUsage(connection, projectId) {
     const usageRows = await dbpool.queryWithConn(connection,
@@ -57,5 +140,7 @@ module.exports = {
         } finally {
             connection.release();
         }
-    }
+    },
+    assertJobRecordingLimit,
+    getPlaylistRecordingCount
 };

--- a/assets/app/a2services/project-service.js
+++ b/assets/app/a2services/project-service.js
@@ -55,6 +55,10 @@ angular.module('a2.srv.project', [
                     var summary = results[1] || {};
                     var limits = summary.limits || {};
                     var jobLimit = limits.jobCount;
+                    // Tier reframe (2026-06-29): per-job recording (playlist
+                    // size) cap. null/undefined => uncapped (premium).
+                    var recordingJobLimit = (limits.jobRecordingCount === null || limits.jobRecordingCount === undefined)
+                        ? null : Number(limits.jobRecordingCount);
                     var isInactive = summary.entitlementState === 'inactive';
                     var isViewOnly = summary.isLocked === true;
                     var isJobLimitReached = jobLimit !== null && jobLimit !== undefined && Number(usage.jobCount || 0) >= Number(jobLimit);
@@ -62,6 +66,8 @@ angular.module('a2.srv.project', [
                         usage: usage,
                         summary: summary,
                         limits: limits,
+                        projectType: summary.projectType,
+                        recordingJobLimit: recordingJobLimit,
                         settingsUrl: summary.settingsUrl,
                         isInactive: isInactive,
                         isViewOnly: isViewOnly,

--- a/assets/app/app/analysis/patternmatching/createnewpatternmatching.html
+++ b/assets/app/app/analysis/patternmatching/createnewpatternmatching.html
@@ -57,6 +57,18 @@
             <span class="pl-1 brand-warning" ng-if="controller.isWarningMessage()">
                 <em>{{ controller.warningMessage }}</em>
             </span>
+            <p
+                class="pl-1 brand-warning mt-1"
+                ng-if="controller.tieringGuard.recordingJobLimit"
+            >
+                <em>Free projects can run unlimited analyses, but each analysis can process up to {{ controller.tieringGuard.recordingJobLimit | number }} recordings. Larger playlists must be split.</em>
+            </p>
+            <p
+                class="pl-1 text-danger mt-1"
+                ng-if="controller.isRecordingLimitExceeded()"
+            >
+                <em>{{ controller.recordingLimitMessage() }}</em>
+            </p>
             <ui-select ng-disabled="disabled" ng-if="controller.list.playlists && controller.list.playlists.length" ng-model="controller.data.playlist">
                 <ui-select-match placeholder="Select or search a playlist...">
                     {{$select.selected.name}}

--- a/assets/app/app/analysis/patternmatching/index.js
+++ b/assets/app/app/analysis/patternmatching/index.js
@@ -1215,6 +1215,9 @@ angular.module('a2.analysis.patternmatching', [
             if (self.data.playlist.count === 0) {
                 return notify.error('Note: The playlist should not be empty.');
             }
+            if (self.isRecordingLimitExceeded()) {
+                return notify.error(self.recordingLimitMessage());
+            }
             self.isSaving = true;
             return a2PatternMatching.create({
                 name: self.data.name,
@@ -1232,7 +1235,25 @@ angular.module('a2.analysis.patternmatching', [
         },
         isJobValid: function () {
             return self.data && self.data.name && self.data.name.length > 3 &&
-                self.data.playlist && self.data.template;
+                self.data.playlist && self.data.template &&
+                !self.isRecordingLimitExceeded();
+        },
+        // Tier reframe (2026-06-29): free projects cap each analysis job at
+        // tieringGuard.recordingJobLimit recordings (uncapped for premium). This
+        // is a per-job playlist-size constraint, not a usage meter.
+        isRecordingLimitExceeded: function () {
+            var limit = self.tieringGuard && self.tieringGuard.recordingJobLimit;
+            if (limit === null || limit === undefined) return false;
+            return self.data.playlist && Number(self.data.playlist.count) > Number(limit);
+        },
+        recordingLimitMessage: function () {
+            var limit = self.tieringGuard && self.tieringGuard.recordingJobLimit;
+            if (limit === null || limit === undefined) return '';
+            return 'This playlist has ' + Number(self.data.playlist.count).toLocaleString() +
+                ' recordings, but each analysis on a free project can process up to ' +
+                Number(limit).toLocaleString() + ' recordings. You can run unlimited ' +
+                'analyses on a free project \u2014 just select a smaller playlist (or split ' +
+                'this one). Upgrade to Pro for unlimited recordings per analysis.';
         },
         cancel: function (url) {
              $modalInstance.close({ cancel: true, url: url });

--- a/config/hosts.json
+++ b/config/hosts.json
@@ -1,5 +1,6 @@
 {
 	"jobqueue" : "http://10.0.0.4:3007",
 	"publicUrl": "https://arbimon.org",
-	"support": "https://help.arbimon.org"
+	"support": "https://help.arbimon.org",
+	"bioApi": "http://biodiversity-api.apps-prod.svc.cluster.local"
 }


### PR DESCRIPTION
Companion to rfcx/arbimon tier reframe (PR #2514, merged). Enforces the per-analysis-job recording (playlist size) cap for **free** projects (12,000; premium = uncapped).

### Enforcement (server-side)
- `app/model/tiering.js`: bridges to bio-api's unauthenticated `GET /projects/:slug/entitlement-summary` for the project's `limits.jobRecordingCount` (the limit is owned by bio-api / Bio Postgres — legacy never hardcodes 12000). **Fail-open** on any bio-api error so a transient issue can't block production analysis.
- `assertJobRecordingLimit()` wired into every playlist-driven job-create chokepoint: Pattern Matching, soundscape + classification + training (via the central `jobs.newJob`), and AED-clustering. Rejects with a clear 403 message when the playlist exceeds the limit.
- `config/hosts.json`: `bioApi` default → cluster-internal biodiversity-api service (override `HOSTS_BIOAPI`).

### UX
- `getAnalysisTieringGuard()` (shared by all analysis-create dialogs) now exposes `recordingJobLimit` + `projectType`.
- PM create dialog: upfront note ("free projects run unlimited analyses, up to 12,000 recordings each") + inline error and **submit blocked** when the selected playlist is over the limit, suggesting a smaller playlist / Pro upgrade.

Deploys AFTER bio-api (already live serving `jobRecordingCount`). Verified live: `entitlement-summary` returns `jobRecordingCount:12000` for free projects. Other analysis-create dialogs consume the same guard and can be wired identically as a fast-follow (backend already enforces for all types). Design: rfcx-local runbooks/DESIGN-arbimon-tier-rules-reframe-2026-06-29.md.