### PR TITLE
fix(tiering): force IPv4 for bio-api entitlement lookup (avoid ~5s AAAA stall)

### DIFF
--- a/app/model/tiering.js
+++ b/app/model/tiering.js
@@ -22,7 +22,12 @@ function fetchProjectEntitlement(slug) {
             method: 'GET',
             url: `${BIO_API_BASE_URL}/projects/${encodeURIComponent(slug)}/entitlement-summary`,
             json: true,
-            timeout: 5000
+            timeout: 5000,
+            // Force IPv4: Node's default dual-stack resolution tries AAAA first
+            // for cluster-internal *.svc.cluster.local names and stalls ~5s
+            // before falling back to A, which would race the timeout and
+            // (fail-open) silently skip enforcement. family:4 => ~30ms.
+            family: 4
         }, function (err, resp, body) {
             if (err || !resp || resp.statusCode !== 200 || !body) {
                 debug('entitlement lookup failed (fail-open) for %s: %s', slug, err || (resp && resp.statusCode));


### PR DESCRIPTION
Follow-up to #1737. The bio-api entitlement lookup from the arbimon pod intermittently ETIMEDOUT (Node dual-stack tries AAAA first for the cluster-internal svc name, stalls ~5s, races the 5s timeout → fail-open → 12k guard silently skipped). Adding `family: 4` makes it ~30ms and the guard enforces reliably.

**Validated live** (patched module in the running pod): free 12,001-rec playlist → BLOCKED with the correct message; premium → allowed (uncapped).