### PR TITLE
fix(tiering): A-only DNS lookup for bio-api call (request family:4 not reliably honored)

### DIFF
--- a/app/model/tiering.js
+++ b/app/model/tiering.js
@@ -3,8 +3,28 @@
 
 const dbpool = require('../utils/dbpool');
 const request = require('request');
+const dns = require('dns');
 const config = require('../config');
 const debug = require('debug')('arbimon2:tiering');
+
+// Custom A-only DNS lookup for the bio-api call. Node's default dual-stack
+// resolution issues an AAAA query for the cluster-internal
+// *.svc.cluster.local name that hangs ~5s (no IPv6 answer) before falling back
+// to A. That would race the 5s request timeout and (fail-open) silently skip
+// 12k enforcement. Resolving A records directly skips AAAA entirely (~15ms,
+// deterministic). `family:4` on `request` was NOT sufficient (the option isn't
+// reliably forwarded to the socket lookup).
+function ipv4Lookup(hostname, options, callback) {
+    if (typeof options === 'function') { callback = options; }
+    dns.resolve4(hostname, function (err, addresses) {
+        if (err || !addresses || !addresses.length) {
+            // Fall back to the default resolver (e.g. when an IP/literal is
+            // passed); still better than failing outright.
+            return dns.lookup(hostname, { family: 4 }, callback);
+        }
+        callback(null, addresses[0], 4);
+    });
+}
 
 // Tier reframe (2026-06-29): per-job recording (playlist size) cap. The limit
 // itself is OWNED by bio-api (Bio Postgres `insights`.project_type_limit), which
@@ -23,11 +43,7 @@ function fetchProjectEntitlement(slug) {
             url: `${BIO_API_BASE_URL}/projects/${encodeURIComponent(slug)}/entitlement-summary`,
             json: true,
             timeout: 5000,
-            // Force IPv4: Node's default dual-stack resolution tries AAAA first
-            // for cluster-internal *.svc.cluster.local names and stalls ~5s
-            // before falling back to A, which would race the timeout and
-            // (fail-open) silently skip enforcement. family:4 => ~30ms.
-            family: 4
+            lookup: ipv4Lookup
         }, function (err, resp, body) {
             if (err || !resp || resp.statusCode !== 200 || !body) {
                 debug('entitlement lookup failed (fail-open) for %s: %s', slug, err || (resp && resp.statusCode));


### PR DESCRIPTION
Follow-up to #1738. The old `request` lib doesn't reliably forward `family:4` to the socket DNS lookup, leaving an intermittent ~5s AAAA stall on the cluster-internal bio-api name (races the 5s timeout → fail-open → 12k guard skipped). Replace with a custom `lookup` that calls `dns.resolve4` directly (A records only, no AAAA query), with a `dns.lookup({family:4})` fallback.

Isolated live timing in the running pod: bio-api entitlement call ~10ms consistently; guard correctly BLOCKS free >12k playlists and ALLOWS premium.