### PR TITLE
Fix playlist creation status finalization

### DIFF
--- a/app/model/playlists.js
+++ b/app/model/playlists.js
@@ -285,40 +285,81 @@ var Playlists = {
      * @return {Promise} resolving to created playlists' insert_id
      */
     create: async function(data) {
-        const playlistId = (await dbpool.query(`INSERT INTO playlists(project_id, name, playlist_type_id, status) VALUES (?, ?, ?, ?)`,
-            [data.project_id, data.name, 1, status.WAITING])
-        ).insertId
-        if (data.recIdsIncluded || data.aedIdsIncluded) {
-            if (data.aedIdsIncluded) {
-                await this.addRecs(playlistId, data.params);
+        const connection = await dbpool.getConnection();
+        let playlistId;
+
+        try {
+            await dbpool.queryWithConn(connection, 'START TRANSACTION');
+            try {
+                playlistId = (await dbpool.queryWithConn(connection,
+                    `INSERT INTO playlists(project_id, name, playlist_type_id, status) VALUES (?, ?, ?, ?)`,
+                    [data.project_id, data.name, 1, status.WAITING]
+                )).insertId;
+            } catch (err) {
+                if (err.code !== 'ER_DUP_ENTRY') {
+                    throw err;
+                }
+
+                const duplicate = (await dbpool.queryWithConn(connection,
+                    'SELECT playlist_id, status FROM playlists WHERE project_id = ? AND name = ? LIMIT 1',
+                    [data.project_id, data.name]
+                ))[0];
+
+                if (!duplicate || duplicate.status === status.CREATED) {
+                    throw new APIError('Playlist name in use');
+                }
+
+                playlistId = duplicate.playlist_id;
+                await dbpool.queryWithConn(connection, 'DELETE FROM playlist_recordings WHERE playlist_id = ?', [playlistId]);
+                await dbpool.queryWithConn(connection,
+                    'UPDATE playlists SET playlist_type_id = ?, uri = NULL, metadata = NULL, total_recordings = ?, status = ? WHERE playlist_id = ?',
+                    [1, 0, status.WAITING, playlistId]
+                );
             }
-            else {
-                const aedData = await model.ClusteringJobs.findRois({ aed: data.params });
-                const recIds = aedData.map(aed => { return aed.recording_id });
-                await this.addRecs(playlistId, [...new Set(recIds)]);
-            }
-        } else {
-            data.params.project_id = data.project_id;
-            data.params.sortBy = 'r.site_id, r.datetime'
-            data.params.output = ['list', 'sql']
-            if (data.params.recIds) {
-                await this.addRecs(playlistId, data.params.recIds);
+
+            let totalInserted = 0;
+            if (data.recIdsIncluded || data.aedIdsIncluded) {
+                if (data.aedIdsIncluded) {
+                    totalInserted = await this.addRecs(playlistId, data.params, connection);
+                }
+                else {
+                    const aedData = await model.ClusteringJobs.findRois({ aed: data.params });
+                    const recIds = aedData.map(aed => { return aed.recording_id });
+                    totalInserted = await this.addRecs(playlistId, [...new Set(recIds)], connection);
+                }
             } else {
-                const sqlParts = await model.recordings.findProjectRecordings(data.params)
-                const testCreatingTime = moment().format('YYYY-MM-DD HH:mm:ss')
-                console.log('Playlist: start insert', testCreatingTime)
-                await dbpool.query(`INSERT INTO playlist_recordings(recording_id, playlist_id) SELECT /*+ MAX_EXECUTION_TIME(360000) */ DISTINCT r.recording_id, ${playlistId} ${sqlParts[1]} ${sqlParts[2]}`)
-                    .catch(async err => {
-                        console.err('Error inserting in a playlist', err)
-                        const q = 'UPDATE playlists SET status = ? WHERE playlist_id = ?'
-                        await dbpool.query(q, [status.FAILED , playlistId])
-                    })
-                const testInsertingTime = moment().format('YYYY-MM-DD HH:mm:ss')
-                console.log('Playlist: inserted', testInsertingTime, playlistId);
+                data.params.project_id = data.project_id;
+                data.params.sortBy = 'r.site_id, r.datetime';
+                data.params.output = ['list', 'sql'];
+                if (data.params.recIds) {
+                    totalInserted = await this.addRecs(playlistId, data.params.recIds, connection);
+                } else {
+                    const sqlParts = await model.recordings.findProjectRecordings(data.params);
+                    const testCreatingTime = moment().format('YYYY-MM-DD HH:mm:ss');
+                    console.log('Playlist: start insert', testCreatingTime);
+                    const result = await dbpool.queryWithConn(connection,
+                        `INSERT INTO playlist_recordings(recording_id, playlist_id) SELECT /*+ MAX_EXECUTION_TIME(360000) */ DISTINCT r.recording_id, ${playlistId} ${sqlParts[1]} ${sqlParts[2]}`
+                    );
+                    totalInserted = result.affectedRows || 0;
+                    const testInsertingTime = moment().format('YYYY-MM-DD HH:mm:ss');
+                    console.log('Playlist: inserted', testInsertingTime, playlistId, totalInserted);
+                }
             }
+
+            await dbpool.queryWithConn(connection,
+                'UPDATE playlists SET total_recordings = ?, status = ? WHERE playlist_id = ?',
+                [totalInserted, status.CREATED, playlistId]
+            );
+            await dbpool.queryWithConn(connection, 'COMMIT');
+            return playlistId;
+        } catch (err) {
+            await dbpool.queryWithConn(connection, 'ROLLBACK').catch(function(rollbackErr) {
+                console.error('Error rolling back playlist creation', rollbackErr);
+            });
+            throw err;
+        } finally {
+            connection.release();
         }
-        await this.refreshTotalRecs(playlistId)
-        return playlistId
     },
 
     /** Adds recordings to a given playlist.
@@ -327,9 +368,16 @@ var Playlists = {
      * @param {Array} recIds - array of recording ids to add to playlist.
      * @return {Promise} resolved after the recordings are added to the playlist.
      */
-    addRecs: async function(playlistId, recIds) {
+    addRecs: async function(playlistId, recIds, connection) {
         const chunkSize = 10000
         let splittedRecs = []
+        let totalInserted = 0
+        recIds = recIds.map(function(recId) {
+            return Number(recId)
+        })
+        if (recIds.some(function(recId) { return !Number.isInteger(recId) || recId <= 0 })) {
+            throw new APIError('Invalid recording id in playlist request')
+        }
         if (recIds.length < chunkSize) {
             splittedRecs = [recIds]
         } else {
@@ -338,8 +386,15 @@ var Playlists = {
             }
         }
         for (let arr of splittedRecs) {
-            await dbpool.query("INSERT INTO playlist_recordings(playlist_id, recording_id) VALUES" + arr.map(recId => `(${playlistId}, ${recId})`).join(", "))
+            if (!arr.length) {
+                continue
+            }
+            const result = connection
+                ? await dbpool.queryWithConn(connection, "INSERT INTO playlist_recordings(playlist_id, recording_id) VALUES" + arr.map(recId => `(${playlistId}, ${recId})`).join(", "))
+                : await dbpool.query("INSERT INTO playlist_recordings(playlist_id, recording_id) VALUES" + arr.map(recId => `(${playlistId}, ${recId})`).join(", "))
+            totalInserted += result.affectedRows || 0
         }
+        return totalInserted
     },
 
     /** Combines two playlists (from the same project) into one.


### PR DESCRIPTION
## Summary\n- Fixes playlist creation rows being left in status=WAITING after recordings are inserted.\n- Avoids read-after-write replica lag by finalizing total_recordings from INSERT affectedRows on the same transaction.\n- Recovers hidden WAITING/FAILED duplicate-name rows by rebuilding that incomplete playlist instead of surfacing a generic 500 Playlist error.\n- Validates explicit recIds before interpolation.\n\n## Root cause\nIn rfcx-local production, playlist creation inserts into playlists and playlist_recordings, then immediately calls refreshTotalRecs(), which opens a fresh pooled connection and counts playlist_recordings. With the current MariaDB/MaxScale HA topology, that SELECT can be routed to a replica before the just-inserted rows are visible. The count returns null, so the playlist remains status=WAITING. The UI only lists status=CREATED playlists, so users see the playlist as not created. Retrying the same name hits the project/name unique key and appears as a generic Playlist error.\n\nObserved live for user arcilaluisap@gmail.com on project monitoreo-acustico-uraba: ER_DUP_ENTRY for project/name after hidden status=0 playlists had thousands of playlist_recordings rows.\n\n## Verification\n- node --check app/model/playlists.js\n- git diff --check\n- Copied patched file into running arbimon pod and ran Node 16 parser: node --check /tmp/playlists-fix.js\n\n## Deployment note\nAfter merge/deploy, production still has existing stuck status=WAITING playlist rows. A scoped repair should update only rows where status=0 and playlist_recordings exist, setting total_recordings to the exact count and status=20.