### PR TITLE
fix: return Arbimon project id from integration create

### DIFF
--- a/app/routes/data-api/integration.js
+++ b/app/routes/data-api/integration.js
@@ -22,9 +22,10 @@ router.post('/projects', verifyToken(), hasRole(['appUser', 'rfcxUser']), async 
     const { name, is_private, external_id } = params
     const projectId = await model.projects.createProject({ name, is_private, external_id, url }, user.user_id);
     const project = await model.projects.find({ id: projectId }).get(0);
-    res.status(201).json(project);
+    const body = project && typeof project.toJSON === 'function' ? project.toJSON() : (project || {});
+    res.status(201).json(Object.assign({}, body, { project_id: projectId, id: projectId }));
   } catch (e) {
-    httpErrorHandler(req, res, 'Failed creating a site')(e);
+    httpErrorHandler(req, res, 'Failed creating a project')(e);
   }
 })
 


### PR DESCRIPTION
## Summary\n- return a plain JSON body from POST /legacy-api/integration/projects\n- include both project_id and id so Core can persist the Arbimon project id as external_id\n- correct the project-create error message\n\n## Why\nCore currently receives an empty/undefined body from the legacy integration create endpoint, logs `Arbimon project create returned no project_id/id: undefined`, and returns POST /projects 500 after legacy has already created the project.\n\n## Live evidence\n- Bio now calls in-cluster Core correctly after rfcx-local#277\n- Core still fails on create with `Arbimon project create returned no project_id/id: undefined`\n- Legacy logs show `POST 201 /legacy-api/integration/projects` for the same attempts