### PR TITLE
test: cover integration project response body

### DIFF
--- a/app/routes/data-api/integration-project-response.js
+++ b/app/routes/data-api/integration-project-response.js
@@ -1,0 +1,8 @@
+function formatCreatedProjectResponse(project, projectId) {
+  const body = project && typeof project.toJSON === 'function' ? project.toJSON() : (project || {});
+  return Object.assign({}, body, { project_id: projectId, id: projectId });
+}
+
+module.exports = {
+  formatCreatedProjectResponse
+};

--- a/app/routes/data-api/integration.js
+++ b/app/routes/data-api/integration.js
@@ -10,6 +10,8 @@ const verifyToken = authentication.verifyToken;
 const hasRole = authentication.hasRole;
 const { Converter, EmptyResultError, ForbiddenError, httpErrorHandler } = require('@rfcx/http-utils');
 
+const { formatCreatedProjectResponse } = require('./integration-project-response');
+
 router.post('/projects', verifyToken(), hasRole(['appUser', 'rfcxUser']), async function(req, res) {
   try {
     const converter = new Converter(req.body, {});
@@ -22,8 +24,7 @@ router.post('/projects', verifyToken(), hasRole(['appUser', 'rfcxUser']), async 
     const { name, is_private, external_id } = params
     const projectId = await model.projects.createProject({ name, is_private, external_id, url }, user.user_id);
     const project = await model.projects.find({ id: projectId }).get(0);
-    const body = project && typeof project.toJSON === 'function' ? project.toJSON() : (project || {});
-    res.status(201).json(Object.assign({}, body, { project_id: projectId, id: projectId }));
+    res.status(201).json(formatCreatedProjectResponse(project, projectId));
   } catch (e) {
     httpErrorHandler(req, res, 'Failed creating a project')(e);
   }

--- a/test/app.js
+++ b/test/app.js
@@ -1,0 +1,1 @@
+// Test bootstrap placeholder for npm test.

--- a/test/integration-project-response.test.js
+++ b/test/integration-project-response.test.js
@@ -1,0 +1,42 @@
+var expect = require('chai').expect;
+var formatCreatedProjectResponse = require('../app/routes/data-api/integration-project-response').formatCreatedProjectResponse;
+
+describe('integration project create response', function () {
+  it('returns project_id and id when the model row is empty', function () {
+    expect(formatCreatedProjectResponse(null, 9876)).to.deep.equal({
+      project_id: 9876,
+      id: 9876
+    });
+  });
+
+  it('preserves project fields while normalizing id fields', function () {
+    var response = formatCreatedProjectResponse({
+      project_id: 1,
+      id: 1,
+      name: 'AMCEL',
+      url: 'amcel'
+    }, 9876);
+
+    expect(response).to.include({
+      project_id: 9876,
+      id: 9876,
+      name: 'AMCEL',
+      url: 'amcel'
+    });
+  });
+
+  it('supports model objects with toJSON', function () {
+    var response = formatCreatedProjectResponse({
+      toJSON: function () {
+        return { name: 'Test Project', url: 'test-project' };
+      }
+    }, 1234);
+
+    expect(response).to.deep.equal({
+      name: 'Test Project',
+      url: 'test-project',
+      project_id: 1234,
+      id: 1234
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- extract the project-create response formatter into a tiny helper\n- add Mocha coverage that guarantees the legacy integration endpoint response includes both project_id and id\n- keep the route behavior equivalent to the deployed fix\n\n## Test\n- NODE_PATH=/Users/admin/code/rfcx-sources/arbimon-legacy/node_modules /Users/admin/code/rfcx-sources/arbimon-legacy/node_modules/.bin/mocha -r test/app test/integration-project-response.test.js\n- 3 passing