### PR TITLE
Admin JSON lists: trailing-slash paths (/admin/projects/, /admin/users/)

### DIFF
--- a/assets/app/admin/projects/list.js
+++ b/assets/app/admin/projects/list.js
@@ -89,7 +89,11 @@ angular.module('a2.admin.projects.list', [
 .service('AdminProjectsListService', function($http){
     return {
         getList : function() {
-            return $http.get('/admin/projects').then(function(response){
+            // Trailing slash is REQUIRED (2026-07-12): the edge router sends the
+            // exact path /admin/projects (browser navigation) to the modern Vue
+            // admin page; this JSON endpoint is reached via /admin/projects/
+            // (express matches both). See rfcx-local public-router arbimon.org.
+            return $http.get('/admin/projects/').then(function(response){
                 return response.data;
             });
         },

--- a/assets/app/admin/users/list.js
+++ b/assets/app/admin/users/list.js
@@ -25,7 +25,9 @@ angular.module('a2.admin.users.list', [
 .service('AdminUsersListService', function($http){
     return {
         getList : function() {
-            return $http.get('/admin/users').then(function(response){
+            // Trailing slash REQUIRED (2026-07-12): exact /admin/users now routes to
+            // the modern Vue admin page at the edge; JSON API uses /admin/users/.
+            return $http.get('/admin/users/').then(function(response){
                 return response.data;
             });
         },


### PR DESCRIPTION
Companion to rfcx/arbimon#2520 + the rfcx-local edge change. The exact paths /admin/projects and /admin/users now route to the modern Vue admin page at the edge; the legacy admin SPA's JSON list calls switch to the trailing-slash form (express matches both), keeping them on this app.