### PR TITLE
Retire the dead live job-queue-status widget on the admin Jobs page

### DIFF
--- a/app/routes/admin/index.js
+++ b/app/routes/admin/index.js
@@ -3,7 +3,6 @@
 
 var debug = require('debug')('arbimon2:route:admin');
 var express = require('express');
-var request = require('request');
 var router = express.Router();
 var async = require('async');
 var csv_stringify = require("csv-stringify");
@@ -133,13 +132,24 @@ router.get('/plot-data/data.txt', function(req, res, next) {
 });
 
 
-router.get('/job-queue', function(req, res, next) {
+// RETIRED 2026-07-12: the live "job queue status" widget (Queue ID /
+// Iteration / Waiting / Max concurrent) described the AWS SQS-style queue
+// daemon that ran the analysis pipeline pre-migration. That service is gone;
+// `config('hosts').jobqueue` still points at the dead AWS-era address
+// (10.0.0.4:3007), so this endpoint hung until TCP timeout then errored.
+// The modern pipeline is the in-cluster jobqueue-dispatcher (ns apps-prod),
+// which polls arbimon2.jobs (state='waiting') and launches per-type k8s
+// Jobs — there is NO persistent queue object with those fields to report.
+// Return an explicit retired marker instantly (no network call) so the UI
+// can show an honest note instead of a spinner/timeout. Real live job data
+// is still available via the Job List below (GET /admin/jobs) and the
+// per-type traffic light on the dashboard. See rfcx-local OPEN-ITEMS #52.
+router.get('/job-queue', function(req, res) {
     res.type('json');
-    request.get(config('hosts').jobqueue + '/stats')
-        .on('error', function(err) {
-            res.json({ error:'Could not read job queue stats.' });
-        })
-        .pipe(res);
+    res.json({
+        retired: true,
+        error: 'The legacy job-queue daemon was retired in the AWS\u2192cluster migration. Analysis jobs now run via the in-cluster jobqueue-dispatcher; see the Job List below for live jobs.'
+    });
 });
 
 router.get('/jobs', function(req, res, next) {

--- a/assets/app/admin/jobs/index.html
+++ b/assets/app/admin/jobs/index.html
@@ -1,28 +1,23 @@
+<!-- Job queue status panel RETIRED 2026-07-12: the AWS SQS-style queue
+     daemon it described no longer exists. Analysis jobs now run via the
+     in-cluster jobqueue-dispatcher (polls jobs where state='waiting' and
+     launches per-type k8s Jobs); there is no persistent queue object with
+     Queue ID / Iteration / Waiting / Max concurrent to display. Live job
+     data is in the Job List below. See rfcx-local OPEN-ITEMS #52. -->
 <div class="row" style="margin-top:10px;">
     <div class="col-sm-12">
         <div class="panel panel-default">
             <div class="panel-heading">
-                Job queue status
+                Job pipeline
             </div>
             <div class="panel-body">
-                <p ng-show="jobsStatus.error"> {{ jobsStatus.error }}</p>
+                <p class="text-muted" style="margin:0;">
+                    Analysis jobs run via the in-cluster job dispatcher.
+                    The legacy job-queue daemon was retired in the
+                    AWS&rarr;cluster migration, so live queue counters are no
+                    longer shown here. See the Job List below for current jobs.
+                </p>
             </div>
-            <table class="table" ng-show="!jobsStatus.error">
-                <tbody>
-                    <tr>
-                        <td> Queue ID: {{ jobsStatus.queue }}</td>
-                        <td> Iteration: {{ jobsStatus.iteration }}</td>
-                        <td> Last updated: {{ jobsStatus.last_updated }}</td>
-                        <td> State: {{ jobsStatus.state }}</td>
-                    </tr>
-                    <tr>
-                        <td> Options: {{ jobsStatus.options }}</td>
-                        <td> Waiting: {{ jobsStatus.waiting }}</td>
-                        <td> Last enqueued: {{ jobsStatus.last_enqueued }}</td>
-                        <td> Max concurrent: {{ jobsStatus.max_concurrent }}</td>
-                    </tr>
-                </tbody>
-            </table>
         </div>
     </div>
 </div>

--- a/assets/app/admin/jobs/index.js
+++ b/assets/app/admin/jobs/index.js
@@ -14,12 +14,10 @@ angular.module('a2.admin.jobs', [
 })
 .controller('AdminJobsCtrl', function($scope, $http, $interval, Project) {
     
-    var getJobQueueInfo = function(argument) {
-        $http.get('/admin/job-queue')
-            .success(function(data) {
-                $scope.jobsStatus = data;
-            });
-    };
+    // The legacy job-queue status endpoint was retired 2026-07-12 (the AWS
+    // SQS-style queue daemon no longer exists; jobs run via the in-cluster
+    // jobqueue-dispatcher). The Job List below is the live source. Nothing
+    // to poll here anymore — see rfcx-local OPEN-ITEMS #52.
     
     $scope.findJobs = function() {
         var query = {};
@@ -109,8 +107,6 @@ angular.module('a2.admin.jobs', [
     ];
     
     $scope.initParams();
-    getJobQueueInfo();
-    
     
     $http.get('/legacy-api/jobs/types')
         .success(function(jobTypes) {


### PR DESCRIPTION
The admin Jobs page's 'Job queue status' panel (Queue ID / Iteration / Waiting / Max concurrent) described the AWS SQS-style queue daemon that ran analysis before the AWS→cluster migration. That service is gone; `config('hosts').jobqueue` still points at the dead AWS IP 10.0.0.4:3007, so `GET /admin/job-queue` hung until timeout then errored.

The modern pipeline is the in-cluster `jobqueue-dispatcher` (polls `arbimon2.jobs` state='waiting' → per-type k8s Jobs); no persistent queue object to report.

- Backend returns `{retired:true}` instantly (no dead network call); dropped the unused `request` import.
- Frontend shows a short 'jobs run via the in-cluster dispatcher' note instead of the panel; stops polling the retired endpoint.
- Live Job List + dashboard job traffic-light unaffected.

Ref: rfcx-local OPEN-ITEMS #52 (dashboard relevance audit + MySQL→PG repoint follow-up).