### PR TITLE
fix(export-job): send export emails via the notify gateway (Mandrill fallback)

### DIFF
--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const stream = require('stream');
 const csv_stringify = require('csv-stringify');
 const mandrill = require('mandrill-api/mandrill')
+const axios = require('axios')
 const moment = require('moment')
 const { exportOccupancyModels, getExportRecordingsRow, getCountSitesRecPerDates, updateExportRecordings, getCountConnections } = require('../services/recordings')
 const { errorMessage } = require('../services/stats')
@@ -509,6 +510,23 @@ async function sendEmail (subject, title, rowData, content, isSignedUrl) {
         }]
         message.html = textHeader + textSupport + textFooter
     }
+    return sendMessage(message, title)
+}
+
+// Transport: prefer the RFCx notify gateway (Cloudflare Email Sending) and fall
+// back to Mandrill only if the gateway is unconfigured or errors AND a Mandrill
+// key is present. Mirrors the device-api migration pattern. The `message` is in
+// Mandrill-lite shape (from_email/to[{email}]/subject/html/attachments[{type,
+// name,content}]) which the gateway normalizes, so no payload rewrite is needed.
+async function sendViaNotifyGateway (message) {
+    await axios.post(process.env.EMAIL_SEND_URL, message, {
+        headers: { Authorization: `Bearer ${process.env.EMAIL_SEND_TOKEN}` },
+        timeout: 15000
+    })
+    return { success: true }
+}
+
+function sendViaMandrill (message, title) {
     return new Promise(function (resolve, reject) {
       const mandrillClient = new mandrill.Mandrill(process.env.MANDRILL_KEY)
 
@@ -526,6 +544,23 @@ async function sendEmail (subject, title, rowData, content, isSignedUrl) {
           reject(e)
         })
     })
+}
+
+async function sendMessage (message, title) {
+    const hasGateway = !!(process.env.EMAIL_SEND_URL && process.env.EMAIL_SEND_TOKEN)
+    if (hasGateway) {
+        try {
+            const result = await sendViaNotifyGateway(message)
+            console.log('email status (notify gateway) sent, title', title)
+            return result
+        } catch (e) {
+            const detail = e.response ? `${e.response.status} ${JSON.stringify(e.response.data)}` : e.message
+            console.error('Error send email via notify gateway.', detail)
+            if (!process.env.MANDRILL_KEY) throw e
+            console.warn('Falling back to Mandrill.')
+        }
+    }
+    return sendViaMandrill(message, title)
 }
 
 main()


### PR DESCRIPTION
## Why

**User report (Luisa Arcila-Pérez):** RFM models finished, clicked *Download
Results* → "results will be sent to your email" → **no email ever arrived.**

Root cause: the `arbimon-recording-export-job` builds the CSV + uploads it, then
emails the download link via **Mandrill**, whose keys are **dead after the AWS →
rfcx-local migration**. So every export-ready email (RFM, pattern-matching,
clustering, soundscape, occupancy) has silently failed to send. (Confirmed
fleet-wide: 202 unprocessed rows in `recordings_export_parameters`, 48 RFM;
Luisa has 9.)

## What

Route the export job's `sendEmail` through the **RFCx notify gateway**
(Cloudflare Email Sending, `notify.rfcx.org`) instead of Mandrill, falling back
to Mandrill only if the gateway is unconfigured/errors **and** a `MANDRILL_KEY`
is present (mirrors the completed `device-api` migration).

The message object is already **Mandrill-lite** shape
(`from_email` / `to:[{email}]` / `subject` / `html` / `attachments:[{type,name,
content}]`), which the gateway normalizes, so **no payload rewrite** is needed.
Signed-URL delivery (the job's preferred path) is unchanged; attachment mode
also works (gateway supports attachments under the 5 MiB cap).

## Deploy notes (rfcx-local)
- Add `EMAIL_SEND_URL=https://notify.rfcx.org/email/v1/send` + `EMAIL_SEND_TOKEN`
  to the export-job env (manifest/secret).
- The job's S3 must point at rfcx-local MinIO (`arbimon-exports` bucket) so the
  signed URL resolves.
- **Unsuspend** the CronJob and drain the backlog (the stuck rows re-process
  since `processed_at` is still NULL).

## Testing
- `node --check` clean.
- Notify-gateway arbitrary-recipient send verified working from `no-reply@arbimon.org`
  (arbimon.org is in full send mode, not sandbox).