### PR TITLE
feat(export-job): user-facing download links via arb.mn/dl (not raw presign)

### DIFF
--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -12,7 +12,7 @@ const recordings = require('../../app/model/recordings')
 const clusterings = require('../../app/model/clustering-jobs')
 const projects = require('../../app/model/projects')
 const config_hosts = require('../../config/hosts');
-const { saveLatestData, combineFilename, uploadAsStream, getSignedUrl, uploadFileToS3 } = require('../services/storage')
+const { saveLatestData, combineFilename, uploadAsStream, getSignedUrl, getDownloadUrl, uploadFileToS3 } = require('../services/storage')
 const recordingsExport = require('./recordings')
 const patternMatching = require('./pattern-matching')
 const soundscape = require('./soundscape')
@@ -131,7 +131,7 @@ async function main () {
                 const bucketFormatted = S3_EXPORT_BUCKET_ARBIMON.split('/')[0]
                 const s3filePath = await uploadFileToS3(bucketFormatted, zipPath, rowData.project_id, currentTime, reportName, '.zip')
                 console.log('--s3filePath', s3filePath, 'reportName', reportName, 'fileName', fileName)
-                const url = await getSignedUrl({ Bucket: bucketFormatted, Key: s3filePath })
+                const url = await getDownloadUrl({ Bucket: bucketFormatted, Key: s3filePath, filename: `${reportName}.zip`, contentType: 'application/zip' })
                 console.log('--signed url', url)
                 await sendEmail('Arbimon export', 'Arbimon export', rowData, url, true)
                 await updateExportRecordings(rowData, { processed_at: currentTime })
@@ -203,7 +203,8 @@ async function main () {
 async function saveFile (filePath, currentTime, projectId, reportName) {
     const s3FileKey = combineFilename(currentTime, projectId, reportName ? reportName : 'arbimon-export', '.csv')
     await uploadAsStream({ filePath, Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: s3FileKey, ContentType: 'text/csv' })
-    return await getSignedUrl({ Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: s3FileKey })
+    const downloadName = `${reportName ? reportName : 'arbimon-export'}.csv`
+    return await getDownloadUrl({ Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: s3FileKey, filename: downloadName, contentType: 'text/csv' })
 }
 
 // Process Clustering report and send the email
@@ -237,7 +238,7 @@ async function processClusteringStream (cluster, results, rowData, currentTime, 
                 const isBigContent = contentSize && contentSize > 10240 // 10MB
                 if (isBigContent) {
                     const filePath = await saveLatestData(S3_EXPORT_BUCKET_ARBIMON, data, rowData.project_id, currentTime, 'clustering-rois-export', '.csv', 'text/csv')
-                    const url = await getSignedUrl({ Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: filePath })
+                    const url = await getDownloadUrl({ Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: filePath, filename: 'clustering-rois-export.csv', contentType: 'text/csv' })
                     await sendEmail('Arbimon Export clustering report', null, rowData, url, true)
                 }
                 try {
@@ -287,7 +288,7 @@ async function sendZipFolderToTheUser(rowData, currentTime, jobName, message, re
         try {
             console.log(S3_EXPORT_BUCKET_ARBIMON, buffer, buffer.length, rowData.project_id, currentTime, reportName, '.zip', 'application/zip')
             const filePath = await saveLatestData(S3_EXPORT_BUCKET_ARBIMON, buffer, rowData.project_id, currentTime, reportName, '.zip', 'application/zip')
-            const url = await getSignedUrl({ Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: filePath })
+            const url = await getDownloadUrl({ Bucket: S3_EXPORT_BUCKET_ARBIMON, Key: filePath, filename: `${reportName}.zip`, contentType: 'application/zip' })
             console.log('--signed url', url)
             await sendEmail('Arbimon export', 'Arbimon export', rowData, url, true)
             await updateExportRecordings(rowData, { processed_at: currentTime })

--- a/jobs/services/storage.js
+++ b/jobs/services/storage.js
@@ -1,6 +1,7 @@
 const { Upload } = require("@aws-sdk/lib-storage");
 const { S3Client } = require("@aws-sdk/client-s3");
 const AWS = require('aws-sdk');
+const axios = require('axios');
 const { createReadStream } = require("fs");
 const fs = require('fs')
 
@@ -255,6 +256,41 @@ async function uploadAsStream ({ filePath, Bucket, Key, ContentType }) {
   return export_s3.upload({ Bucket, Key, ContentType, Body }).promise()
 }
 
+// Mint an arb.mn/dl short link for a stored object (biodiversity-api streams it
+// from private MinIO on access). Preferred over a raw S3 presigned URL for
+// user-facing download links, because our s3-proxy re-signs per layer and does
+// NOT honour a caller's presigned signature (so a presigned URL would not
+// resolve through the public chain). Falls back to a presigned URL if the mint
+// endpoint is not configured (SHORT_LINK_MINT_URL + SHORT_LINK_MINT_TOKEN) or
+// errors — degrade-not-break.
+async function getDownloadUrl ({ Bucket, Key, filename, contentType, expiresSeconds = 604800 }) {
+  const mintUrl = process.env.SHORT_LINK_MINT_URL
+  const mintToken = process.env.SHORT_LINK_MINT_TOKEN
+  if (mintUrl && mintToken) {
+    try {
+      const res = await axios.post(mintUrl, {
+        namespace: 'dl',
+        bucket: Bucket,
+        key: Key,
+        filename,
+        contentType,
+        expiresInSeconds: expiresSeconds
+      }, {
+        headers: { 'X-Mint-Token': mintToken },
+        timeout: 15000
+      })
+      if (res.data && res.data.url) {
+        return res.data.url
+      }
+      console.error('Mint returned no url; falling back to presigned URL', res.data)
+    } catch (e) {
+      const detail = e.response ? `${e.response.status} ${JSON.stringify(e.response.data)}` : e.message
+      console.error('Error minting arb.mn/dl link; falling back to presigned URL.', detail)
+    }
+  }
+  return getSignedUrl({ Bucket, Key, Expires: expiresSeconds })
+}
+
 async function getObject ({ Bucket, Key, isLegacy = true }) {
   return new Promise((resolve, reject) => {
     (isLegacy === true ? legacy_s3 : rfcx_s3)
@@ -293,6 +329,7 @@ module.exports = {
   saveLatestData,
   getObject,
   getSignedUrl,
+  getDownloadUrl,
   uploadFileToS3,
   uploadAsStream
 }


### PR DESCRIPTION
Follow-up to #1746. Export 'Download Results' emails now carry an **arb.mn/dl** short link instead of a raw S3 presigned URL.

**Why:** our s3-proxy re-signs per layer and does NOT honour a caller's presigned signature, so a presigned URL from this job would not resolve through the public chain — part of why users (e.g. Luisa Arcila's RFM results) never got a working link.

**What:** `storage.js getDownloadUrl()` POSTs the stored object's bucket/key to the biodiversity-api mint endpoint (`SHORT_LINK_MINT_URL` + `X-Mint-Token`) → `arb.mn/dl/<slug>`, which biodiversity-api streams from private MinIO with a Content-Disposition filename. Falls back to a presigned URL if the mint env is unset/errs (degrade-not-break). Applied at all user-facing URL sites (RFM/recordings, PM zip, clustering, zip-folder). `node --check` clean.

**Deploy (rfcx-local):** set `SHORT_LINK_MINT_URL=http://biodiversity-api.apps-prod.svc.cluster.local/internal/short-links` + `SHORT_LINK_MINT_TOKEN` on the export job; point `S3_BUCKET_ARBIMON` at the `arbimon` bucket (biodiversity-api default, s3-reader-allowlisted) so the minted link streams.