### PR TITLE
fix(export-job): add @rfcx/s3-storage-client to jobs deps (image startup crash)

### DIFF
--- a/jobs/package.json
+++ b/jobs/package.json
@@ -23,6 +23,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.0.20",
     "@ffprobe-installer/ffprobe": "^1.0.12",
     "@rfcx/http-utils": "^1.0.2",
+    "@rfcx/s3-storage-client": "github:rfcx/s3-storage-client#1.0.0",
     "archiver": "^6.0.1",
     "async": "~2.6.3",
     "aws-sdk": "^2.885.0",


### PR DESCRIPTION
The export-job Docker stage installs `jobs/package.json` deps only, then COPYs `app/model/*.js` + `app/utils/storage.js` into the image. `app/utils/storage.js` requires `@rfcx/s3-storage-client` (in the **root** package.json as `github:rfcx/s3-storage-client#1.0.0`, but NOT in `jobs/`), so the image crashed at startup: `Cannot find module '@rfcx/s3-storage-client'` — **unrunnable since the AWS→rfcx-local cutover** (why the export cron was shipped `suspend: true`).

Audited every copied `app/` file's requires vs the jobs deps: this is the **only** missing one. Adds it (same github ref as root). Verified `npm install` in `jobs/` resolves the public github dep and `require()` returns the expected factory. Unblocks the export-job image so the RFM/export 'Download Results' emails (user report: Luisa Arcila) can finally run.