### PR TITLE
fix(export-job): pre-create tmpfilecache dir in the image (ENOENT on run)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -54,6 +54,11 @@ RUN apt update \
         libflac-dev \
         autoconf \
         automake
+# The PM / soundscape / template export paths write intermediate CSVs to
+# jobs/arbimon-recording-export-job/tmpfilecache/ but (unlike the index.js
+# paths) do not create it, so the job crashed with ENOENT once it actually ran.
+# Pre-create it in the image.
+RUN mkdir -p /app/jobs/arbimon-recording-export-job/tmpfilecache
 CMD ["node", "--max-old-space-size=8192", "jobs/arbimon-recording-export-job/index.js"]
 
 # ---


### PR DESCRIPTION
Follow-up to #1748. Once the export job could start (after the dep fix), a manual test run got past module-load and began processing the oldest export (a PM export), then crashed: `ENOENT open '.../tmpfilecache/_pattern_matching.csv'`. The PM/soundscape/template paths write intermediate CSVs to `jobs/arbimon-recording-export-job/tmpfilecache/` but never create it (only the index.js paths `fs.mkdirSync` it). Pre-create the dir in the Docker image. RFM path writes to the job's own dir so RFM (Luisa's case) was unaffected; this unblocks PM/soundscape/template too.