### PR TITLE
feat(export-job): dynamic email subject without leading 'Arbimon'

### DIFF
--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -531,12 +531,17 @@ async function sendEmail (subject, title, rowData, content, isSignedUrl, stats) 
     const statsText = statItems.length ? `\n${statItems.join('\n')}\n` : ''
 
     const isGmail = rowData.user_email.includes('gmail.com');
+    // Subject: no leading "Arbimon"; include the project and (when known) the
+    // filename so a user with multiple exports can tell them apart.
+    const emailSubject = stats.filename
+        ? `Export ready — ${rowData.name} — ${stats.filename}`
+        : `Export ready — ${rowData.name}`
     let message = {
         from_email: 'no-reply@arbimon.org',
         to: [{
             email: rowData.user_email
         }],
-        subject: 'Arbimon export'
+        subject: emailSubject
     }
     if (isSignedUrl) {
         const button = `<button style="background:#ADFF2C;border:1px solid #ADFF2C;padding:6px 14px;;border-radius:9999px;cursor:pointer;margin: 10px 0">


### PR DESCRIPTION
The subject was hardcoded `'Arbimon export'` (the descriptive `subject` arg was ignored). Drop the leading 'Arbimon' and make it dynamic: 'Export ready — <project> — <filename>' (filename omitted when unknown). Also distinguishes multiple exports a user requests (previously all identical). `node --check` clean.