### PR TITLE
feat(export-job): render RFM results email from @rfcx/notification-templates

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,6 +3,9 @@
 FROM node:18.14.0 as build
 WORKDIR /app
 COPY ["jobs/package.json", "jobs/package-lock.json*", "/app/"]
+# The vendored @rfcx/notification-templates (file: dep) must exist before
+# `npm install` can resolve it.
+COPY jobs/vendor /app/vendor
 RUN npm install
 COPY jobs /app/jobs
 

--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -6,6 +6,7 @@ const csv_stringify = require('csv-stringify');
 const mandrill = require('mandrill-api/mandrill')
 const axios = require('axios')
 const moment = require('moment')
+const { renderEmail } = require('@rfcx/notification-templates')
 const { exportOccupancyModels, getExportRecordingsRow, getCountSitesRecPerDates, updateExportRecordings, getCountConnections } = require('../services/recordings')
 const { errorMessage } = require('../services/stats')
 const recordings = require('../../app/model/recordings')
@@ -111,7 +112,7 @@ async function main () {
                 console.log('Arbimon Export job: uploading file to S3')
                 const { url, stats } = await saveFile(filePath, currentTime, rowData.project_id, fileName)
                 console.log('Arbimon Export job: file is accessible by url', url, 'stats', stats)
-                await sendEmail('Arbimon Export recording report', `${fileName}.csv`, rowData, url, true, stats)
+                await sendRfmResultsEmail(rowData, url, stats)
                 await updateExportRecordings(rowData, { processed_at: currentTime })
                 fs.unlink(filePath, () => {})
                 console.log(`Arbimon Export job finished: export recordings report for ${message}`)
@@ -486,6 +487,34 @@ async function processGroupedDetectionsStream (results, rowData, projection_para
             })
         })
     })
+}
+
+// Send the RFM (Random Forest Model) analysis-results export notification using
+// the shared @rfcx/notification-templates template (single source of truth for
+// the copy/branding), then dispatch via the notify gateway (Mandrill fallback).
+async function sendRfmResultsEmail (rowData, url, stats) {
+    stats = stats || {}
+    const EXPIRY_DAYS = 7
+    const expiresAt = moment().add(EXPIRY_DAYS, 'days').format('MMMM D, YYYY [at] HH:mm')
+    const isGmail = (rowData.user_email || '').includes('gmail.com')
+    const rendered = renderEmail('arbimon.exportAnalysisResultsRFM', {
+        projectName: rowData.name,
+        url,
+        mode: isGmail ? 'button' : 'link',
+        filename: stats.filename,
+        rows: stats.rows,
+        bytes: stats.bytes,
+        expiryDays: EXPIRY_DAYS,
+        expiresAt
+    })
+    const message = {
+        from_email: 'no-reply@arbimon.org',
+        to: [{ email: rowData.user_email }],
+        subject: rendered.subject,
+        html: rendered.html,
+        text: rendered.text
+    }
+    return sendMessage(message, rendered.subject)
 }
 
 // Send report to the user

--- a/jobs/package.json
+++ b/jobs/package.json
@@ -23,6 +23,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.0.20",
     "@ffprobe-installer/ffprobe": "^1.0.12",
     "@rfcx/http-utils": "^1.0.2",
+    "@rfcx/notification-templates": "file:vendor/rfcx-notification-templates",
     "@rfcx/s3-storage-client": "github:rfcx/s3-storage-client#1.0.0",
     "archiver": "^6.0.1",
     "async": "~2.6.3",

--- a/jobs/vendor/rfcx-notification-templates/README.md
+++ b/jobs/vendor/rfcx-notification-templates/README.md
@@ -1,0 +1,103 @@
+# @rfcx/notification-templates
+
+Shared, **transport-agnostic** transactional email rendering for RFCx / Arbimon
+applications. Produces `{ subject, text, html }` from typed data. It does **not**
+send email — callers hand the result to their transport (the `notify.rfcx.org`
+gateway, Mandrill, etc.).
+
+## Why
+
+Today each app hand-rolls its own HTML (device-api Handlebars, rfcx-api
+Handlebars views, arbimon-legacy EJS + string concat, arbimon CLI TS template
+strings). Branding, footers and escaping drift apart. This package centralizes
+the layout, footer and per-template copy behind one typed API.
+
+## Design
+
+- **Zero runtime dependencies.** Pure TypeScript string templates + a tiny HTML
+  escaper. No Handlebars/EJS in the dependency tree, so any Node app (CJS or
+  ESM) can consume it without engine or loader friction.
+- **Transport stays out.** The package never performs IO. Routing (`to`,
+  `from`, `bcc`) belongs to the caller / notify gateway.
+- **Typed at the call site.** `renderEmail(name, data)` is fully type-checked
+  via a `TemplateName -> data shape` map.
+- **Shared layout/footer.** Every template renders inside `renderLayout`, so the
+  header banner and RFCx footer are identical everywhere.
+- **Snapshot tests.** HTML output is locked with Vitest snapshots to catch
+  accidental branding/markup regressions.
+
+## Usage
+
+```ts
+import { renderEmail } from '@rfcx/notification-templates'
+
+const { subject, text, html } = renderEmail('device.deploymentSuccess', {
+  deviceType: 'AudioMoth',
+  date: deployedAt.toLocaleDateString(),
+  time: deployedAt.toLocaleTimeString()
+})
+
+// Then hand to your transport (notify gateway generic payload):
+await axios.post(EMAIL_SEND_URL, {
+  to: [{ email: user.email, name: user.name }],
+  from: { email: 'contact@rfcx.org', name: 'Rainforest Connection' },
+  subject,
+  text,
+  html
+}, { headers: { Authorization: `Bearer ${EMAIL_SEND_TOKEN}` } })
+```
+
+`DEFAULT_FROM` provides the conventional from address per brand:
+
+```ts
+import { DEFAULT_FROM } from '@rfcx/notification-templates'
+DEFAULT_FROM.rfcx    // { email: 'contact@rfcx.org', name: 'Rainforest Connection' }
+DEFAULT_FROM.arbimon // { email: 'no-reply@arbimon.org', name: 'Arbimon' }
+```
+
+## Templates
+
+| Name                          | Data shape                                              | Ported from |
+| ----------------------------- | ------------------------------------------------------- | ----------- |
+| `device.deploymentSuccess`    | `{ deviceType, date, time }`                            | device-api `deploy-success-email-template.html` |
+| `arbimon.projectBackup`       | `{ url, projectName }`                                  | arbimon CLI `_services/mail/templates.ts` (`project-backup`) |
+| `arbimon.projectBackupFailed` | `{ projectName }`                                       | arbimon CLI `_services/mail/templates.ts` (`project-backup-failed`) |
+| `arbimon.exportDetections`    | `{ url, jobId }`                                        | arbimon CLI `_services/mail/templates.ts` (`export-detections`) |
+| `arbimon.exportRecordings`    | `{ projectName, mode, url? }`                           | arbimon-legacy `jobs/arbimon-recording-export-job/index.js` |
+| `arbimon.exportAnalysisResultsRFM` | `{ projectName, url, mode?, filename?, rows?, bytes?, expiryDays?, expiresAt? }` | arbimon-legacy RFM analysis-results export (2026-07-15 consolidation) |
+| `user.activateAccount`        | `{ fullName, username, host, hash }`                    | arbimon-legacy `app/views/mail/activate-account.ejs` |
+| `user.resetPassword`          | `{ fullName, username, host, hash }`                    | arbimon-legacy `app/views/mail/reset-password.ejs` |
+| `support.contactForm`         | `{ message, replyTo }`                                  | rfcx-api `noncore/views/email/contact-form.handlebars` |
+| `alerts.event`                | `{ streamName, classificationName, time }`             | rfcx-api `noncore/views/email/event-alert.handlebars` |
+| `support.userFeedback`        | `{ name, email, date, feedback, images? }`             | device-api `user-feedback-email-template.html` |
+
+**`arbimon.exportRecordings` delivery modes.** The legacy export job chose a
+download-button vs plain-link body by sniffing the recipient for `@gmail.com`,
+and had a third path that attached the CSV inline. That routing/attachment
+decision stays with the caller (attachments are transport, not template); pass
+`mode: 'signed-url-button' | 'signed-url-link' | 'attachment'` and, for the two
+signed-url modes, the `url`. In `attachment` mode the caller adds the file to
+its transport payload (e.g. the notify-gateway `attachments` array).
+
+## Adding a template
+
+1. Create `src/templates/<name>.ts` exporting a `TemplateDefinition<TData>`.
+2. Register it in `src/index.ts` (`TEMPLATES` + `TemplateDataMap`).
+3. Add tests + snapshot in `src/index.test.ts`.
+
+## Scripts
+
+```sh
+npm install
+npm test        # vitest (unit + snapshots)
+npm run build   # tsup -> dist (esm + cjs + d.ts)
+npm run typecheck
+```
+
+## Distribution options
+
+This package is intentionally standalone and buildable in isolation. See the
+staged rollout plan in the PR description for how it is expected to be consumed
+(git tag/tarball first, private npm registry later). Until a publish/auth path
+is agreed, consumers should pin a tarball or git ref rather than a registry
+version.

--- a/jobs/vendor/rfcx-notification-templates/dist/escape.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/escape.d.ts
@@ -1,0 +1,7 @@
+export declare function escapeHtml(value: unknown): string;
+/**
+ * Escape an absolute http(s) URL for safe use inside an href attribute.
+ * Falls back to '#' for anything that is not a plain http(s) URL, which
+ * prevents javascript: and data: injection from untrusted inputs.
+ */
+export declare function safeUrl(value: unknown): string;

--- a/jobs/vendor/rfcx-notification-templates/dist/escape.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/escape.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.escapeHtml = escapeHtml;
+exports.safeUrl = safeUrl;
+/**
+ * Minimal HTML escaping for interpolated values in email bodies.
+ * Zero-dependency by design so this package can be consumed by any Node app
+ * (CJS or ESM) without pulling a templating engine into the dependency tree.
+ */
+const HTML_ENTITIES = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+};
+function escapeHtml(value) {
+    return String(value !== null && value !== void 0 ? value : '').replace(/[&<>"']/g, (ch) => { var _a; return (_a = HTML_ENTITIES[ch]) !== null && _a !== void 0 ? _a : ch; });
+}
+/**
+ * Escape an absolute http(s) URL for safe use inside an href attribute.
+ * Falls back to '#' for anything that is not a plain http(s) URL, which
+ * prevents javascript: and data: injection from untrusted inputs.
+ */
+function safeUrl(value) {
+    const raw = String(value !== null && value !== void 0 ? value : '').trim();
+    if (/^https?:\/\//i.test(raw)) {
+        return escapeHtml(raw);
+    }
+    return '#';
+}

--- a/jobs/vendor/rfcx-notification-templates/dist/index.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/index.d.ts
@@ -1,0 +1,53 @@
+import type { AlertsEventData } from './templates/alerts-event.js';
+import type { ArbimonExportAnalysisResultsRfmData } from './templates/arbimon-export-analysis-results-rfm.js';
+import type { ArbimonExportDetectionsData } from './templates/arbimon-export-detections.js';
+import type { ArbimonExportRecordingsData } from './templates/arbimon-export-recordings.js';
+import type { ArbimonProjectBackupData } from './templates/arbimon-project-backup.js';
+import type { ArbimonProjectBackupFailedData } from './templates/arbimon-project-backup-failed.js';
+import type { DeviceDeploymentSuccessData } from './templates/device-deployment-success.js';
+import type { SupportContactFormData } from './templates/support-contact-form.js';
+import type { SupportUserFeedbackData } from './templates/support-user-feedback.js';
+import type { UserActivateAccountData } from './templates/user-activate-account.js';
+import type { UserResetPasswordData } from './templates/user-reset-password.js';
+import type { RenderedEmail } from './types.js';
+export type { RenderedEmail, TemplateDefinition } from './types.js';
+export type { Brand } from './layout.js';
+export { DEFAULT_FROM } from './layout.js';
+export { escapeHtml, safeUrl } from './escape.js';
+export type { DeviceDeploymentSuccessData, DeviceType } from './templates/device-deployment-success.js';
+export type { AlertsEventData } from './templates/alerts-event.js';
+export type { ArbimonExportDetectionsData } from './templates/arbimon-export-detections.js';
+export type { ArbimonExportRecordingsData, ArbimonExportDeliveryMode } from './templates/arbimon-export-recordings.js';
+export type { ArbimonExportAnalysisResultsRfmData, ArbimonDownloadMode } from './templates/arbimon-export-analysis-results-rfm.js';
+export type { ArbimonProjectBackupData } from './templates/arbimon-project-backup.js';
+export type { ArbimonProjectBackupFailedData } from './templates/arbimon-project-backup-failed.js';
+export type { SupportContactFormData } from './templates/support-contact-form.js';
+export type { SupportUserFeedbackData } from './templates/support-user-feedback.js';
+export type { UserActivateAccountData } from './templates/user-activate-account.js';
+export type { UserResetPasswordData } from './templates/user-reset-password.js';
+/**
+ * Maps each template name to its typed data shape so `renderEmail` is fully
+ * type-checked at every call site.
+ */
+export interface TemplateDataMap {
+    'device.deploymentSuccess': DeviceDeploymentSuccessData;
+    'arbimon.projectBackup': ArbimonProjectBackupData;
+    'arbimon.projectBackupFailed': ArbimonProjectBackupFailedData;
+    'arbimon.exportDetections': ArbimonExportDetectionsData;
+    'arbimon.exportRecordings': ArbimonExportRecordingsData;
+    'arbimon.exportAnalysisResultsRFM': ArbimonExportAnalysisResultsRfmData;
+    'user.activateAccount': UserActivateAccountData;
+    'user.resetPassword': UserResetPasswordData;
+    'support.contactForm': SupportContactFormData;
+    'support.userFeedback': SupportUserFeedbackData;
+    'alerts.event': AlertsEventData;
+}
+export type TemplateName = keyof TemplateDataMap;
+/**
+ * Render a template by name to `{ subject, text, html }`.
+ *
+ * Transport-agnostic: callers wrap the result in whatever message envelope
+ * their transport requires (notify gateway generic payload, Mandrill-lite, etc.).
+ */
+export declare function renderEmail<TName extends TemplateName>(templateName: TName, data: TemplateDataMap[TName]): RenderedEmail;
+export declare const templateNames: TemplateName[];

--- a/jobs/vendor/rfcx-notification-templates/dist/index.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/index.js
@@ -1,0 +1,49 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.templateNames = exports.safeUrl = exports.escapeHtml = exports.DEFAULT_FROM = void 0;
+exports.renderEmail = renderEmail;
+const alerts_event_js_1 = require("./templates/alerts-event.js");
+const arbimon_export_analysis_results_rfm_js_1 = require("./templates/arbimon-export-analysis-results-rfm.js");
+const arbimon_export_detections_js_1 = require("./templates/arbimon-export-detections.js");
+const arbimon_export_recordings_js_1 = require("./templates/arbimon-export-recordings.js");
+const arbimon_project_backup_js_1 = require("./templates/arbimon-project-backup.js");
+const arbimon_project_backup_failed_js_1 = require("./templates/arbimon-project-backup-failed.js");
+const device_deployment_success_js_1 = require("./templates/device-deployment-success.js");
+const support_contact_form_js_1 = require("./templates/support-contact-form.js");
+const support_user_feedback_js_1 = require("./templates/support-user-feedback.js");
+const user_activate_account_js_1 = require("./templates/user-activate-account.js");
+const user_reset_password_js_1 = require("./templates/user-reset-password.js");
+const types_js_1 = require("./types.js");
+var layout_js_1 = require("./layout.js");
+Object.defineProperty(exports, "DEFAULT_FROM", { enumerable: true, get: function () { return layout_js_1.DEFAULT_FROM; } });
+var escape_js_1 = require("./escape.js");
+Object.defineProperty(exports, "escapeHtml", { enumerable: true, get: function () { return escape_js_1.escapeHtml; } });
+Object.defineProperty(exports, "safeUrl", { enumerable: true, get: function () { return escape_js_1.safeUrl; } });
+/**
+ * Registry of all known templates keyed by their stable dotted name.
+ * Add new templates here as applications are migrated.
+ */
+const TEMPLATES = {
+    'device.deploymentSuccess': device_deployment_success_js_1.deviceDeploymentSuccess,
+    'arbimon.projectBackup': arbimon_project_backup_js_1.arbimonProjectBackup,
+    'arbimon.projectBackupFailed': arbimon_project_backup_failed_js_1.arbimonProjectBackupFailed,
+    'arbimon.exportDetections': arbimon_export_detections_js_1.arbimonExportDetections,
+    'arbimon.exportRecordings': arbimon_export_recordings_js_1.arbimonExportRecordings,
+    'arbimon.exportAnalysisResultsRFM': arbimon_export_analysis_results_rfm_js_1.arbimonExportAnalysisResultsRfm,
+    'user.activateAccount': user_activate_account_js_1.userActivateAccount,
+    'user.resetPassword': user_reset_password_js_1.userResetPassword,
+    'support.contactForm': support_contact_form_js_1.supportContactForm,
+    'support.userFeedback': support_user_feedback_js_1.supportUserFeedback,
+    'alerts.event': alerts_event_js_1.alertsEvent
+};
+/**
+ * Render a template by name to `{ subject, text, html }`.
+ *
+ * Transport-agnostic: callers wrap the result in whatever message envelope
+ * their transport requires (notify gateway generic payload, Mandrill-lite, etc.).
+ */
+function renderEmail(templateName, data) {
+    const template = TEMPLATES[templateName];
+    return (0, types_js_1.renderTemplate)(template, data);
+}
+exports.templateNames = Object.keys(TEMPLATES);

--- a/jobs/vendor/rfcx-notification-templates/dist/layout.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/layout.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared, brand-consistent email layout (header + body + footer).
+ *
+ * This is intentionally a single reusable shell so every application renders
+ * the same header banner, container styling and RFCx footer. Individual
+ * templates only produce the inner body markup and hand it to `renderLayout`.
+ */
+export type Brand = 'rfcx' | 'arbimon';
+export interface LayoutOptions {
+    /** Inner HTML for the message body (already escaped by the template). */
+    bodyHtml: string;
+    /** Brand controls header/footer wording and default from address. */
+    brand?: Brand;
+}
+export declare function renderLayout(options: LayoutOptions): string;
+export declare const DEFAULT_FROM: Record<Brand, {
+    email: string;
+    name: string;
+}>;

--- a/jobs/vendor/rfcx-notification-templates/dist/layout.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/layout.js
@@ -1,0 +1,96 @@
+"use strict";
+/**
+ * Shared, brand-consistent email layout (header + body + footer).
+ *
+ * This is intentionally a single reusable shell so every application renders
+ * the same header banner, container styling and RFCx footer. Individual
+ * templates only produce the inner body markup and hand it to `renderLayout`.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.DEFAULT_FROM = void 0;
+exports.renderLayout = renderLayout;
+const HEADER_IMG = 'https://static.rfcx.org/img/email/header.jpg';
+const SOCIAL_LINKS = [
+    { href: 'https://www.facebook.com/RainforestCx/', img: 'https://static.rfcx.org/img/email/facebook.png' },
+    { href: 'https://twitter.com/rainforestcx', img: 'https://static.rfcx.org/img/email/twitter.png' },
+    { href: 'https://www.flickr.com/photos/rainforestcx/', img: 'https://static.rfcx.org/img/email/flickr.png' },
+    { href: 'https://www.instagram.com/rainforestcx/', img: 'https://static.rfcx.org/img/email/instagram.png' },
+    { href: 'https://www.youtube.com/user/RfcxOrg', img: 'https://static.rfcx.org/img/email/youtube.png' }
+];
+function socialCell(href, img) {
+    return `<td valign="center" align="center" class="center">
+                    <a href="${href}" class="footer__social-link" target="_blank">
+                      <img src="${img}" width="16" alt="RFCx" border="0" style="-ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none;"/>
+                    </a>
+                  </td>`;
+}
+function renderLayout(options) {
+    const { bodyHtml } = options;
+    const social = SOCIAL_LINKS.map(({ href, img }) => socialCell(href, img)).join('\n                  ');
+    return `<html>
+  <head>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&display=swap" rel="stylesheet">
+    <style type="text/css">.ExternalClass,.ExternalClass div,.ExternalClass font,.ExternalClass p,.ExternalClass span,.ExternalClass td,img{line-height:100%}#outlook a{padding:0}.ExternalClass,.ReadMsgBody{width:100%}a,blockquote,body,li,p,table,td{-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}table,td{mso-table-lspace:0;mso-table-rspace:0}img{-ms-interpolation-mode:bicubic;border:0;height:auto;outline:0;text-decoration:none}table{border-collapse:collapse!important}#bodyCell,#bodyTable,body{margin:0;padding:0;font-family:Lato,sans-serif;color:#000}#bodyCell{padding:20px}#bodyTable{width:600px}.im{color:#000!important}@media only screen and (max-width:480px){a,blockquote,body,li,p,table,td{-webkit-text-size-adjust:none!important}body{min-width:100%!important}#bodyTable{max-width:600px!important}#signIn{max-width:280px!important}}@media only screen and (max-width:640px){body[yahoo] .deviceWidth{width:440px!important}body[yahoo] .center{text-align:center!important}}@media only screen and (max-width:479px){body[yahoo] .deviceWidth{width:280px!important}body[yahoo] .center{text-align:center!important}}</style>
+  </head>
+  <body>
+    <center>
+      <table cellpadding="0" cellspacing="0" width="100%" align="center" border="0" style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0;
+          padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>
+        <thead>
+          <tr>
+            <td style="padding: 0px;" align="center" valign="top">
+                <a style="display: block;" href="https://rfcx.org/">
+                  <img src="${HEADER_IMG}" width="600" alt="RFCx" border="0" style="-ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none;"/>
+                </a>
+            </td>
+          </tr>
+        </thead>
+      </table>
+      <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" id="bodyTable" bgcolor="#ffffff"
+        style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;
+                margin: 0; padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>
+        <tr>
+          <td align="center" valign="top" id="bodyCell">
+            <div class="main">
+${bodyHtml}
+            </div>
+          </td>
+        </tr>
+      </table>
+      <table cellpadding="0" cellspacing="0" width="100%" align="center" border="0" bgcolor="#ffffff" style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0;
+        padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>
+        <tfoot>
+          <tr>
+            <td valign="top" class="center" style="padding: 10px 0 10px;">
+              <hr style="border: 1px solid #828282; border-bottom: 0; margin: 0px;" />
+            </td>
+          </tr>
+          <tr>
+            <td valign="top" class="center" style='padding: 10px 10px; text-align: center; font-family: "Lato", sans-serif; font-size: 12px; color: #828282'>
+              Rainforest Connection is a 501<sub>(c)(3)</sub>
+            </td>
+          </tr>
+          <tr>
+            <td valign="top" class="center" style='padding: 15px 0;'>
+              <table cellpadding="0" cellspacing="0" width="200px" align="center" border="0" bgcolor="#ffffff">
+                <tr>
+                  ${social}
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td valign="top" class="center" style='padding: 10px 10px 20px; text-align: center; font-family: "Lato", sans-serif; font-size: 12px; color: #828282'>
+              77 Van Ness Ave, Suite 101-1717, San Francisco, CA, 94102, USA, +1 (415) 335-9205
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </center>
+  </body>
+</html>`;
+}
+exports.DEFAULT_FROM = {
+    rfcx: { email: 'contact@rfcx.org', name: 'Rainforest Connection' },
+    arbimon: { email: 'no-reply@arbimon.org', name: 'Arbimon' }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/alerts-event.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/alerts-event.d.ts
@@ -1,0 +1,17 @@
+import type { TemplateDefinition } from '../types.js';
+export interface AlertsEventData {
+    /** Stream / site display name where the detection happened. */
+    streamName: string;
+    /** Human-readable classification (species / sound) detected. */
+    classificationName: string;
+    /** Local time string of the detection. */
+    time: string;
+}
+/**
+ * Event-alert email to subscribed users when a classification is detected.
+ * Ported from rfcx-api `noncore/views/email/event-alert.handlebars` +
+ * `core/events/bl/notifications.js` (which rendered the subject in-app and
+ * relied on provider-side Handlebars merge vars — now rendered here instead,
+ * removing the dependence on provider merge features).
+ */
+export declare const alertsEvent: TemplateDefinition<AlertsEventData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/alerts-event.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/alerts-event.js
@@ -1,0 +1,41 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.alertsEvent = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+/**
+ * Event-alert email to subscribed users when a classification is detected.
+ * Ported from rfcx-api `noncore/views/email/event-alert.handlebars` +
+ * `core/events/bl/notifications.js` (which rendered the subject in-app and
+ * relied on provider-side Handlebars merge vars — now rendered here instead,
+ * removing the dependence on provider merge features).
+ */
+exports.alertsEvent = {
+    name: 'alerts.event',
+    brand: 'rfcx',
+    subject: (data) => `A ${data.classificationName} detected on ${data.streamName} at ${data.time}`,
+    text: (data) => `Site: ${data.streamName}\n` +
+        `What detected: ${data.classificationName}\n` +
+        `Time: ${data.time} (Local time)`,
+    html: (data) => {
+        const streamName = (0, escape_js_1.escapeHtml)(data.streamName);
+        const classificationName = (0, escape_js_1.escapeHtml)(data.classificationName);
+        const time = (0, escape_js_1.escapeHtml)(data.time);
+        const row = (label, value) => `                  <tr style="margin: 0; padding: 0;">
+                    <td width="200" align="right" style="text-align: right; color: #323a45; margin: 0; padding: 7px 10px; font: 600 14px Arial, sans-serif;">
+                      ${label}
+                    </td>
+                    <td width="450" align="left" style="text-align: left; color: #323a45; margin: 0; padding: 7px 10px; font: 400 14px Arial, sans-serif;">
+                      ${value}
+                    </td>
+                  </tr>`;
+        const body = `              <table width="100%" cellspacing="0" style="margin: 0 auto; padding: 0;">
+                <tbody style="margin: 0; padding: 0;">
+${row('Site:', streamName)}
+${row('What detected:', classificationName)}
+${row('Time:', `${time} (Local time)`)}
+                </tbody>
+              </table>`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'rfcx' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.d.ts
@@ -1,0 +1,40 @@
+import type { TemplateDefinition } from '../types.js';
+/**
+ * How the download is presented in the body:
+ *  - 'button': green download button (historically the Gmail path).
+ *  - 'link':   plain inline download link (historically the non-Gmail path).
+ * In BOTH modes the raw URL is also shown as copyable plain text, so it works
+ * even when a mail client strips the button/link.
+ */
+export type ArbimonDownloadMode = 'button' | 'link';
+export interface ArbimonExportAnalysisResultsRfmData {
+    /** Project name shown in the subject + body. */
+    projectName: string;
+    /** Download URL (arb.mn/dl short link). */
+    url: string;
+    /** How to present the download (see ArbimonDownloadMode). Default 'button'. */
+    mode?: ArbimonDownloadMode;
+    /** Export filename, e.g. "rfm_phlebodes_rfm_mon_08.csv". */
+    filename?: string;
+    /** Number of data rows in the export (thousands-separated in the output). */
+    rows?: number;
+    /** File size in bytes (rendered human-readable). */
+    bytes?: number;
+    /** Days until the link expires (default 7). */
+    expiryDays?: number;
+    /**
+     * Pre-formatted concrete expiry timestamp for the parenthetical, e.g.
+     * "July 22, 2026 at 12:16". The caller formats it (timezone-aware); the
+     * template stays IO/clock-free.
+     */
+    expiresAt?: string;
+}
+/**
+ * "Your RFM analysis results are ready for download" — sent by the
+ * arbimon-legacy recording-export job when a Random Forest Model (RFM)
+ * classification-job results export completes.
+ *
+ * Body order: greeting -> download (button/link) -> copyable URL -> stats
+ * (Filename / Rows / Size) -> expiry + support -> signature.
+ */
+export declare const arbimonExportAnalysisResultsRfm: TemplateDefinition<ArbimonExportAnalysisResultsRfmData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.js
@@ -1,0 +1,94 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.arbimonExportAnalysisResultsRfm = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+const DOWNLOAD_ICON = 'https://static.rfcx.org/arbimon/download-icon.png';
+function formatBytes(bytes) {
+    if (bytes == null || isNaN(bytes))
+        return undefined;
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let n = Number(bytes);
+    let i = 0;
+    while (n >= 1024 && i < units.length - 1) {
+        n /= 1024;
+        i++;
+    }
+    // Whole numbers for B; one decimal for KB/MB/GB (keeps the trailing .0, e.g.
+    // "2.0 MB") except when >= 100 where a decimal adds no value.
+    const value = i === 0 || n >= 100 ? String(Math.round(n)) : n.toFixed(1);
+    return `${value} ${units[i]}`;
+}
+function statLines(data) {
+    const lines = [];
+    if (data.filename != null && data.filename !== '')
+        lines.push(`Filename: ${data.filename}`);
+    if (data.rows != null && !isNaN(data.rows))
+        lines.push(`Rows: ${Number(data.rows).toLocaleString('en-US')}`);
+    const size = formatBytes(data.bytes);
+    if (size != null)
+        lines.push(`Size: ${size}`);
+    return lines;
+}
+function expiryClause(data) {
+    var _a;
+    const days = (_a = data.expiryDays) !== null && _a !== void 0 ? _a : 7;
+    const when = data.expiresAt != null && data.expiresAt !== '' ? ` (on ${data.expiresAt})` : '';
+    return `Please note that this link will expire in ${days} days${when}.`;
+}
+/**
+ * "Your RFM analysis results are ready for download" — sent by the
+ * arbimon-legacy recording-export job when a Random Forest Model (RFM)
+ * classification-job results export completes.
+ *
+ * Body order: greeting -> download (button/link) -> copyable URL -> stats
+ * (Filename / Rows / Size) -> expiry + support -> signature.
+ */
+exports.arbimonExportAnalysisResultsRfm = {
+    name: 'arbimon.exportAnalysisResultsRFM',
+    brand: 'arbimon',
+    subject: (data) => data.filename != null && data.filename !== ''
+        ? `Export ready — ${data.projectName} — ${data.filename}`
+        : `Export ready — ${data.projectName}`,
+    text: (data) => {
+        const stats = statLines(data);
+        const statsBlock = stats.length ? `\n${stats.join('\n')}\n` : '';
+        return (`Hello,\n\n` +
+            `Thanks so much for using Arbimon! Your export report for the project "${data.projectName}" is ready for download.\n\n` +
+            `Download your export:\n${data.url}\n` +
+            `${statsBlock}\n` +
+            `${expiryClause(data)} If you have any questions about Arbimon, check out our support docs: https://help.arbimon.org/\n\n` +
+            `- The Arbimon Team`);
+    },
+    html: (data) => {
+        var _a;
+        const projectName = (0, escape_js_1.escapeHtml)(data.projectName);
+        const url = (0, escape_js_1.safeUrl)(data.url);
+        const mode = (_a = data.mode) !== null && _a !== void 0 ? _a : 'button';
+        const header = `              <p style="color:black;margin-top:0">Hello,</p>
+              <p style="color:black;">Thanks so much for using Arbimon! Your export report for the project "${projectName}" is ready for download.</p>`;
+        const download = mode === 'button'
+            ? `              <button style="background:#ADFF2C;border:1px solid #ADFF2C;padding:6px 14px;;border-radius:9999px;cursor:pointer;margin: 10px 0">
+                  <a style="text-decoration:none;color:#14130D;white-space:nowrap;text-align:center;vertical-align:middle;align-items:center;display:inline-flex;display: -webkit-inline-flex;" download target="_self" href="${url}">
+                      Download
+                      <img style="width: 14px; height: 14px; margin-left:8px" src="${DOWNLOAD_ICON}">
+                  </a>
+              </button>`
+            : `              <p><img style="width: 14px; height: 14px; margin-left:8px" src="${DOWNLOAD_ICON}"><a style="margin-left: 1px" href="${url}">Download export</a></p>`;
+        const plainLink = `              <p style="color:black;">Or copy and paste this link into your browser:<br>
+                <a href="${url}" style="color:#1a73e8; word-break:break-all;">${url}</a></p>`;
+        const stats = statLines(data).map(escape_js_1.escapeHtml);
+        const statsHtml = stats.length
+            ? `              <p style="color:black; margin:8px 0;">${stats.join('<br>')}</p>`
+            : '';
+        const expirySupport = `              <p style="color:black;">${(0, escape_js_1.escapeHtml)(expiryClause(data))} If you have any questions about Arbimon, check out our <a href="https://help.arbimon.org/">support docs</a>.</p>`;
+        const footer = `              <p style="color:black;"><span> - The Arbimon Team </span></p>`;
+        const body = `${header}
+${download}
+${plainLink}
+${statsHtml}
+${expirySupport}
+${footer}`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-detections.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-detections.d.ts
@@ -1,0 +1,13 @@
+import type { TemplateDefinition } from '../types.js';
+export interface ArbimonExportDetectionsData {
+    /** Signed download URL for the exported detections (expires ~7 days). */
+    url: string;
+    /** Classifier (CNN) job id that was exported. */
+    jobId: number;
+}
+/**
+ * "Your CNN export is ready" — sent by the arbimon CLI
+ * (apps/cli/src/export-cnn) when a classifier-job detection export completes.
+ * Ported from arbimon CLI `_services/mail/templates.ts` (`export-detections`).
+ */
+export declare const arbimonExportDetections: TemplateDefinition<ArbimonExportDetectionsData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-detections.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-detections.js
@@ -1,0 +1,42 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.arbimonExportDetections = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+const DOWNLOAD_ICON = 'https://static.rfcx.org/arbimon/download-icon.png';
+/**
+ * "Your CNN export is ready" — sent by the arbimon CLI
+ * (apps/cli/src/export-cnn) when a classifier-job detection export completes.
+ * Ported from arbimon CLI `_services/mail/templates.ts` (`export-detections`).
+ */
+exports.arbimonExportDetections = {
+    name: 'arbimon.exportDetections',
+    brand: 'arbimon',
+    subject: () => 'Arbimon CNN export detections ready',
+    text: (data) => `Hello,\n\n` +
+        `Thanks so much for using Arbimon! Your classifier job export id ${data.jobId} has been completed. ` +
+        `Please note that this link will expire in 7 days.\n\n` +
+        `Download your export: ${data.url}\n\n` +
+        `If you have any questions about Arbimon, check out our support docs: https://help.arbimon.org/\n\n` +
+        `- The Arbimon Team`,
+    html: (data) => {
+        const jobId = (0, escape_js_1.escapeHtml)(data.jobId);
+        const url = (0, escape_js_1.safeUrl)(data.url);
+        const body = `              <p style="color:black;margin-top:0">Hello,</p>
+              <p style="color:black;">
+                Thanks so much for using Arbimon! Your classifier job export id ${jobId} has been completed.
+                Please note that this link will expire in 7 days.
+                If you have any questions about Arbimon, check out our <a href="https://help.arbimon.org/">support docs</a>.
+              </p>
+              <button style="background:#ADFF2C;border:1px solid #ADFF2C;padding:6px 14px;;border-radius:9999px;cursor:pointer;margin: 10px 0">
+                  <a style="text-decoration:none;color:#14130D;white-space:nowrap;text-align:center;vertical-align:middle;align-items:center;display:inline-flex;display: -webkit-inline-flex;" href="${url}">
+                      Download
+                      <img style="width: 14px; height: 14px; margin-left:8px" src="${DOWNLOAD_ICON}">
+                  </a>
+              </button>
+              <p style="color:black;">
+                <span> - The Arbimon Team </span>
+              </p>`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-recordings.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-recordings.d.ts
@@ -1,0 +1,28 @@
+import type { TemplateDefinition } from '../types.js';
+/**
+ * Delivery variant for the recordings/report export email:
+ *  - 'signed-url-button': download rendered as a button (was the Gmail path).
+ *  - 'signed-url-link':   download rendered as a plain inline link.
+ *  - 'attachment':        no in-body link; the report is attached by the
+ *                         transport (the caller adds the attachment to the
+ *                         notify-gateway payload — this package never does IO).
+ *
+ * Historically arbimon-legacy chose the button vs link path by sniffing the
+ * recipient's address for '@gmail.com'. That routing decision stays in the
+ * caller; the template just renders whichever variant it is told to.
+ */
+export type ArbimonExportDeliveryMode = 'signed-url-button' | 'signed-url-link' | 'attachment';
+export interface ArbimonExportRecordingsData {
+    /** Project name shown in the body. */
+    projectName: string;
+    /** How the export is delivered (see ArbimonExportDeliveryMode). */
+    mode: ArbimonExportDeliveryMode;
+    /** Signed download URL. Required for the two 'signed-url-*' modes; ignored for 'attachment'. */
+    url?: string;
+}
+/**
+ * "Your export report is ready" — sent by arbimon-legacy's recording-export
+ * job. Ported from `jobs/arbimon-recording-export-job/index.js` `sendEmail()`
+ * (subject "Arbimon export", from no-reply@arbimon.org).
+ */
+export declare const arbimonExportRecordings: TemplateDefinition<ArbimonExportRecordingsData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-recordings.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-recordings.js
@@ -1,0 +1,57 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.arbimonExportRecordings = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+const DOWNLOAD_ICON = 'https://static.rfcx.org/arbimon/download-icon.png';
+/**
+ * "Your export report is ready" — sent by arbimon-legacy's recording-export
+ * job. Ported from `jobs/arbimon-recording-export-job/index.js` `sendEmail()`
+ * (subject "Arbimon export", from no-reply@arbimon.org).
+ */
+exports.arbimonExportRecordings = {
+    name: 'arbimon.exportRecordings',
+    brand: 'arbimon',
+    subject: () => 'Arbimon export',
+    text: (data) => {
+        var _a;
+        const expires = data.mode === 'attachment' ? '' : ' Please note that this link will expire in 7 days.';
+        const download = data.mode === 'attachment'
+            ? '\n\nThe report is attached to this email.'
+            : `\n\nDownload your export: ${(_a = data.url) !== null && _a !== void 0 ? _a : ''}`;
+        return (`Hello,\n\n` +
+            `Thanks so much for using Arbimon! Your export report for the project "${data.projectName}" has been completed.` +
+            `${expires}` +
+            ` If you have any questions about Arbimon, check out our support docs: https://help.arbimon.org/` +
+            `${download}\n\n` +
+            `- The Arbimon Team`);
+    },
+    html: (data) => {
+        const projectName = (0, escape_js_1.escapeHtml)(data.projectName);
+        const url = (0, escape_js_1.safeUrl)(data.url);
+        const expires = data.mode === 'attachment' ? '' : ' Please note that this link will expire in 7 days.';
+        const textHeader = `              <p style="color:black;margin-top:0">Hello,</p>
+              <p style="color:black;">Thanks so much for using Arbimon! Your export report for the project "${projectName}" has been completed.`;
+        const textSupport = `${expires} If you have any questions about Arbimon, check out our <a href="https://help.arbimon.org/">support docs</a>.
+              </p>`;
+        const textFooter = `              <p style="color:black;">
+                <span> - The Arbimon Team </span>
+              </p>`;
+        let download = '';
+        if (data.mode === 'signed-url-button') {
+            download = `
+              <button style="background:#ADFF2C;border:1px solid #ADFF2C;padding:6px 14px;;border-radius:9999px;cursor:pointer;margin: 10px 0">
+                  <a style="text-decoration:none;color:#14130D;white-space:nowrap;text-align:center;vertical-align:middle;align-items:center;display:inline-flex;display: -webkit-inline-flex;" download target="_self" href="${url}">
+                      Download
+                      <img style="width: 14px; height: 14px; margin-left:8px" src="${DOWNLOAD_ICON}">
+                  </a>
+              </button>`;
+        }
+        else if (data.mode === 'signed-url-link') {
+            download = `
+              <p><img style="width: 14px; height: 14px; margin-left:8px" src="${DOWNLOAD_ICON}"><a style="margin-left: 1px" href="${url}">Download export</a></p>`;
+        }
+        const body = `${textHeader}${textSupport}${download}\n${textFooter}`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-project-backup-failed.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-project-backup-failed.d.ts
@@ -1,0 +1,11 @@
+import type { TemplateDefinition } from '../types.js';
+export interface ArbimonProjectBackupFailedData {
+    /** Human-readable project name. */
+    projectName: string;
+}
+/**
+ * "Your project backup failed" — sent by the arbimon CLI when a
+ * user-requested project backup errors out.
+ * Ported from arbimon CLI `_services/mail/templates.ts` (`project-backup-failed`).
+ */
+export declare const arbimonProjectBackupFailed: TemplateDefinition<ArbimonProjectBackupFailedData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-project-backup-failed.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-project-backup-failed.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.arbimonProjectBackupFailed = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+/**
+ * "Your project backup failed" — sent by the arbimon CLI when a
+ * user-requested project backup errors out.
+ * Ported from arbimon CLI `_services/mail/templates.ts` (`project-backup-failed`).
+ */
+exports.arbimonProjectBackupFailed = {
+    name: 'arbimon.projectBackupFailed',
+    brand: 'arbimon',
+    subject: () => 'Arbimon project backup failed',
+    text: (data) => `Hello,\n\n` +
+        `There was an issue with your project backup of '${data.projectName}'. ` +
+        `Our engineering team is looking into this and will update you when we have resolved it. ` +
+        `We apologize for the inconvenience and thank you for your patience!\n\n` +
+        `All the best,\nArbimon team`,
+    html: (data) => {
+        const projectName = (0, escape_js_1.escapeHtml)(data.projectName);
+        const body = `              <p style="color:black;margin-top:0">Hello,</p>
+              <p style="color:black;">
+                There was an issue with your project backup of '${projectName}'. Our engineering team is looking into this and will update you when we have resolved it. We apologize for the inconvenience and thank you for your patience!
+              </p>
+              <p style="color:black;">
+                All the best, <br>Arbimon team
+              </p>`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-project-backup.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-project-backup.d.ts
@@ -1,0 +1,13 @@
+import type { TemplateDefinition } from '../types.js';
+export interface ArbimonProjectBackupData {
+    /** Signed download URL for the backup bundle (expires ~7 days). */
+    url: string;
+    /** Human-readable project name. */
+    projectName: string;
+}
+/**
+ * "Your project backup is ready" — sent by the arbimon CLI
+ * (apps/cli/src/backup) when a user-requested project backup completes.
+ * Ported from arbimon CLI `_services/mail/templates.ts` (`project-backup`).
+ */
+export declare const arbimonProjectBackup: TemplateDefinition<ArbimonProjectBackupData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-project-backup.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-project-backup.js
@@ -1,0 +1,39 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.arbimonProjectBackup = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+/**
+ * "Your project backup is ready" — sent by the arbimon CLI
+ * (apps/cli/src/backup) when a user-requested project backup completes.
+ * Ported from arbimon CLI `_services/mail/templates.ts` (`project-backup`).
+ */
+exports.arbimonProjectBackup = {
+    name: 'arbimon.projectBackup',
+    brand: 'arbimon',
+    subject: () => 'Arbimon project backup ready',
+    text: (data) => `Hello,\n\n` +
+        `Thanks so much for using Arbimon! Your backup of the project "${data.projectName}" ` +
+        `has been completed and is now ready.\n\n` +
+        `Download your file: ${data.url}\n\n` +
+        `Please note that this link will expire in 7 days.\n\n` +
+        `For more information and support, please visit our documentation: https://help.arbimon.org/\n\n` +
+        `- The Arbimon Team`,
+    html: (data) => {
+        const projectName = (0, escape_js_1.escapeHtml)(data.projectName);
+        const url = (0, escape_js_1.safeUrl)(data.url);
+        const body = `              <p style="color:black;margin-top:0">Hello,</p>
+              <p style="color:black;">
+                Thanks so much for using Arbimon! Your backup of the project "${projectName}" has been completed and now ready.
+              </p>
+              <p style="color:black;">Please <a href="${url}">click here</a> to download your file.</p>
+              <p style="color:black;">Please note that this link will expire in 7 days.</p>
+              <p style="color:black;">
+                For more information and support, please visit our documentation: <a href="https://help.arbimon.org/">https://help.arbimon.org/</a>
+              </p>
+              <p style="color:black;">
+                <span> - The Arbimon Team </span>
+              </p>`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/device-deployment-success.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/device-deployment-success.d.ts
@@ -1,0 +1,15 @@
+import type { TemplateDefinition } from '../types.js';
+/**
+ * Human-friendly device type label used in copy.
+ * Mirrors the mapping previously hard-coded in device-api.
+ */
+export type DeviceType = 'Guardian' | 'Song Meter' | 'AudioMoth' | 'recording';
+export interface DeviceDeploymentSuccessData {
+    /** Display label for the device type. */
+    deviceType: DeviceType | string;
+    /** Localised date string, e.g. "5/16/2025". */
+    date: string;
+    /** Localised time string, e.g. "3:24:00 PM". */
+    time: string;
+}
+export declare const deviceDeploymentSuccess: TemplateDefinition<DeviceDeploymentSuccessData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/device-deployment-success.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/device-deployment-success.js
@@ -1,0 +1,28 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.deviceDeploymentSuccess = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+const UPLOADER_TYPES = new Set(['AudioMoth', 'Song Meter']);
+function nextStepsHtml(deviceType) {
+    const safeType = (0, escape_js_1.escapeHtml)(deviceType);
+    return `              <h3 style="color: #000;"> Next steps…</h3>
+              <p style="color: #000;">1. When you are done recording with the ${safeType}, switch it to the OFF position and remove the SD card.</p>
+              <p style="color: #000;">2. Upload the files using the Arbimon Uploader by download the <a href='https://rf.cx/ingest-app-latest-win'> Arbimon Uploader for Windows </a> or the <a href='https://rf.cx/ingest-app-latest-mac'>Arbimon Uploader for Mac</a> here.</p>
+              <p style="color: #000;">3. Open <a href='https://arbimon.rfcx.org/'> Arbimon</a> to analyse an unlimited amount of audio from your ${safeType} device.</p>`;
+}
+exports.deviceDeploymentSuccess = {
+    name: 'device.deploymentSuccess',
+    brand: 'rfcx',
+    subject: (data) => `Your ${data.deviceType} device was deployed successfully`,
+    text: (data) => `Your ${data.deviceType} device was successfully deployed on ${data.date} at ${data.time} UTC.`,
+    html: (data) => {
+        const safeType = (0, escape_js_1.escapeHtml)(data.deviceType);
+        const safeDate = (0, escape_js_1.escapeHtml)(data.date);
+        const safeTime = (0, escape_js_1.escapeHtml)(data.time);
+        const nextSteps = UPLOADER_TYPES.has(data.deviceType) ? `\n${nextStepsHtml(data.deviceType)}` : '';
+        const body = `              <h1 style="color: #000;">${safeType} deployment complete!</h1>
+              <p style="color: #000;">Your ${safeType} device was successfully deployed on ${safeDate} at ${safeTime} UTC.</p>${nextSteps}`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'rfcx' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/support-contact-form.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/support-contact-form.d.ts
@@ -1,0 +1,12 @@
+import type { TemplateDefinition } from '../types.js';
+export interface SupportContactFormData {
+    /** The submitted message body (plain text; rendered preformatted). */
+    message: string;
+    /** Reply-to address supplied by the submitter. */
+    replyTo: string;
+}
+/**
+ * Contact-form notification to the internal support inbox (contact@rfcx.org).
+ * Ported from rfcx-api `noncore/views/email/contact-form.handlebars`.
+ */
+export declare const supportContactForm: TemplateDefinition<SupportContactFormData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/support-contact-form.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/support-contact-form.js
@@ -1,0 +1,36 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.supportContactForm = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+/**
+ * Contact-form notification to the internal support inbox (contact@rfcx.org).
+ * Ported from rfcx-api `noncore/views/email/contact-form.handlebars`.
+ */
+exports.supportContactForm = {
+    name: 'support.contactForm',
+    brand: 'rfcx',
+    subject: () => 'RFCx contact form submission',
+    text: (data) => `New contact form submission.\n\n` +
+        `${data.message}\n\n` +
+        `Reply to: ${data.replyTo}`,
+    html: (data) => {
+        const message = (0, escape_js_1.escapeHtml)(data.message);
+        const replyTo = (0, escape_js_1.escapeHtml)(data.replyTo);
+        const body = `              <table width="100%" cellspacing="0" style="margin: 0 auto; padding: 0;">
+                <tbody style="margin: 0; padding: 0;">
+                  <tr style="margin: 0; padding: 0;">
+                    <td align="left" style="text-align: justify; color: #323a45; margin: 0; padding: 10px 0; font: 400 14px Arial, sans-serif; border-top: 1px solid #eee;">
+                      <pre style="color: #323a45; margin: 0; padding: 0; font: 400 14px Arial, sans-serif; line-height: 1.4; white-space: pre-wrap;">${message}</pre>
+                    </td>
+                  </tr>
+                  <tr style="margin: 0; padding: 0;">
+                    <td align="left" style="text-align: left; color: #323a45; margin: 0; padding: 7px 0; font: 400 14px Arial, sans-serif; border-top: 1px solid #eee;">
+                      <b>Reply to:</b> ${replyTo}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'rfcx' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/support-user-feedback.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/support-user-feedback.d.ts
@@ -1,0 +1,18 @@
+import type { TemplateDefinition } from '../types.js';
+export interface SupportUserFeedbackData {
+    /** Name of the user who submitted feedback. */
+    name: string;
+    /** Email of the user who submitted feedback. */
+    email: string;
+    /** Submission date string. */
+    date: string;
+    /** The feedback text. */
+    feedback: string;
+    /** Optional attachment image URLs. */
+    images?: string[];
+}
+/**
+ * User-feedback notification to the internal support team.
+ * Ported from device-api `src/common/email/user-feedback-email-template.html`.
+ */
+export declare const supportUserFeedback: TemplateDefinition<SupportUserFeedbackData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/support-user-feedback.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/support-user-feedback.js
@@ -1,0 +1,47 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.supportUserFeedback = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+/**
+ * User-feedback notification to the internal support team.
+ * Ported from device-api `src/common/email/user-feedback-email-template.html`.
+ */
+exports.supportUserFeedback = {
+    name: 'support.userFeedback',
+    brand: 'rfcx',
+    subject: () => 'New RFCx Companion user feedback',
+    text: (data) => {
+        var _a;
+        const images = (_a = data.images) !== null && _a !== void 0 ? _a : [];
+        const attachments = images.length > 0
+            ? `\n\nAttachments:\n${images.map((u, i) => `attachment_${i}: ${u}`).join('\n')}`
+            : '';
+        return (`Hi RFCx Support Team!\n\n` +
+            `We have got a new feedback from ${data.name}(${data.email}) at ${data.date}.\n\n` +
+            `"${data.feedback}"${attachments}\n\n` +
+            `Regards,\nRFCx Companion Bot`);
+    },
+    html: (data) => {
+        var _a;
+        const name = (0, escape_js_1.escapeHtml)(data.name);
+        const email = (0, escape_js_1.escapeHtml)(data.email);
+        const date = (0, escape_js_1.escapeHtml)(data.date);
+        const feedback = (0, escape_js_1.escapeHtml)(data.feedback);
+        const images = (_a = data.images) !== null && _a !== void 0 ? _a : [];
+        const attachments = images.length > 0
+            ? `\n              <p style="color:black;">with attachments:</p>\n` +
+                images
+                    .map((u, i) => `              <p><a href="${(0, escape_js_1.safeUrl)(u)}">attachment_${i}</a></p>`)
+                    .join('\n')
+            : '';
+        const body = `              <p style="color:black;">Hi RFCx Support Team!</p>
+              <p style="color:black;">We have got a new feedback from ${name}(${email}) at ${date}.</p>
+              <blockquote style="color: black">
+                "${feedback}"
+              </blockquote>${attachments}
+              <p style="color:black;">Regards,</p>
+              <p style="color:black;">RFCx Companion Bot</p>`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'rfcx' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/user-activate-account.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/user-activate-account.d.ts
@@ -1,0 +1,17 @@
+import type { TemplateDefinition } from '../types.js';
+export interface UserActivateAccountData {
+    /** Recipient's full name for the greeting. */
+    fullName: string;
+    /** Account username being activated. */
+    username: string;
+    /** Public base URL, e.g. https://arbimon.org (no trailing slash). */
+    host: string;
+    /** Activation token appended to `${host}/activate/${hash}`. */
+    hash: string;
+}
+/**
+ * "Activate your account" — sent by arbimon-legacy on account registration.
+ * Ported from arbimon-legacy `app/views/mail/activate-account.ejs`
+ * (subject "RFCx Arbimon: Account activation", from support@rfcx.org).
+ */
+export declare const userActivateAccount: TemplateDefinition<UserActivateAccountData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/user-activate-account.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/user-activate-account.js
@@ -1,0 +1,32 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.userActivateAccount = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+/**
+ * "Activate your account" — sent by arbimon-legacy on account registration.
+ * Ported from arbimon-legacy `app/views/mail/activate-account.ejs`
+ * (subject "RFCx Arbimon: Account activation", from support@rfcx.org).
+ */
+exports.userActivateAccount = {
+    name: 'user.activateAccount',
+    brand: 'arbimon',
+    subject: () => 'RFCx Arbimon: Account activation',
+    text: (data) => {
+        const link = `${data.host}/activate/${data.hash}`;
+        return (`Hello ${data.fullName},\n\n` +
+            `Your Arbimon account for ${data.username} is almost ready to use!\n\n` +
+            `Follow this link to activate your account:\n\n` +
+            `${link}`);
+    },
+    html: (data) => {
+        const fullName = (0, escape_js_1.escapeHtml)(data.fullName);
+        const username = (0, escape_js_1.escapeHtml)(data.username);
+        const link = (0, escape_js_1.safeUrl)(`${data.host}/activate/${data.hash}`);
+        const body = `              <p style="color:#000;">Hello ${fullName},</p>
+              <p style="color:#000;">Your Arbimon account for <b>${username}</b> is almost ready to use!</p>
+              <p style="color:#000;">Follow this link to activate your account:</p>
+              <p style="color:#000;"><a href="${link}">${link}</a></p>`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/user-reset-password.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/user-reset-password.d.ts
@@ -1,0 +1,17 @@
+import type { TemplateDefinition } from '../types.js';
+export interface UserResetPasswordData {
+    /** Recipient's full name for the greeting. */
+    fullName: string;
+    /** Account username reminder. */
+    username: string;
+    /** Public base URL, e.g. https://arbimon.org (no trailing slash). */
+    host: string;
+    /** Reset token appended to `${host}/reset_password/${hash}`. */
+    hash: string;
+}
+/**
+ * "Reset your password" — sent by arbimon-legacy on a password-reset request.
+ * Ported from arbimon-legacy `app/views/mail/reset-password.ejs`
+ * (subject "RFCx Arbimon: Password reset", from support@rfcx.org).
+ */
+export declare const userResetPassword: TemplateDefinition<UserResetPasswordData>;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/user-reset-password.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/user-reset-password.js
@@ -1,0 +1,30 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.userResetPassword = void 0;
+const escape_js_1 = require("../escape.js");
+const layout_js_1 = require("../layout.js");
+/**
+ * "Reset your password" — sent by arbimon-legacy on a password-reset request.
+ * Ported from arbimon-legacy `app/views/mail/reset-password.ejs`
+ * (subject "RFCx Arbimon: Password reset", from support@rfcx.org).
+ */
+exports.userResetPassword = {
+    name: 'user.resetPassword',
+    brand: 'arbimon',
+    subject: () => 'RFCx Arbimon: Password reset',
+    text: (data) => {
+        const link = `${data.host}/reset_password/${data.hash}`;
+        return (`Hello ${data.fullName},\n\n` +
+            `your username is ${data.username}\n\n` +
+            `Follow this link to reset your password:\n${link}`);
+    },
+    html: (data) => {
+        const fullName = (0, escape_js_1.escapeHtml)(data.fullName);
+        const username = (0, escape_js_1.escapeHtml)(data.username);
+        const link = (0, escape_js_1.safeUrl)(`${data.host}/reset_password/${data.hash}`);
+        const body = `              <p style="color:#000;">Hello <b>${fullName}</b>,</p>
+              <p style="color:#000;">your username is <b>${username}</b></p>
+              <p style="color:#000;">Follow this link to reset your password: <a href="${link}">Reset Password Here</a></p>`;
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon' });
+    }
+};

--- a/jobs/vendor/rfcx-notification-templates/dist/types.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/types.d.ts
@@ -1,0 +1,22 @@
+import type { Brand } from './layout.js';
+/**
+ * The rendered output of a template: everything a transport (notify gateway,
+ * Mandrill, etc.) needs to build a message, minus recipient/from routing.
+ */
+export interface RenderedEmail {
+    subject: string;
+    text: string;
+    html: string;
+}
+/**
+ * A template is a pure function set: given typed data, produce subject/text/html.
+ * Templates never perform IO and never know about transports.
+ */
+export interface TemplateDefinition<TData> {
+    name: string;
+    brand: Brand;
+    subject: (data: TData) => string;
+    text: (data: TData) => string;
+    html: (data: TData) => string;
+}
+export declare function renderTemplate<TData>(template: TemplateDefinition<TData>, data: TData): RenderedEmail;

--- a/jobs/vendor/rfcx-notification-templates/dist/types.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/types.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.renderTemplate = renderTemplate;
+function renderTemplate(template, data) {
+    return {
+        subject: template.subject(data),
+        text: template.text(data),
+        html: template.html(data)
+    };
+}

--- a/jobs/vendor/rfcx-notification-templates/package.json
+++ b/jobs/vendor/rfcx-notification-templates/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rfcx/notification-templates",
+  "version": "0.1.0",
+  "description": "Shared, transport-agnostic notification template rendering for RFCx / Arbimon applications",
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rfcx/rfcx-notification-templates.git"
+  },
+  "type": "commonjs",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "scripts": {
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "build": "npm run clean && tsc -p tsconfig.json",
+    "test": "npm run build && vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepack": "npm test"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  }
+}


### PR DESCRIPTION
First consolidation of an export email into the shared template package. Switches the **RFM analysis-results** export notification from inline HTML to `@rfcx/notification-templates` `arbimon.exportAnalysisResultsRFM` (single source of truth; ends per-app drift).

- New `sendRfmResultsEmail()` renders subject/html/text via `renderEmail()` and dispatches through the existing `sendMessage()` (notify gateway + Mandrill fallback). Caller formats the concrete `expiresAt` (moment, local tz) + picks button/link by gmail — template stays IO/clock-free.
- Vendored the built package into `jobs/vendor/rfcx-notification-templates` (dist + package.json + README, **no** node_modules), `file:` dep in `jobs/package.json` — same pattern as device-api.
- Dockerfile COPYs `jobs/vendor` before `npm install` so the `file:` dep resolves at build.
- Verified the vendored template resolves + renders (subject/stats/plaintext-link/expiry) from the job's installed deps.

The legacy inline `sendEmail()` stays for the other export types until they're migrated too. Depends on rfcx/rfcx-notification-templates#2 (the template).