### PR TITLE
feat(export-job): RFM email job metadata (id/name/playlist) + UTC expiry

### DIFF
--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -103,7 +103,7 @@ async function main () {
         return new Promise((resolve, reject) => {
             const exportReportType = 'RFM Classification';
             console.log(`Arbimon Export ${exportReportType} job`)
-            rfmClassification.collectData(projection_parameters, async (err, filePath, fileName) => {
+            rfmClassification.collectData(projection_parameters, async (err, filePath, fileName, jobMeta) => {
                 if (err) {
                     console.error('Arbimon Export job error', err)
                     fs.unlink(filePath, () => {})
@@ -111,8 +111,8 @@ async function main () {
                 }
                 console.log('Arbimon Export job: uploading file to S3')
                 const { url, stats } = await saveFile(filePath, currentTime, rowData.project_id, fileName)
-                console.log('Arbimon Export job: file is accessible by url', url, 'stats', stats)
-                await sendRfmResultsEmail(rowData, url, stats)
+                console.log('Arbimon Export job: file is accessible by url', url, 'stats', stats, 'jobMeta', jobMeta)
+                await sendRfmResultsEmail(rowData, url, stats, jobMeta)
                 await updateExportRecordings(rowData, { processed_at: currentTime })
                 fs.unlink(filePath, () => {})
                 console.log(`Arbimon Export job finished: export recordings report for ${message}`)
@@ -492,15 +492,20 @@ async function processGroupedDetectionsStream (results, rowData, projection_para
 // Send the RFM (Random Forest Model) analysis-results export notification using
 // the shared @rfcx/notification-templates template (single source of truth for
 // the copy/branding), then dispatch via the notify gateway (Mandrill fallback).
-async function sendRfmResultsEmail (rowData, url, stats) {
+async function sendRfmResultsEmail (rowData, url, stats, jobMeta) {
     stats = stats || {}
+    jobMeta = jobMeta || {}
     const EXPIRY_DAYS = 7
-    const expiresAt = moment().add(EXPIRY_DAYS, 'days').format('MMMM D, YYYY [at] HH:mm')
+    // Expiry timestamp in UTC.
+    const expiresAt = moment.utc().add(EXPIRY_DAYS, 'days').format('MMMM D, YYYY [at] HH:mm [UTC]')
     const isGmail = (rowData.user_email || '').includes('gmail.com')
     const rendered = renderEmail('arbimon.exportAnalysisResultsRFM', {
         projectName: rowData.name,
         url,
         mode: isGmail ? 'button' : 'link',
+        jobId: jobMeta.jobId != null ? Number(jobMeta.jobId) : undefined,
+        jobName: jobMeta.jobName || undefined,
+        playlistName: jobMeta.playlistName || undefined,
         filename: stats.filename,
         rows: stats.rows,
         bytes: stats.bytes,

--- a/jobs/arbimon-recording-export-job/rfm-classification.js
+++ b/jobs/arbimon-recording-export-job/rfm-classification.js
@@ -3,13 +3,14 @@ const path = require('path')
 const fs = require('fs')
 const stream = require('stream');
 const csv_stringify = require('csv-stringify');
-const { getCsvData, getName } = require('../services/rfm-classify');
+const { getCsvData, getName, getJobMeta } = require('../services/rfm-classify');
 
 const exportReportType = 'RFM Classification';
 const exportReportJob = `Arbimon Export ${exportReportType} job`
 
 async function collectData (projection_parameters, cb) {
   const [res] = await getName(projection_parameters.rfmClassify)
+  const jobMeta = await getJobMeta(projection_parameters.rfmClassify).catch(() => null)
   const filePath = path.join(__dirname, `rfm_${res.name}.csv`)
   const targetFile = fs.createWriteStream(filePath, { flags: 'a' })
   await exportRFMClassify(projection_parameters.rfmClassify, targetFile, async (err, data) => {
@@ -20,7 +21,7 @@ async function collectData (projection_parameters, cb) {
     }
     console.log(`${exportReportJob}: finished collecting chunks`)
     targetFile.end()
-    cb(null, path.resolve(filePath), `rfm_${res.name}`)
+    cb(null, path.resolve(filePath), `rfm_${res.name}`, jobMeta)
   }).catch((e) => {
     console.err('Error export RFM Classification', e)
     cb(e)

--- a/jobs/services/rfm-classify.js
+++ b/jobs/services/rfm-classify.js
@@ -69,7 +69,20 @@ async function getName(cid) {
     return rows
 }
 
+// Job metadata for the notification email: numeric id, human-readable (raw) job
+// name, and the playlist the classification job ran against (if any).
+async function getJobMeta(cid) {
+    const connection = await mysql.getConnection()
+    const sql = `SELECT c.job_id AS jobId, c.name AS jobName, pl.name AS playlistName
+            FROM job_params_classification c
+            LEFT JOIN playlists pl ON pl.playlist_id = c.playlist_id
+            WHERE c.job_id = ${cid}`;
+    const [rows, fields] = await connection.execute(sql)
+    return rows && rows.length ? rows[0] : null
+}
+
 module.exports = {
     getCsvData,
-    getName
+    getName,
+    getJobMeta
 }

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.d.ts
@@ -14,6 +14,12 @@ export interface ArbimonExportAnalysisResultsRfmData {
     url: string;
     /** How to present the download (see ArbimonDownloadMode). Default 'button'. */
     mode?: ArbimonDownloadMode;
+    /** Numeric analysis job id. */
+    jobId?: number;
+    /** Human-readable analysis job name. */
+    jobName?: string;
+    /** Playlist name the job ran against (if available). */
+    playlistName?: string;
     /** Export filename, e.g. "rfm_phlebodes_rfm_mon_08.csv". */
     filename?: string;
     /** Number of data rows in the export (thousands-separated in the output). */
@@ -24,8 +30,8 @@ export interface ArbimonExportAnalysisResultsRfmData {
     expiryDays?: number;
     /**
      * Pre-formatted concrete expiry timestamp for the parenthetical, e.g.
-     * "July 22, 2026 at 12:16". The caller formats it (timezone-aware); the
-     * template stays IO/clock-free.
+     * "July 22, 2026 at 12:16 UTC". The caller formats it (UTC); the template
+     * stays IO/clock-free.
      */
     expiresAt?: string;
 }

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.js
@@ -21,6 +21,14 @@ function formatBytes(bytes) {
 }
 function statLines(data) {
     const lines = [];
+    // Job metadata first: Job ID / Job name / Playlist.
+    if (data.jobId != null && !isNaN(data.jobId))
+        lines.push(`Job ID: ${data.jobId}`);
+    if (data.jobName != null && data.jobName !== '')
+        lines.push(`Job name: ${data.jobName}`);
+    if (data.playlistName != null && data.playlistName !== '')
+        lines.push(`Playlist: ${data.playlistName}`);
+    // Then file metadata.
     if (data.filename != null && data.filename !== '')
         lines.push(`Filename: ${data.filename}`);
     if (data.rows != null && !isNaN(data.rows))


### PR DESCRIPTION
Per review: add job metadata to the RFM export email and format the expiry in UTC.

- New `getJobMeta()` (rfm-classify service) fetches numeric job id + raw job name + playlist name (`job_params_classification` LEFT JOIN `playlists`); threaded through `rfm-classification.collectData()`'s callback.
- `sendRfmResultsEmail` passes `jobId`/`jobName`/`playlistName` to the shared template (renders 'Job ID / Job name / Playlist' above Filename).
- Expiry timestamp now **UTC** (`moment.utc()` → '… at HH:mm UTC').
- Refreshed the vendored `@rfcx/notification-templates` dist to the version that renders the metadata block (rfcx/rfcx-notification-templates#3).

`node --check` clean; render verified from the vendored copy.