### PR TITLE
chore(export-job): re-vendor notification-templates (RFM email drops footer + 'Hello,')

### DIFF
--- a/jobs/vendor/rfcx-notification-templates/dist/layout.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/layout.d.ts
@@ -11,6 +11,8 @@ export interface LayoutOptions {
     bodyHtml: string;
     /** Brand controls header/footer wording and default from address. */
     brand?: Brand;
+    /** Render the shared RFCx footer (501c3 / social / address). Default true. */
+    footer?: boolean;
 }
 export declare function renderLayout(options: LayoutOptions): string;
 export declare const DEFAULT_FROM: Record<Brand, {

--- a/jobs/vendor/rfcx-notification-templates/dist/layout.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/layout.js
@@ -25,8 +25,39 @@ function socialCell(href, img) {
                   </td>`;
 }
 function renderLayout(options) {
-    const { bodyHtml } = options;
+    const { bodyHtml, footer = true } = options;
     const social = SOCIAL_LINKS.map(({ href, img }) => socialCell(href, img)).join('\n                  ');
+    const footerHtml = footer
+        ? `      <table cellpadding="0" cellspacing="0" width="100%" align="center" border="0" bgcolor="#ffffff" style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0;
+        padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>
+        <tfoot>
+          <tr>
+            <td valign="top" class="center" style="padding: 10px 0 10px;">
+              <hr style="border: 1px solid #828282; border-bottom: 0; margin: 0px;" />
+            </td>
+          </tr>
+          <tr>
+            <td valign="top" class="center" style='padding: 10px 10px; text-align: center; font-family: "Lato", sans-serif; font-size: 12px; color: #828282'>
+              Rainforest Connection is a 501<sub>(c)(3)</sub>
+            </td>
+          </tr>
+          <tr>
+            <td valign="top" class="center" style='padding: 15px 0;'>
+              <table cellpadding="0" cellspacing="0" width="200px" align="center" border="0" bgcolor="#ffffff">
+                <tr>
+                  ${social}
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td valign="top" class="center" style='padding: 10px 10px 20px; text-align: center; font-family: "Lato", sans-serif; font-size: 12px; color: #828282'>
+              77 Van Ness Ave, Suite 101-1717, San Francisco, CA, 94102, USA, +1 (415) 335-9205
+            </td>
+          </tr>
+        </tfoot>
+      </table>`
+        : '';
     return `<html>
   <head>
     <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&display=swap" rel="stylesheet">
@@ -57,35 +88,7 @@ ${bodyHtml}
           </td>
         </tr>
       </table>
-      <table cellpadding="0" cellspacing="0" width="100%" align="center" border="0" bgcolor="#ffffff" style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0;
-        padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>
-        <tfoot>
-          <tr>
-            <td valign="top" class="center" style="padding: 10px 0 10px;">
-              <hr style="border: 1px solid #828282; border-bottom: 0; margin: 0px;" />
-            </td>
-          </tr>
-          <tr>
-            <td valign="top" class="center" style='padding: 10px 10px; text-align: center; font-family: "Lato", sans-serif; font-size: 12px; color: #828282'>
-              Rainforest Connection is a 501<sub>(c)(3)</sub>
-            </td>
-          </tr>
-          <tr>
-            <td valign="top" class="center" style='padding: 15px 0;'>
-              <table cellpadding="0" cellspacing="0" width="200px" align="center" border="0" bgcolor="#ffffff">
-                <tr>
-                  ${social}
-                </tr>
-              </table>
-            </td>
-          </tr>
-          <tr>
-            <td valign="top" class="center" style='padding: 10px 10px 20px; text-align: center; font-family: "Lato", sans-serif; font-size: 12px; color: #828282'>
-              77 Van Ness Ave, Suite 101-1717, San Francisco, CA, 94102, USA, +1 (415) 335-9205
-            </td>
-          </tr>
-        </tfoot>
-      </table>
+${footerHtml}
     </center>
   </body>
 </html>`;

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.js
@@ -61,8 +61,7 @@ exports.arbimonExportAnalysisResultsRfm = {
     text: (data) => {
         const stats = statLines(data);
         const statsBlock = stats.length ? `\n${stats.join('\n')}\n` : '';
-        return (`Hello,\n\n` +
-            `Thanks so much for using Arbimon! Your export report for the project "${data.projectName}" is ready for download.\n\n` +
+        return (`Thanks so much for using Arbimon! Your export report for the project "${data.projectName}" is ready for download.\n\n` +
             `Download your export:\n${data.url}\n` +
             `${statsBlock}\n` +
             `${expiryClause(data)} If you have any questions about Arbimon, check out our support docs: https://help.arbimon.org/\n\n` +
@@ -73,8 +72,7 @@ exports.arbimonExportAnalysisResultsRfm = {
         const projectName = (0, escape_js_1.escapeHtml)(data.projectName);
         const url = (0, escape_js_1.safeUrl)(data.url);
         const mode = (_a = data.mode) !== null && _a !== void 0 ? _a : 'button';
-        const header = `              <p style="color:black;margin-top:0">Hello,</p>
-              <p style="color:black;">Thanks so much for using Arbimon! Your export report for the project "${projectName}" is ready for download.</p>`;
+        const header = `              <p style="color:black;margin-top:0">Thanks so much for using Arbimon! Your export report for the project "${projectName}" is ready for download.</p>`;
         const download = mode === 'button'
             ? `              <button style="background:#ADFF2C;border:1px solid #ADFF2C;padding:6px 14px;;border-radius:9999px;cursor:pointer;margin: 10px 0">
                   <a style="text-decoration:none;color:#14130D;white-space:nowrap;text-align:center;vertical-align:middle;align-items:center;display:inline-flex;display: -webkit-inline-flex;" download target="_self" href="${url}">
@@ -97,6 +95,6 @@ ${plainLink}
 ${statsHtml}
 ${expirySupport}
 ${footer}`;
-        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon' });
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon', footer: false });
     }
 };


### PR DESCRIPTION
Refresh the vendored `@rfcx/notification-templates` dist to the version that removes the 'Hello,' greeting and the shared 501(c)(3)/address footer from the RFM export email (rfcx/rfcx-notification-templates#4). No job code change; vendor dist only.