### PR TITLE
chore(export-job): re-vendor notification-templates (RFM email drops header banner)

### DIFF
--- a/jobs/vendor/rfcx-notification-templates/dist/layout.d.ts
+++ b/jobs/vendor/rfcx-notification-templates/dist/layout.d.ts
@@ -13,6 +13,8 @@ export interface LayoutOptions {
     brand?: Brand;
     /** Render the shared RFCx footer (501c3 / social / address). Default true. */
     footer?: boolean;
+    /** Render the shared RFCx header banner image. Default true. */
+    header?: boolean;
 }
 export declare function renderLayout(options: LayoutOptions): string;
 export declare const DEFAULT_FROM: Record<Brand, {

--- a/jobs/vendor/rfcx-notification-templates/dist/layout.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/layout.js
@@ -25,8 +25,22 @@ function socialCell(href, img) {
                   </td>`;
 }
 function renderLayout(options) {
-    const { bodyHtml, footer = true } = options;
+    const { bodyHtml, footer = true, header = true } = options;
     const social = SOCIAL_LINKS.map(({ href, img }) => socialCell(href, img)).join('\n                  ');
+    const headerHtml = header
+        ? `      <table cellpadding="0" cellspacing="0" width="100%" align="center" border="0" style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0;
+          padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>
+        <thead>
+          <tr>
+            <td style="padding: 0px;" align="center" valign="top">
+                <a style="display: block;" href="https://rfcx.org/">
+                  <img src="${HEADER_IMG}" width="600" alt="RFCx" border="0" style="-ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none;"/>
+                </a>
+            </td>
+          </tr>
+        </thead>
+      </table>`
+        : '';
     const footerHtml = footer
         ? `      <table cellpadding="0" cellspacing="0" width="100%" align="center" border="0" bgcolor="#ffffff" style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0;
         padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>
@@ -65,18 +79,7 @@ function renderLayout(options) {
   </head>
   <body>
     <center>
-      <table cellpadding="0" cellspacing="0" width="100%" align="center" border="0" style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0;
-          padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>
-        <thead>
-          <tr>
-            <td style="padding: 0px;" align="center" valign="top">
-                <a style="display: block;" href="https://rfcx.org/">
-                  <img src="${HEADER_IMG}" width="600" alt="RFCx" border="0" style="-ms-interpolation-mode: bicubic; border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none;"/>
-                </a>
-            </td>
-          </tr>
-        </thead>
-      </table>
+${headerHtml}
       <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" id="bodyTable" bgcolor="#ffffff"
         style='width: 600px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;
                 margin: 0; padding: 0; font-family: "Lato", sans-serif; border-collapse: collapse !important;'>

--- a/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.js
+++ b/jobs/vendor/rfcx-notification-templates/dist/templates/arbimon-export-analysis-results-rfm.js
@@ -95,6 +95,6 @@ ${plainLink}
 ${statsHtml}
 ${expirySupport}
 ${footer}`;
-        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon', footer: false });
+        return (0, layout_js_1.renderLayout)({ bodyHtml: body, brand: 'arbimon', footer: false, header: false });
     }
 };


### PR DESCRIPTION
Refresh the vendored `@rfcx/notification-templates` dist to the version that removes the RFCx header banner image from the RFM export email (rfcx/rfcx-notification-templates#5). Vendor dist only; no job code change.