### PR TITLE
fix(export-job): stop PM export path from wedging the export queue (poison row)

### DIFF
--- a/jobs/arbimon-recording-export-job/index.js
+++ b/jobs/arbimon-recording-export-job/index.js
@@ -121,25 +121,50 @@ async function main () {
         })
     } else if (projection_parameters && (projection_parameters.pmAll || projection_parameters.pmIds)) {
         //----------------Arbimon export all project PM jobs----------------
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             const exportReportType = 'Pattern Matchings';
             console.log(`Arbimon Export ${exportReportType} job`)
             patternMatching.collectData(filters, projection_parameters, async (err, fileName) => {
+                // Mirror the RFM path: on ANY failure, RECORD the error on the
+                // row and resolve so the serial queue advances. The old code
+                // ignored `err` entirely, so a failed PM export (e.g. the
+                // historical _pattern_matching.csv ENOENT) crashed the process
+                // before the row's `error` was set -> the same poison row was
+                // re-picked every 5 min and wedged the WHOLE export queue.
                 let reportName
-                if (fileName !== null) { reportName = fileName }
-                else { reportName = 'pattern-matching_export' }
-                const zipPath = __dirname + `/${reportName}.zip`
-                const bucketFormatted = S3_EXPORT_BUCKET_ARBIMON.split('/')[0]
-                const s3filePath = await uploadFileToS3(bucketFormatted, zipPath, rowData.project_id, currentTime, reportName, '.zip')
-                console.log('--s3filePath', s3filePath, 'reportName', reportName, 'fileName', fileName)
-                const url = await getDownloadUrl({ Bucket: bucketFormatted, Key: s3filePath, filename: `${reportName}.zip`, contentType: 'application/zip' })
-                console.log('--signed url', url)
-                await sendEmail('Arbimon export', 'Arbimon export', rowData, url, true)
-                await updateExportRecordings(rowData, { processed_at: currentTime })
-                fs.rmSync(tmpFilePath, { recursive: true, force: true });
-                fs.rmSync(zipPath, { recursive: true, force: true });
-                console.log(`Arbimon Export ${exportReportType} job finished: ${message}`)
-                resolve()
+                let zipPath
+                try {
+                    if (err) { throw err }
+                    if (fileName !== null) { reportName = fileName }
+                    else { reportName = 'pattern-matching_export' }
+                    zipPath = __dirname + `/${reportName}.zip`
+                    const bucketFormatted = S3_EXPORT_BUCKET_ARBIMON.split('/')[0]
+                    const s3filePath = await uploadFileToS3(bucketFormatted, zipPath, rowData.project_id, currentTime, reportName, '.zip')
+                    console.log('--s3filePath', s3filePath, 'reportName', reportName, 'fileName', fileName)
+                    const url = await getDownloadUrl({ Bucket: bucketFormatted, Key: s3filePath, filename: `${reportName}.zip`, contentType: 'application/zip' })
+                    console.log('--signed url', url)
+                    await sendEmail('Arbimon export', 'Arbimon export', rowData, url, true)
+                    await updateExportRecordings(rowData, { processed_at: currentTime })
+                    console.log(`Arbimon Export ${exportReportType} job finished: ${message}`)
+                } catch (e) {
+                    console.error(`Arbimon Export ${exportReportType} job error`, e)
+                    await errorMessage(message, jobName)
+                    // updateExportRecordings interpolates the value inside a
+                    // single-quoted SQL literal WITHOUT escaping, so a stack
+                    // trace containing a quote/backslash/newline would break the
+                    // UPDATE and throw again. Sanitize to a safe single line.
+                    const raw = e instanceof Error ? (e.message || String(e)) : JSON.stringify(e)
+                    const errStr = String(raw).replace(/[\\']/g, ' ').replace(/\s+/g, ' ').slice(0, 2000)
+                    try {
+                        await updateExportRecordings(rowData, { error: errStr })
+                    } catch (uErr) {
+                        console.error('Failed to record export error on row', uErr)
+                    }
+                } finally {
+                    try { fs.rmSync(tmpFilePath, { recursive: true, force: true }) } catch (_) {}
+                    if (zipPath) { try { fs.rmSync(zipPath, { recursive: true, force: true }) } catch (_) {} }
+                    resolve()
+                }
             })
         })
     }   else if (projection_parameters && projection_parameters.projectTemplate) {

--- a/jobs/arbimon-recording-export-job/pattern-matching.js
+++ b/jobs/arbimon-recording-export-job/pattern-matching.js
@@ -20,34 +20,72 @@ const tmpFilePath = __dirname + '/tmpfilecache'
 const archive = archiver('zip', { zlib: { level: 9 }});
 let outputStreamFile
 
+// Wait until a WriteStream has actually flushed + closed its file descriptor
+// before anything tries to read the file back. createWriteStream opens the
+// file LAZILY/asynchronously, so a read issued immediately after .end() can
+// beat the open() and ENOENT. This helper is the fix for the historical
+// "_pattern_matching.csv ENOENT" crash (the file was written but a reader
+// raced ahead of the flush). Resolves on 'close'; rejects on stream 'error'.
+function endAndFlush (writeStream) {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const done = (err) => {
+      if (settled) return
+      settled = true
+      if (err) reject(err); else resolve()
+    }
+    writeStream.on('error', done)
+    writeStream.on('close', () => done())
+    writeStream.end()
+  })
+}
+
 async function collectData (filters, projection_parameters, cb) {
+  // Ensure the intermediate-CSV directory exists (belt-and-braces; the image
+  // Dockerfile also pre-creates it). Without it every createWriteStream ENOENTs.
+  try {
+    fs.mkdirSync(tmpFilePath, { recursive: true })
+  } catch (e) {
+    console.error(`${exportReportJob}: could not create tmp dir ${tmpFilePath}`, e)
+    return cb(e)
+  }
+
   outputStreamFile = fs.createWriteStream(__dirname + '/pattern-matching_export.zip');
+  // If the zip output stream itself errors, surface it (don't let it become an
+  // unhandled 'error' event that hard-crashes the process).
+  outputStreamFile.on('error', (err) => {
+    console.error(`${exportReportJob}: output zip stream error`, err)
+  })
 
   archive.pipe(outputStreamFile)
-  await exportAllPmJobs(filters.project_id, projection_parameters, async (err, data) => {
-    if (err) {
-      console.err('Error export PM', err)
-      return cb(err)
-    }
-    console.log(`${exportReportJob}: before finalizeArchive`)
-    await finalizeArchive()
-    console.log(`${exportReportJob}: after finalizeArchive`)
-    if (data !== null) {
-      try {
-        const newPath =  __dirname + `/${data}.zip`
-        await rename(__dirname + '/pattern-matching_export.zip', newPath)
-        if (!fs.existsSync(newPath)) {
-          console.info('Error renaming file', newPath)
-        }
-        cb(null, data)
-      } catch (e) {
-        console.err('Error renaming file', e)
+  try {
+    await exportAllPmJobs(filters.project_id, projection_parameters, async (err, data) => {
+      if (err) {
+        console.error('Error export PM', err)
+        return cb(err)
       }
-    } else cb(null, null);
-  }).catch((e) => {
-    console.err('Error export PM', e)
-    cb(e)
-  })
+      try {
+        console.log(`${exportReportJob}: before finalizeArchive`)
+        await finalizeArchive()
+        console.log(`${exportReportJob}: after finalizeArchive`)
+        if (data !== null) {
+          const newPath = __dirname + `/${data}.zip`
+          await rename(__dirname + '/pattern-matching_export.zip', newPath)
+          if (!fs.existsSync(newPath)) {
+            return cb(new Error(`Renamed export archive missing: ${newPath}`))
+          }
+          return cb(null, data)
+        }
+        return cb(null, null)
+      } catch (e) {
+        console.error('Error finalizing/renaming PM export archive', e)
+        return cb(e)
+      }
+    })
+  } catch (e) {
+    console.error('Error export PM', e)
+    return cb(e)
+  }
 }
 
 async function finalizeArchive () {
@@ -68,10 +106,18 @@ async function fileToZipDirectory (sourceFilePath, sourceFileName) {
   console.log('<- start fileToZipDirectory sourceFilePath', sourceFilePath)
   console.log('<- start fileToZipDirectory sourceFileName', sourceFileName)
   return new Promise((resolve, reject) => {
-    archive.append(fs.createReadStream(sourceFilePath)
-      .on('end', function() {console.log('<- 1. End fileToZipDirectory.', sourceFileName); resolve()})
-      .on('error', function(err) {console.log('<- 1. Error fileToZipDirectory.', sourceFileName, err); reject()})
-    , { name: sourceFileName })
+    const src = fs.createReadStream(sourceFilePath)
+    src
+      .on('end', function() { console.log('<- 1. End fileToZipDirectory.', sourceFileName); resolve() })
+      .on('error', function(err) {
+        // Was `reject()` with NO argument -> the process saw an
+        // UnhandledPromiseRejection with reason `undefined` and hard-crashed
+        // BEFORE the export row's `error` could be set (poison-row wedge).
+        // Always reject with a real Error.
+        console.log('<- 1. Error fileToZipDirectory.', sourceFileName, err)
+        reject(err instanceof Error ? err : new Error(`fileToZipDirectory failed for ${sourceFileName}: ${err}`))
+      })
+    archive.append(src, { name: sourceFileName })
   });
 }
 
@@ -87,6 +133,11 @@ async function exportAllPmJobs (projectId, projection_parameters, cb) {
       fileNameForOneJob = `pm_${nameToUrl(job.job_name)}_${job.job_id}`
       const filePath = path.join(tmpFilePath, fileName)
       const targetFile = fs.createWriteStream(filePath, { flags: 'a' })
+      targetFile.on('error', (err) => {
+        // Prevent a lazy-open ENOENT (or disk error) from becoming an
+        // unhandled 'error' event on the stream that crashes the process.
+        console.error('<- targetFile stream error', fileName, err)
+      })
       console.log('next PM job start:', fileName)
       const limit = 5000;
       let index = 0
@@ -108,12 +159,16 @@ async function exportAllPmJobs (projectId, projection_parameters, cb) {
         isFirstChunk = false
         index++
       }
-      targetFile.end()
+      // Flush + close the per-job CSV BEFORE zipping it, so the read stream in
+      // fileToZipDirectory can never race the write's lazy flush.
+      await endAndFlush(targetFile)
       console.log('PM job end:', fileName)
-      await fileToZipDirectory(filePath, fileName).then(() => {
+      await fileToZipDirectory(filePath, fileName)
+      await new Promise((resolve) => {
         fs.unlink(filePath, function(err){
-          if(err) return console.error('<- 2. error pm csv delete', fileName, err);
-          console.log('<- 2. pm csv deleted successfully', fileName);
+          if (err) console.error('<- 2. error pm csv delete', fileName, err);
+          else console.log('<- 2. pm csv deleted successfully', fileName);
+          resolve()
         })
       })
     }
@@ -121,8 +176,12 @@ async function exportAllPmJobs (projectId, projection_parameters, cb) {
       cb(null, fileNameForOneJob)
     } else cb(null, null)
   } catch (e) {
-    console.error(e)
-    cb(null, null)
+    // Propagate the real error so index.js records `error` on the row and the
+    // queue advances, instead of the old `cb(null, null)` which reported
+    // SUCCESS on failure (and, combined with the write-before-read race, left
+    // a broken/empty archive to be emailed).
+    console.error('Error in exportAllPmJobs', e)
+    cb(e)
   }
 }
 
@@ -130,7 +189,10 @@ async function exportAllPmJobsCsv (results) {
   const fileName = '_pattern_matching.csv';
   const filePath = path.join(tmpFilePath, fileName)
   const targetFileSummaryData = fs.createWriteStream(filePath, { flags: 'a' })
-  return new Promise(async function (resolve, reject) {
+  targetFileSummaryData.on('error', (err) => {
+    console.error('<- _pattern_matching.csv stream error', err)
+  })
+  return new Promise(function (resolve, reject) {
     let fields = [];
     results.forEach(result => {
         fields.push(...Object.keys(result).filter(f => !fields.includes(f)))
@@ -153,21 +215,29 @@ async function exportAllPmJobsCsv (results) {
       _buf.push(Object.values(d))
     })
 
-    datastream.on('end', async () => {
+    datastream.on('end', () => {
       csv_stringify(_buf, { header: true, columns: fields }, async (err, data) => {
-        if (err) {
-          reject(err)
-        }
-        targetFileSummaryData.write(data)
-        targetFileSummaryData.end()
-        const filePath = tmpFilePath + '/_pattern_matching.csv'
-        await fileToZipDirectory(filePath, fileName).then(() => {
-          fs.unlink(filePath, function(err) {
-            if (err) return console.error('<- 2. error targetFileSummaryData delete', fileName, err);
-            console.log('<- 2. targetFileSummaryData deleted successfully', fileName);
+        try {
+          if (err) return reject(err)
+          targetFileSummaryData.write(data)
+          // Flush + close BEFORE reading the file back to zip it. This is the
+          // core fix for the "_pattern_matching.csv ENOENT" crash: the old code
+          // called fileToZipDirectory() immediately after .end() and the read
+          // raced the write's lazy flush (worked on fast disks, ENOENT'd in the
+          // container).
+          await endAndFlush(targetFileSummaryData)
+          await fileToZipDirectory(filePath, fileName)
+          await new Promise((res) => {
+            fs.unlink(filePath, function(uErr) {
+              if (uErr) console.error('<- 2. error targetFileSummaryData delete', fileName, uErr);
+              else console.log('<- 2. targetFileSummaryData deleted successfully', fileName);
+              res()
+            })
           })
-        })
-        resolve()
+          resolve()
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
       })
     })
   })
@@ -175,6 +245,7 @@ async function exportAllPmJobsCsv (results) {
 
 async function writeChunk (results, targetFile, projectSites, isFirstChunk) {
   return new Promise(async function (resolve, reject) {
+    try {
       let fields = [];
       results.forEach(result => {
           fields.push(...Object.keys(result).filter(f => !fields.includes(f)))
@@ -196,12 +267,16 @@ async function writeChunk (results, targetFile, projectSites, isFirstChunk) {
             result[f] = '---'}
           }
         )
-        const recUrl = recs.filter(r => r.recording_id === result.recording_id)[0].uri;
-        const url = await getSignedUrl({
-          Bucket: isLegacy(recUrl) ? S3_LEGACY_BUCKET_ARBIMON : S3_RFCX_BUCKET_ARBIMON,
-          Key: recUrl,
-          isLegacy: isLegacy(recUrl)
-        });
+        const rec = recs.filter(r => r.recording_id === result.recording_id)[0]
+        const recUrl = rec ? rec.uri : null;
+        let url = '---'
+        if (recUrl) {
+          url = await getSignedUrl({
+            Bucket: isLegacy(recUrl) ? S3_LEGACY_BUCKET_ARBIMON : S3_RFCX_BUCKET_ARBIMON,
+            Key: recUrl,
+            isLegacy: isLegacy(recUrl)
+          });
+        }
         result.audio_url = url;
         _buf.push(result);
       }
@@ -213,20 +288,22 @@ async function writeChunk (results, targetFile, projectSites, isFirstChunk) {
       }
       datastream.push(null);
 
-      datastream.on('end', async () => {
+      datastream.on('end', () => {
         csv_stringify(_buf, { header: isFirstChunk, columns: fields }, async (err, data) => {
           if (err) {
-            reject(err)
+            return reject(err instanceof Error ? err : new Error(String(err)))
           }
           console.log('targetFile write', _buf.length)
           targetFile.write(data);
           return resolve();
         })
       })
+    } catch (e) {
+      reject(e instanceof Error ? e : new Error(String(e)))
+    }
   })
 }
 
 module.exports = {
   collectData
 }
-

--- a/jobs/arbimon-recording-export-job/pattern-matching.js
+++ b/jobs/arbimon-recording-export-job/pattern-matching.js
@@ -28,6 +28,9 @@ let outputStreamFile
 // raced ahead of the flush). Resolves on 'close'; rejects on stream 'error'.
 function endAndFlush (writeStream) {
   return new Promise((resolve, reject) => {
+    // Guard: if the stream is already closed, resolve immediately (a 'close'
+    // that already fired would otherwise never re-fire and this would hang).
+    if (writeStream.closed || writeStream.destroyed) return resolve()
     let settled = false
     const done = (err) => {
       if (settled) return
@@ -36,6 +39,12 @@ function endAndFlush (writeStream) {
     }
     writeStream.on('error', done)
     writeStream.on('close', () => done())
+    writeStream.on('finish', () => {
+      // 'finish' fires when all data is flushed to the OS. If the stream
+      // doesn't emit 'close' (emitClose disabled), fall back to it so we
+      // never hang; the fd is flushed by this point.
+      if (!writeStream.emitClose) done()
+    })
     writeStream.end()
   })
 }


### PR DESCRIPTION
## Problem

The Arbimon "Download Results" export job's **pattern-matching path**
(`pmAll` / `pmIds`) crashed the whole process before it could record `error`
on its `recordings_export_parameters` row. Because the dispatch is a serial
`... LIMIT 1 WHERE processed_at IS NULL AND error IS NULL` cron, that broken
row got **re-picked every 5 minutes and wedged the entire export queue** (this
actually happened 2026-07-15; last successful export was 2026-05-04).

Observed live crash (newest image, `_pattern_matching.csv` ENOENT →
`ERR_UNHANDLED_REJECTION`) confirmed from production Loki logs of the
`export-test3` pod.

## Root causes fixed

1. **Write-before-read race (the ENOENT).** `exportAllPmJobsCsv` wrote
   `_pattern_matching.csv` then *immediately* read it back to zip it.
   `createWriteStream` flushes lazily, so the read raced the flush and ENOENT'd.
   It won on fast disks (why RFM worked and local runs passed) but lost in the
   container. **Fix:** await an explicit flush+close (`endAndFlush`) before any
   read — for the summary CSV and each per-job CSV.
2. **`reject()` with no argument** in `fileToZipDirectory`'s read-stream error
   handler → `UnhandledPromiseRejection` with reason `undefined` → hard crash.
   Now rejects with a real `Error`.
3. **`console.err(...)` ×3 is not a function** → the `.catch` handlers *themselves*
   threw `TypeError` (a second unhandled rejection). Fixed to `console.error`.
4. **`exportAllPmJobs` swallowed failures** with `cb(null, null)` (reported
   SUCCESS on failure). Now propagates the real error via `cb(err)`.
5. **`index.js` `pmAll`/`pmIds` branch ignored `err`** and never called
   `updateExportRecordings({error})`. Now mirrors the RFM path: on any failure
   it records the error on the row (**SQL-sanitized** so a stack trace can't
   break the unescaped UPDATE and re-crash) and resolves so the queue advances.

Also hardened: `mkdir -p tmpfilecache` in `collectData`; stream `'error'`
listeners so a lazy-open ENOENT can't become a fatal unhandled `'error'` event;
a missing-recording guard in `writeChunk`.

## Testing (no real users emailed)

Verified in a `node:18.14.0` container against the real code paths (DB/S3/email
stubbed):
- **Happy path** zips cleanly, no CSV interleave, callback success.
- **Forced `getPmRois` failure** now returns via the callback (`err-path`,
  exit 0) instead of crashing → in `index.js` this records `error` and the
  queue advances.
- **Previously-fatal missing-tmpdir** case now self-heals.

The live CronJob (`apps-prod/arbimon-recording-export-job`) stays **`suspend:
true`**; unsuspend + backlog drain remain operator-gated (they email real users).
Part of rfcx-local OPEN-ITEMS #64.
