### PR TITLE
feat(mysql2pg-p6): dbpool-pg adapter + shadow-read mode (DB_ENGINE gate, ships inert)

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -1,0 +1,561 @@
+'use strict';
+/**
+ * DBPOOL-PG — PostgreSQL adapter + shadow-read engine for the mysql2pg
+ * migration (rfcx-local OPEN-ITEMS #40, migration plan Phase 6).
+ *
+ * THREE engine modes, selected by env `DB_ENGINE` (default `mysql`):
+ *
+ *   mysql   (default) — this module is INERT. dbpool.js does not call it.
+ *                       Ships safe: zero behavior change, one boolean check.
+ *   shadow           — MariaDB stays authoritative and serves EVERY user
+ *                       response. Read-only statements are ALSO replayed
+ *                       asynchronously on the PG `arbimon` copy, the two
+ *                       results normalized+diffed, and mismatches emitted
+ *                       as structured `DBPOOL_SHADOW_DIVERGENCE` log lines
+ *                       (promtail -> Loki, same lane as the P3 tap).
+ *                       Replay is fire-and-forget with a concurrency cap +
+ *                       per-statement timeout: a PG error, slowness, or
+ *                       outage can NEVER affect the user response.
+ *   pg               — (Phase 6.4, operator-gated, NOT this session) route
+ *                       SELECTs to PG for the response. Scaffolded here but
+ *                       the response-routing path is intentionally left as
+ *                       an explicit throw so it cannot be enabled by accident.
+ *
+ * SAFETY MODEL (mirrors the P3 replay harness, data-stores/arbimon-pg/replay/):
+ *   - Only statements the allowlist classifier POSITIVELY identifies as
+ *     plain read-only SELECTs are ever sent to PG. Everything else is
+ *     skipped (logged-only). This is an allowlist, not a denylist.
+ *   - Defense in depth: the PG connection uses the read-only role
+ *     (arbimon_ro) inside a `default_transaction_read_only=on` session, so
+ *     even a misclassified statement physically cannot mutate PG.
+ *   - The shadow path NEVER runs inside the app's request promise chain;
+ *     it is scheduled after the MariaDB result is already handed back.
+ *
+ * Controls (env):
+ *   DB_ENGINE=mysql|shadow|pg          engine mode (default mysql)
+ *   DB_SHADOW_SAMPLE=1.0               fraction of read stmts to shadow (0..1)
+ *   DB_SHADOW_MAX_INFLIGHT=8           concurrency cap for PG replays
+ *   DB_SHADOW_TIMEOUT_MS=8000          per-statement PG statement_timeout
+ *   DB_SHADOW_MAX_DIFF_ROWS=2000       skip diffing above this row count
+ *   PG_SHADOW_HOST / PG_SHADOW_PORT / PG_SHADOW_USER / PG_SHADOW_PASSWORD /
+ *   PG_SHADOW_DATABASE                 PG target (defaults below)
+ *
+ * The translator + classifier + normalizer are deliberately a JS port of
+ * the Python P3 harness so shadow findings match the offline baseline. The
+ * translator handles the measured hot spots; anything it does not yet cover
+ * surfaces as a `dialect_error` divergence — which IS the Phase-6 work queue.
+ */
+
+var crypto = require('crypto');
+
+// -------------------------------------------------------------- config
+
+var ENGINE = (process.env.DB_ENGINE || 'mysql').toLowerCase();
+var ENABLED = ENGINE === 'shadow' || ENGINE === 'pg';
+
+function numEnv(name, def) {
+    var v = parseFloat(process.env[name]);
+    return isNaN(v) ? def : v;
+}
+
+var SAMPLE = numEnv('DB_SHADOW_SAMPLE', 1.0);
+if (SAMPLE < 0) { SAMPLE = 0; }
+if (SAMPLE > 1) { SAMPLE = 1; }
+var MAX_INFLIGHT = numEnv('DB_SHADOW_MAX_INFLIGHT', 8);
+var TIMEOUT_MS = numEnv('DB_SHADOW_TIMEOUT_MS', 8000);
+var MAX_DIFF_ROWS = numEnv('DB_SHADOW_MAX_DIFF_ROWS', 2000);
+var DIV_PREFIX = 'DBPOOL_SHADOW_DIVERGENCE ';
+var STAT_PREFIX = 'DBPOOL_SHADOW_STAT ';
+
+function pgConf() {
+    return {
+        host: process.env.PG_SHADOW_HOST || 'arbimon-pgbouncer.data.svc.cluster.local',
+        port: parseInt(process.env.PG_SHADOW_PORT || '6432', 10),
+        user: process.env.PG_SHADOW_USER || 'arbimon_ro',
+        password: process.env.PG_SHADOW_PASSWORD || '',
+        database: process.env.PG_SHADOW_DATABASE || 'arbimon',
+        // Keep the shadow pool small: it is a background verifier, not the
+        // request path. max<=MAX_INFLIGHT so we never queue behind the cap.
+        max: Math.max(2, Math.min(MAX_INFLIGHT, 10)),
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+        // pgbouncer is transaction-pooled; disable pg's own keepalive probes
+        // that can trip pooled servers.
+        keepAlive: false
+    };
+}
+
+// ---------------------------------------------------- allowlist classifier
+// JS port of data-stores/arbimon-pg/replay/classify.py. A statement is
+// REPLAYABLE only if it is provably a single plain read-only SELECT.
+
+var FORBIDDEN_KEYWORDS = (function () {
+    var s = {};
+    ('insert update delete replace merge upsert create alter drop truncate ' +
+     'rename grant revoke set call execute prepare deallocate handler do kill ' +
+     'load outfile dumpfile infile lock unlock begin commit rollback savepoint ' +
+     'release start xa explain analyze analyse describe show use install ' +
+     'uninstall shutdown reset purge change stop slave flush optimize repair ' +
+     'checksum check backup restore into for returning').split(/\s+/)
+        .forEach(function (w) { s[w] = true; });
+    return s;
+})();
+
+var FORBIDDEN_FUNCTIONS = (function () {
+    var s = {};
+    ('get_lock release_lock release_all_locks is_free_lock is_used_lock sleep ' +
+     'benchmark master_pos_wait master_gtid_wait last_insert_id row_count ' +
+     'found_rows rand random uuid uuid_short sys_guid now curdate curtime ' +
+     'sysdate current_timestamp current_date current_time unix_timestamp ' +
+     'utc_date utc_time utc_timestamp connection_id current_user session_user ' +
+     'system_user user database version').split(/\s+/)
+        .forEach(function (w) { s[w] = true; });
+    return s;
+})();
+
+var _STRING_RE = /'(?:[^'\\]|\\.|'')*'|"(?:[^"\\]|\\.|"")*"|`(?:[^`]|``)*`/g;
+var _LINE_COMMENT_RE = /--[^\n]*|#[^\n]*/g;
+var _BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g;
+var _WORD_RE = /[a-zA-Z_][a-zA-Z0-9_]*/g;
+
+function neutralize(sql) {
+    var s = sql.replace(_STRING_RE, ' _LIT_ ');
+    s = s.replace(_BLOCK_COMMENT_RE, ' ');
+    s = s.replace(_LINE_COMMENT_RE, ' ');
+    return s;
+}
+
+// verdict.replayable === true only for a provably-plain read-only SELECT.
+function classify(sql) {
+    if (!sql || typeof sql !== 'string') { return { replayable: false, reason: 'empty/non-string' }; }
+    if (sql.indexOf('\u0000') !== -1) { return { replayable: false, reason: 'NUL byte' }; }
+    var neutral = neutralize(sql);
+    if (/['"`]/.test(neutral)) { return { replayable: false, reason: 'unbalanced quote/identifier' }; }
+    var body = neutral.trim();
+    if (!body) { return { replayable: false, reason: 'empty after neutralize' }; }
+    if (body.charAt(body.length - 1) === ';') { body = body.slice(0, -1); }
+    if (body.indexOf(';') !== -1) { return { replayable: false, reason: 'multi-statement' }; }
+    var words = (body.match(_WORD_RE) || []).map(function (w) { return w.toLowerCase(); });
+    if (!words.length) { return { replayable: false, reason: 'no tokens' }; }
+    var first = words[0];
+    if (first === 'with') {
+        if (words.indexOf('select') === -1) { return { replayable: false, reason: 'WITH without SELECT' }; }
+    } else if (first !== 'select') {
+        return { replayable: false, reason: 'first keyword ' + first };
+    }
+    for (var i = 0; i < words.length; i++) {
+        if (FORBIDDEN_KEYWORDS[words[i]]) { return { replayable: false, reason: 'forbidden keyword ' + words[i] }; }
+    }
+    var m;
+    _WORD_RE.lastIndex = 0;
+    while ((m = _WORD_RE.exec(body)) !== null) {
+        var w = m[0].toLowerCase();
+        if (FORBIDDEN_FUNCTIONS[w]) {
+            var rest = body.slice(m.index + m[0].length).replace(/^\s+/, '');
+            if (rest.charAt(0) === '(') { return { replayable: false, reason: 'forbidden function ' + w + '()' }; }
+        }
+    }
+    if (body.indexOf('@') !== -1) { return { replayable: false, reason: 'user/system variable' }; }
+    return { replayable: true, reason: 'plain SELECT' };
+}
+
+// --------------------------------------------------- SQL template + hash
+// JS port of sql_template()/template_hash() — buckets divergences so ~400
+// call sites collapse to ~100-150 templates (same keying as the P3 report).
+
+function sqlTemplate(sql) {
+    var s = sql.replace(_STRING_RE, '?');
+    s = s.replace(_BLOCK_COMMENT_RE, ' ');
+    s = s.replace(_LINE_COMMENT_RE, ' ');
+    s = s.replace(/(^|[^a-zA-Z0-9_.])-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/g, '$1?');
+    s = s.replace(/\(\s*\?(?:\s*,\s*\?)*\s*\)/g, '(?)');
+    s = s.replace(/\s+/g, ' ').trim();
+    return s;
+}
+
+function templateHash(sql) {
+    return crypto.createHash('sha1').update(sqlTemplate(sql).toLowerCase()).digest('hex').slice(0, 16);
+}
+
+// ------------------------------------------------------ MySQL -> PG translator
+// First-pass dialect translation for the measured hot spots. Anything not
+// covered here surfaces as a `dialect_error` divergence = the Phase-6 queue.
+// Runs on the FINAL literal-bearing SQL (mysql.format already applied), so
+// string/backtick literals must be protected before rewriting keywords.
+
+// PG-reserved words that, when they appear as a backtick identifier, must be
+// double-quoted (dropping backticks would produce a syntax error). Everything
+// else drops backticks so PG folds to lowercase (matches the T14 lowercased
+// DDL, and lets camelCase columns like `projectId` resolve).
+var PG_RESERVED_IDENT = (function () {
+    var s = {};
+    ('order group user select from where limit offset desc asc default check ' +
+     'primary references table column constraint using natural join on and or ' +
+     'not null true false case when then else end all any some union except ' +
+     'intersect distinct as in is like between').split(/\s+/)
+        .forEach(function (w) { s[w] = true; });
+    return s;
+})();
+
+function protectLiterals(sql, store) {
+    // Replace '...' and "..." string literals with placeholders so keyword
+    // rewriting cannot touch their contents. Backticks handled separately.
+    return sql.replace(/'(?:[^'\\]|\\.|'')*'|"(?:[^"\\]|\\.|"")*"/g, function (lit) {
+        var key = '\u0001L' + store.length + '\u0001';
+        store.push(lit);
+        return key;
+    });
+}
+
+function restoreLiterals(sql, store) {
+    return sql.replace(/\u0001L(\d+)\u0001/g, function (_, n) { return store[parseInt(n, 10)]; });
+}
+
+function translateBackticks(sql) {
+    return sql.replace(/`([^`]+)`/g, function (_, ident) {
+        var low = ident.toLowerCase();
+        if (PG_RESERVED_IDENT[low]) { return '"' + low + '"'; }
+        // drop backticks; PG folds unquoted to lowercase (T14)
+        return ident;
+    });
+}
+
+// LIMIT offset, count  ->  LIMIT count OFFSET offset
+function translateLimitOffset(sql) {
+    return sql.replace(/\blimit\s+(\d+)\s*,\s*(\d+)/gi, function (_, off, cnt) {
+        return 'LIMIT ' + cnt + ' OFFSET ' + off;
+    });
+}
+
+// A small set of scalar-function / operator rewrites that appear in the
+// measured hot spots. Deliberately conservative — only unambiguous ones.
+function translateFunctions(sql) {
+    var s = sql;
+    // MySQL string concat via CONCAT() is identical in PG; the `||` operator
+    // is logical-OR in MySQL only under PIPES_AS_CONCAT (not set here) so no
+    // rewrite needed. RAND()/NOW() are classifier-forbidden so never arrive.
+    // IFNULL(a,b) -> COALESCE(a,b)
+    s = s.replace(/\bIFNULL\s*\(/gi, 'COALESCE(');
+    // MySQL `= ` on tinyint boolean is fine (smallint per T2). No rewrite.
+    return s;
+}
+
+function translate(mysqlSql) {
+    var store = [];
+    var s = protectLiterals(mysqlSql, store);
+    s = translateBackticks(s);
+    s = translateLimitOffset(s);
+    s = translateFunctions(s);
+    s = restoreLiterals(s, store);
+    return s;
+}
+
+// ------------------------------------------------------------- normalizer
+// JS port of replay.py canon_value/normalize_result/compare. Turns two raw
+// result sets into a comparable canonical form and classifies any diff.
+
+var _ORDER_BY_RE = /\border\s+by\b/i;
+function hasOrderBy(sql) { return _ORDER_BY_RE.test(sql); }
+
+function canonValue(v, epsilon) {
+    if (v === null || v === undefined) { return 'null'; }
+    if (typeof v === 'boolean') { return 'num:' + (v ? 1 : 0); }
+    if (typeof v === 'number') {
+        if (Number.isInteger(v)) { return 'num:' + v; }
+        if (epsilon > 0) {
+            if (v === 0) { return 'num:0'; }
+            var q = Math.round(v / epsilon) * epsilon;
+            if (Number.isInteger(q)) { return 'num:' + q; }
+            return 'num:' + q;
+        }
+        return 'num:' + v;
+    }
+    if (typeof v === 'bigint') { return 'num:' + v.toString(); }
+    if (Buffer.isBuffer(v)) {
+        var asStr = v.toString('utf8');
+        // if it round-trips as utf8 use str, else hex
+        if (Buffer.compare(Buffer.from(asStr, 'utf8'), v) === 0) { return 'str:' + asStr; }
+        return 'bytes:' + v.toString('hex');
+    }
+    if (v instanceof Date) { return 'dt:' + v.toISOString(); }
+    if (typeof v === 'object') {
+        // arrays (pg text[]), json — canonicalize deterministically
+        try { return 'json:' + JSON.stringify(v); } catch (e) { return 'str:' + String(v); }
+    }
+    // Decimal-as-string (pg numeric) and everything else: bridge numeric strings
+    if (typeof v === 'string' && /^-?\d+(\.\d+)?$/.test(v)) {
+        var f = parseFloat(v);
+        if (Number.isInteger(f)) { return 'num:' + f; }
+        return 'num:' + f;
+    }
+    return 'str:' + String(v);
+}
+
+function normalizeRows(rows, epsilon, sortRows) {
+    // rows: array of plain objects (both mysql + pg drivers return objects).
+    // Canonicalize column names (lowercase) and cell values; sort rows if
+    // the query has no ORDER BY.
+    var out = rows.map(function (r) {
+        var keys = Object.keys(r).map(function (k) { return k.toLowerCase(); });
+        keys.sort();
+        var cells = keys.map(function (k) {
+            // find original key case-insensitively
+            var ok = k;
+            if (!(k in r)) {
+                var found = Object.keys(r).filter(function (x) { return x.toLowerCase() === k; })[0];
+                ok = found !== undefined ? found : k;
+            }
+            return k + '=' + canonValue(r[ok], epsilon);
+        });
+        return cells.join('\u0002');
+    });
+    if (sortRows) { out.sort(); }
+    return out;
+}
+
+function colSet(rows) {
+    if (!rows.length) { return []; }
+    return Object.keys(rows[0]).map(function (k) { return k.toLowerCase(); }).sort();
+}
+
+// returns {klass, detail} or null when equal
+function compare(sql, rowsA, rowsB, epsilon) {
+    var ordered = hasOrderBy(sql);
+    var ca = colSet(rowsA), cb = colSet(rowsB);
+    // column sets only comparable when both non-empty; empty-vs-empty is equal
+    if (rowsA.length && rowsB.length && ca.join(',') !== cb.join(',')) {
+        return { klass: 'result_mismatch', detail: 'column sets differ: [' + ca + '] vs [' + cb + ']' };
+    }
+    var na = normalizeRows(rowsA, epsilon, !ordered);
+    var nb = normalizeRows(rowsB, epsilon, !ordered);
+    if (na.length !== nb.length) {
+        return { klass: 'result_mismatch', detail: 'row counts differ: ' + na.length + ' vs ' + nb.length };
+    }
+    var equal = true;
+    for (var i = 0; i < na.length; i++) { if (na[i] !== nb[i]) { equal = false; break; } }
+    if (equal) { return null; }
+    if (ordered) {
+        var sa = na.slice().sort(), sb = nb.slice().sort();
+        var multisetEqual = true;
+        for (var j = 0; j < sa.length; j++) { if (sa[j] !== sb[j]) { multisetEqual = false; break; } }
+        if (multisetEqual) {
+            // Same multiset, order differs. Second chance: if the two results
+            // are IN-ORDER equal after casefolding, the only difference is a
+            // ci-collation vs byte ORDER BY (equal). Otherwise it is a genuine
+            // ordering divergence. (Compare original order, NOT sorted.)
+            if (casefoldEqual(na, nb)) { return null; }
+            return { klass: 'ordering_only', detail: 'same rows, different ORDER BY order' };
+        }
+    }
+    if (casefoldEqual(na.slice().sort(), nb.slice().sort())) {
+        return { klass: 'result_mismatch', detail: 'differs only by string case (ci-collation)' };
+    }
+    return { klass: 'result_mismatch', detail: 'row sets differ' };
+}
+
+function casefoldEqual(a, b) {
+    if (a.length !== b.length) { return false; }
+    for (var i = 0; i < a.length; i++) {
+        if (a[i].toLowerCase() !== b[i].toLowerCase()) { return false; }
+    }
+    return true;
+}
+
+// ------------------------------------------------------------ pg pool (lazy)
+
+var _pool = null;
+var _poolFailed = false;
+
+function getPool() {
+    if (_poolFailed) { return null; }
+    if (_pool) { return _pool; }
+    try {
+        var pglib = require('pg'); // lazy: never required in mysql (inert) mode
+        // CRITICAL dialect parity: the app's mysql driver runs timezone:'Z',
+        // so MariaDB `datetime` (naive) parses as UTC. node-postgres parses
+        // `timestamp without time zone` (OID 1114) in PROCESS-LOCAL time,
+        // which skews every datetime by the host UTC offset (measured +4h on
+        // EDT — the first live e2e finding). Parse 1114 as UTC to match.
+        pglib.types.setTypeParser(1114, function (str) {
+            return str === null ? null : new Date(str.replace(' ', 'T') + 'Z');
+        });
+        var Pool = pglib.Pool;
+        _pool = new Pool(pgConf());
+        _pool.on('error', function (err) {
+            // Background idle-client errors must never crash the app.
+            emitStat({ ev: 'pool_error', err: String(err && err.message || err).slice(0, 200) });
+        });
+        return _pool;
+    } catch (e) {
+        _poolFailed = true;
+        emitStat({ ev: 'pool_init_failed', err: String(e && e.message || e).slice(0, 200) });
+        return null;
+    }
+}
+
+// ------------------------------------------------------------ emit helpers
+
+function emit(prefix, obj) {
+    try { process.stdout.write(prefix + JSON.stringify(obj) + '\n'); } catch (e) { /* never break app */ }
+}
+function emitDivergence(obj) { emit(DIV_PREFIX, obj); }
+function emitStat(obj) { emit(STAT_PREFIX, obj); }
+
+// ------------------------------------------------------------ shadow engine
+
+var _inflight = 0;
+var _counters = { seen: 0, sampled: 0, replayed: 0, skipped_class: 0, dropped_cap: 0,
+                  diff: 0, dialect_error: 0, ok: 0, pg_error: 0, pg_timeout: 0,
+                  emit_capped: 0 };
+
+// Per-template divergence emit cap: full detail for the first N occurrences
+// of a template per window, then counters only (the heartbeat still carries
+// totals, so recurrence is never hidden — only the log volume is bounded).
+var EMIT_CAP_PER_TEMPLATE = numEnv('DB_SHADOW_EMIT_CAP', 5);
+var EMIT_CAP_WINDOW_MS = numEnv('DB_SHADOW_EMIT_WINDOW_MS', 600000); // 10 min
+var _emitCounts = {};   // hash -> count in current window
+var _emitWindowStart = Date.now();
+
+function divergenceEmitAllowed(hash) {
+    var now = Date.now();
+    if (now - _emitWindowStart > EMIT_CAP_WINDOW_MS) {
+        _emitCounts = {};
+        _emitWindowStart = now;
+    }
+    var c = (_emitCounts[hash] || 0) + 1;
+    _emitCounts[hash] = c;
+    if (c > EMIT_CAP_PER_TEMPLATE) { _counters.emit_capped++; return false; }
+    return true;
+}
+
+function sqlText(sql) {
+    if (typeof sql === 'string') { return sql; }
+    if (sql && typeof sql.sql === 'string') { return sql.sql; }
+    return String(sql);
+}
+
+/**
+ * Called by dbpool.js after a MariaDB read query completes (callback form).
+ * FIRE-AND-FORGET: this function returns immediately; all PG work happens on
+ * later ticks and its result only ever produces a log line.
+ *
+ * @param finalSql  the FINAL literal-bearing MySQL SQL (mysql.format applied)
+ * @param mariaRows the rows MariaDB returned (array) — the authoritative side
+ * @param meta      { caller } optional
+ */
+function shadowAfterRead(finalSql, mariaRows, meta) {
+    if (ENGINE !== 'shadow') { return; }
+    if (!Array.isArray(mariaRows)) { return; } // OkPacket (write) or stream — skip
+    _counters.seen++;
+    if (SAMPLE < 1 && Math.random() >= SAMPLE) { return; }
+    _counters.sampled++;
+    var text = sqlText(finalSql);
+    var verdict = classify(text);
+    if (!verdict.replayable) { _counters.skipped_class++; return; }
+    if (_inflight >= MAX_INFLIGHT) { _counters.dropped_cap++; return; }
+    var pool = getPool();
+    if (!pool) { return; }
+    // Snapshot the MariaDB rows cheaply — they are plain objects already.
+    // Cap the diff work for pathologically large results.
+    if (mariaRows.length > MAX_DIFF_ROWS) { return; }
+
+    _inflight++;
+    _counters.replayed++;
+    var pgSql;
+    try { pgSql = translate(text); } catch (e) {
+        _inflight--; _counters.dialect_error++;
+        emitDivergence({ v: 1, ts: new Date().toISOString(), klass: 'dialect_error',
+            phase: 'translate', hash: templateHash(text), tmpl: sqlTemplate(text).slice(0, 400),
+            detail: String(e && e.message || e).slice(0, 200), caller: meta && meta.caller });
+        return;
+    }
+
+    var done = false;
+    var finish = function () { if (!done) { done = true; _inflight--; } };
+
+    pool.connect(function (err, client, release) {
+        if (err) {
+            finish(); _counters.pg_error++;
+            emitStat({ ev: 'connect_error', err: String(err && err.message || err).slice(0, 200) });
+            return;
+        }
+        // pgbouncer is transaction-pooled: wrap everything in ONE explicit
+        // read-only transaction so the timeout guard + SELECT share a server
+        // connection, and ROLLBACK always releases it clean. SET LOCAL scopes
+        // the timeout to this transaction only.
+        var begin = 'BEGIN READ ONLY; SET LOCAL statement_timeout=' + Math.round(TIMEOUT_MS) + ';';
+        client.query(begin, function (gerr) {
+            if (gerr) {
+                try { client.query('ROLLBACK', function () { release(); }); } catch (e) { release(); }
+                finish(); _counters.pg_error++; return;
+            }
+            client.query(pgSql, function (qerr, pgRes) {
+                // Always end the transaction + release the client.
+                try { client.query('ROLLBACK', function () { release(); }); } catch (e) { release(); }
+                finish();
+                if (qerr) {
+                    // 57014 = query_canceled (our statement_timeout): a slow
+                    // PG query is a PERFORMANCE observation, not a dialect
+                    // divergence — do not pollute the divergence report.
+                    if (qerr.code === '57014') {
+                        _counters.pg_timeout++;
+                        emitStat({ ev: 'pg_timeout', hash: templateHash(text),
+                            tmpl: sqlTemplate(text).slice(0, 200) });
+                        return;
+                    }
+                    _counters.dialect_error++;
+                    var dhash = templateHash(text);
+                    if (divergenceEmitAllowed(dhash)) {
+                        emitDivergence({ v: 1, ts: new Date().toISOString(), klass: 'dialect_error',
+                            phase: 'execute', hash: dhash, tmpl: sqlTemplate(text).slice(0, 400),
+                            detail: String(qerr && qerr.message || qerr).slice(0, 240),
+                            pg_code: qerr && qerr.code, caller: meta && meta.caller });
+                    }
+                    return;
+                }
+                var pgRows = (pgRes && pgRes.rows) || [];
+                var cmp;
+                try { cmp = compare(text, mariaRows, pgRows, 1e-9); } catch (e) { cmp = null; }
+                if (cmp) {
+                    _counters.diff++;
+                    var chash = templateHash(text);
+                    if (divergenceEmitAllowed(chash)) {
+                        emitDivergence({ v: 1, ts: new Date().toISOString(), klass: cmp.klass,
+                            phase: 'compare', hash: chash, tmpl: sqlTemplate(text).slice(0, 400),
+                            detail: cmp.detail, rows_maria: mariaRows.length, rows_pg: pgRows.length,
+                            caller: meta && meta.caller });
+                    }
+                } else {
+                    _counters.ok++;
+                }
+            });
+        });
+    });
+}
+
+// periodic stats heartbeat so a silent shadow (0 divergences) is observable
+var _statTimer = null;
+function startStatHeartbeat() {
+    if (_statTimer || ENGINE !== 'shadow') { return; }
+    _statTimer = setInterval(function () {
+        emitStat({ ev: 'counters', inflight: _inflight, engine: ENGINE, c: _counters });
+    }, 60000);
+    if (_statTimer.unref) { _statTimer.unref(); }
+}
+if (ENGINE === 'shadow') { startStatHeartbeat(); }
+
+module.exports = {
+    engine: ENGINE,
+    enabled: ENABLED,
+    isShadow: ENGINE === 'shadow',
+    // dbpool.js hook (shadow):
+    shadowAfterRead: shadowAfterRead,
+    // exported for the self-test + potential Phase-6.4 pg mode:
+    classify: classify,
+    translate: translate,
+    compare: compare,
+    sqlTemplate: sqlTemplate,
+    templateHash: templateHash,
+    normalizeRows: normalizeRows,
+    _counters: _counters
+};

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -1,0 +1,85 @@
+'use strict';
+// Self-test for dbpool-pg.js — classifier + translator + normalizer.
+// Run: DB_ENGINE=shadow node app/utils/dbpool-pg.selftest.js
+// (shadow engine set so module exports are live; no PG connection is made —
+//  we only test the pure functions.)
+process.env.DB_ENGINE = process.env.DB_ENGINE || 'mysql'; // pure fns don't need shadow
+var m = require('./dbpool-pg');
+var fails = 0, n = 0;
+function eq(label, got, want) {
+    n++;
+    var g = JSON.stringify(got), w = JSON.stringify(want);
+    if (g !== w) { fails++; console.log('FAIL', label, '\n   got ', g, '\n   want', w); }
+    else { console.log('ok  ', label); }
+}
+function classifyReplayable(sql) { return m.classify(sql).replayable; }
+
+console.log('== classifier ==');
+eq('plain select', classifyReplayable('SELECT * FROM projects WHERE project_id = 5'), true);
+eq('select with join+groupby', classifyReplayable('SELECT p.project_id, COUNT(*) FROM projects p JOIN sites s ON s.project_id=p.project_id GROUP BY p.project_id'), true);
+eq('with-cte select', classifyReplayable('WITH x AS (SELECT 1 AS a) SELECT a FROM x'), true);
+eq('reject insert', classifyReplayable('INSERT INTO jobs (state) VALUES ("waiting")'), false);
+eq('reject update', classifyReplayable('UPDATE jobs SET state="processing" WHERE job_id=1'), false);
+eq('reject delete', classifyReplayable('DELETE FROM jobs WHERE job_id=1'), false);
+eq('reject for update', classifyReplayable('SELECT * FROM jobs WHERE job_id=1 FOR UPDATE'), false);
+eq('reject multi-stmt', classifyReplayable('SELECT 1; SELECT 2'), false);
+eq('reject now()', classifyReplayable('SELECT NOW()'), false);
+eq('reject last_insert_id', classifyReplayable('SELECT LAST_INSERT_ID()'), false);
+eq('reject user var', classifyReplayable('SELECT @x'), false);
+eq('reject into outfile', classifyReplayable('SELECT * FROM t INTO OUTFILE "/tmp/x"'), false);
+eq('col named update in string ok', classifyReplayable("SELECT * FROM t WHERE name = 'update me'"), true);
+eq('backtick col update ok', classifyReplayable('SELECT `update` FROM t'), true);
+eq('rand forbidden', classifyReplayable('SELECT * FROM t ORDER BY RAND()'), false);
+// desc as order modifier is fine (not statement-initial DESCRIBE)
+eq('order by desc ok', classifyReplayable('SELECT a FROM t ORDER BY a DESC'), true);
+
+console.log('== translator ==');
+eq('backtick reserved -> quoted', m.translate('SELECT `order` FROM `project_soundscape_composition_classes`'),
+   'SELECT "order" FROM project_soundscape_composition_classes');
+eq('backtick normal -> bare', m.translate('SELECT `job_id`, `name` FROM `jobs`'),
+   'SELECT job_id, name FROM jobs');
+eq('limit offset,count', m.translate('SELECT a FROM t ORDER BY a LIMIT 20, 10'),
+   'SELECT a FROM t ORDER BY a LIMIT 10 OFFSET 20');
+eq('limit offset,count placeholder-free (jobs.js:587)', m.translate("SELECT * FROM jobs LIMIT 0, 100"),
+   'SELECT * FROM jobs LIMIT 100 OFFSET 0');
+eq('ifnull->coalesce', m.translate('SELECT IFNULL(a, 0) FROM t'), 'SELECT COALESCE(a, 0) FROM t');
+eq('backtick inside string untouched', m.translate("SELECT `name` FROM t WHERE x = '`literal`'"),
+   "SELECT name FROM t WHERE x = '`literal`'");
+eq('limit inside string untouched', m.translate("SELECT a FROM t WHERE note = 'LIMIT 1, 2'"),
+   "SELECT a FROM t WHERE note = 'LIMIT 1, 2'");
+
+console.log('== template/hash ==');
+eq('template collapses literals+IN arity',
+   m.sqlTemplate("SELECT * FROM t WHERE id IN (1,2,3) AND name='x' AND n=5"),
+   'SELECT * FROM t WHERE id IN (?) AND name=? AND n=?');
+eq('same template same hash',
+   m.templateHash("SELECT * FROM t WHERE id=1") === m.templateHash("SELECT * FROM t WHERE id=999"), true);
+
+console.log('== normalizer/compare ==');
+// identical
+eq('identical rows equal', m.compare('SELECT a,b FROM t', [{a:1,b:'x'}], [{a:1,b:'x'}], 1e-9), null);
+// int vs decimal-string (pg numeric) bridge
+eq('int==numeric-string', m.compare('SELECT a FROM t', [{a:5}], [{a:'5'}], 1e-9), null);
+// tinyint 1 vs boolean true
+eq('tinyint1==bool', m.compare('SELECT a FROM t', [{a:1}], [{a:true}], 1e-9), null);
+// column-name case-insensitive
+eq('colname case-insensitive', m.compare('SELECT A FROM t', [{A:1}], [{a:1}], 1e-9), null);
+// no-order-by: row order should not matter
+eq('unordered set equal reordered', m.compare('SELECT a FROM t', [{a:1},{a:2}], [{a:2},{a:1}], 1e-9), null);
+// order-by: different order -> ordering_only
+var ord = m.compare('SELECT a FROM t ORDER BY a', [{a:1},{a:2}], [{a:2},{a:1}], 1e-9);
+eq('ordered different -> ordering_only', ord && ord.klass, 'ordering_only');
+// genuine mismatch
+var mm = m.compare('SELECT a FROM t', [{a:1}], [{a:2}], 1e-9);
+eq('genuine value diff -> result_mismatch', mm && mm.klass, 'result_mismatch');
+// row count diff
+var rc = m.compare('SELECT a FROM t', [{a:1}], [{a:1},{a:2}], 1e-9);
+eq('row count diff -> result_mismatch', rc && rc.klass, 'result_mismatch');
+// float epsilon
+eq('float within epsilon equal', m.compare('SELECT a FROM t', [{a:1.0000000001}], [{a:1.0}], 1e-9), null);
+// null vs empty NOT equal (T4 policy)
+var ne = m.compare('SELECT a FROM t', [{a:null}], [{a:''}], 1e-9);
+eq('null != empty (T4)', ne && ne.klass, 'result_mismatch');
+
+console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
+process.exit(fails ? 1 : 0);

--- a/app/utils/dbpool.js
+++ b/app/utils/dbpool.js
@@ -2,6 +2,7 @@ var mysql = require('mysql');
 var config = require('../config');
 var sqlutil = require('./sqlutil');
 var tap = require('./dbpool-tap'); // mysql2pg parity tap - OFF unless DBPOOL_TAP=1
+var pgshadow = require('./dbpool-pg'); // mysql2pg Phase 6 shadow-read - INERT unless DB_ENGINE=shadow
 var q = require('q');
 var showQueriesInConsole = true;
 
@@ -62,6 +63,25 @@ var dbpool = {
             if(cb){
                 query_fn.call(connection, sql, values, function(err, rows, fields) {
                     if (tapRec) { tap.finish(tapRec, err, rows); }
+                    // Phase 6 shadow: MariaDB result is authoritative and is
+                    // handed to cb() below unchanged. The PG replay+diff is
+                    // fire-and-forget (never awaited, never affects cb). Only
+                    // successful read results are shadowed.
+                    if (pgshadow.isShadow && !err) {
+                        try {
+                            // Format with the SAME timezone the pool uses
+                            // ('Z'): mysql.format defaults to local time for
+                            // Date params, which would shadow a different
+                            // datetime literal than the driver actually sent.
+                            var rawSql = (typeof sql === 'string') ? sql
+                                : (sql && typeof sql.sql === 'string') ? sql.sql : null;
+                            if (rawSql !== null) {
+                                var finalSql = mysql.format(rawSql, values, false,
+                                    config('db').timezone || 'Z');
+                                pgshadow.shadowAfterRead(finalSql, rows, null);
+                            }
+                        } catch (e) { /* shadow must never break the query path */ }
+                    }
                     cb(err, rows, fields);
                 });
             } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "nodemailer": "~2.5.0",
         "nodemailer-smtp-transport": "~2.7.4",
         "paypal-rest-sdk": "^1.8.1",
+        "pg": "^8.22.0",
         "q": "^1.5.1",
         "redis": "^4.6.4",
         "request": "^2.88.0",
@@ -12279,6 +12280,95 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/phin": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
@@ -12353,6 +12443,45 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13720,6 +13849,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -25234,6 +25372,66 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "requires": {
+        "pg-cloudflare": "^1.4.0",
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      }
+    },
+    "pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "optional": true
+    },
+    "pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "requires": {}
+    },
+    "pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "requires": {
+        "split2": "^4.1.0"
+      }
+    },
     "phin": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
@@ -25290,6 +25488,29 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -26429,6 +26650,11 @@
       "requires": {
         "extend-shallow": "^3.0.0"
       }
+    },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
     },
     "sprintf-js": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "nodemailer": "~2.5.0",
     "nodemailer-smtp-transport": "~2.7.4",
     "paypal-rest-sdk": "^1.8.1",
+    "pg": "^8.22.0",
     "q": "^1.5.1",
     "redis": "^4.6.4",
     "request": "^2.88.0",


### PR DESCRIPTION
## mysql2pg Phase 6 — dbpool-pg adapter + shadow-read mode (ships INERT)

Part of the arbimon2 MariaDB→PostgreSQL migration (rfcx-local OPEN-ITEMS #40, plan Phase 6). The jobs plane flipped to PG 2026-07-19 (#40 / rfcx-local PRs #543–#550); this PR starts the legacy-reads phase: **shadow mode** turns production traffic into the test suite while MariaDB stays authoritative for every user response.

### What this ships

- **`app/utils/dbpool-pg.js`** — engine gate `DB_ENGINE=mysql|shadow|pg`, **default `mysql` = this PR is a no-op in prod** (verified: `pg` is not even `require()`d; one boolean check per query, same cost class as the P3 tap #1743 that ran dark).
- **shadow**: after MariaDB returns a read result (response already handed back untouched), the statement is allowlist-classified (JS port of the P3 replay classifier — only provably-plain SELECTs), dialect-translated (backticks→T14 identifiers, `LIMIT x,y`→`LIMIT/OFFSET`, `IFNULL`→`COALESCE`), and replayed fire-and-forget on the PG `arbimon` copy as `arbimon_ro` inside `BEGIN READ ONLY` + `SET LOCAL statement_timeout` (pgbouncer transaction-pool safe, always ROLLBACK). Results normalized + diffed (P3-parity rules: column-case/row-order/float-epsilon/int-numeric bridge/casefold second chance); mismatches emitted as `DBPOOL_SHADOW_DIVERGENCE` JSON stdout lines (promtail→Loki, same lane as `DBPOOL_TAP`), per-template emit-capped, with a 60s `DBPOOL_SHADOW_STAT` counters heartbeat. Concurrency cap + big-result skip; PG errors/timeouts can never reach the user path.
- **`DB_ENGINE=pg` response routing is deliberately NOT implemented** (Phase 6.4, operator-gated).
- `pg@^8.22.0` (node16-compatible), lazy-required.
- `app/utils/dbpool-pg.selftest.js` — 35 checks (classifier/translator/normalizer), all green.

### Verification done

- Selftest 35/35; default-mode inertness proven (pg absent from require.cache).
- Live e2e vs MariaDB **replica** (`read_only=1`) + PG via pgbouncer (`arbimon_ro`), 14 real query shapes: **12 EQUAL / 2 ordering_only (citext ORDER BY class, expected Phase-6 queue) / 0 dialect_error / 0 result_mismatch**.
- Real `shadowAfterRead()` path exercised live: EQUAL→silent, citext→`ordering_only`, `DATE_FORMAT`→clean `dialect_error` (42883), `FOR UPDATE`→classifier-skipped, backtick+`LIMIT 5,5`→translated+EQUAL.
- Found + fixed during build: node-postgres OID-1114 local-time parse (+4h datetime skew vs the app's `timezone:'Z'`) — now parsed UTC; `mysql.format` timezone parity in the dbpool hook; PG timeout (57014) counted as perf observation, not divergence.

### Rollout (operator-approved staging)

1. Merge → CD deploys **inert** (no env set).
2. Canary: 1 replica `DB_ENGINE=shadow` + `DB_SHADOW_SAMPLE=0.25` (~24h: heap/p50/log-rate/pgbouncer watch).
3. Raise to 1.0, then both replicas. The 7-day-clean divergence gate starts only at full coverage.

Rollback at any stage = unset env (or don't merge: default path untouched).