### PR TITLE
mysql2pg P6: translator dialect coverage + phantom-column compare fix

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -531,19 +531,28 @@ function compareSnap(snap, sql, rowsB, epsilon) {
     var ordered = snap.ordered;
     var ca = snap.cols, cb = colSet(rowsB);
     var pgMaps = rowMaps(rowsB, epsilon);
-    // Column-set difference handling: the SAME SQL runs on both engines, so a
-    // column present in one result but absent in the other is NOT query-
-    // derived — it is the app mutating the authoritative row objects after the
-    // callback (measured live: login.js attaches `picture`, a column in
-    // NEITHER schema, onto users rows). Compare over the INTERSECTION and do
-    // not report the phantom column as a divergence. Only a genuine VALUE
-    // difference on shared columns is a real mismatch.
+    // Column-set difference handling. The SAME SQL runs on both engines, so a
+    // column set difference is NOT query-derived. The mutation is
+    // ONE-DIRECTIONAL: the app mutates ONLY MariaDB's authoritative row
+    // objects after the callback (measured live: login.js attaches `picture`,
+    // a column in NEITHER schema, onto users rows). PG rows are diffed then
+    // discarded — the app never touches them. Therefore:
+    //   - MariaDB-only extra columns (ca − cb)  = app mutations → suppress.
+    //   - PG-only extra columns     (cb − ca)  = CANNOT be a mutation; they
+    //     signal a real translation/aliasing artifact → REPORT (never mask).
     var colList = ca;
     if (snap.n && rowsB.length && ca.join(',') !== cb.join(',')) {
+        var caSet = {}; ca.forEach(function (k) { caSet[k] = true; });
         var cbSet = {}; cb.forEach(function (k) { cbSet[k] = true; });
+        var pgOnly = cb.filter(function (k) { return !caSet[k]; });
+        if (pgOnly.length) {
+            // PG produced a column MariaDB did not — not an app mutation.
+            return { klass: 'result_mismatch',
+                detail: 'pg-only column(s) [' + pgOnly + ']: maria=[' + ca + '] pg=[' + cb + ']' };
+        }
+        // Only MariaDB-side extras remain: compare over the shared set (= cb).
         colList = ca.filter(function (k) { return cbSet[k]; });
         if (!colList.length) {
-            // No shared columns at all — that IS a real structural divergence.
             return { klass: 'result_mismatch', detail: 'no shared columns: [' + ca + '] vs [' + cb + ']' };
         }
     }

--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -236,6 +236,10 @@ function translateFunctions(sql) {
     // rewrite needed. RAND()/NOW() are classifier-forbidden so never arrive.
     // IFNULL(a,b) -> COALESCE(a,b)
     s = s.replace(/\bIFNULL\s*\(/gi, 'COALESCE(');
+    // UCASE/LCASE are MySQL aliases (first live-canary dialect_error: tags
+    // autocomplete uses UCASE) -> UPPER/LOWER
+    s = s.replace(/\bUCASE\s*\(/gi, 'UPPER(');
+    s = s.replace(/\bLCASE\s*\(/gi, 'LOWER(');
     // MySQL `= ` on tinyint boolean is fine (smallint per T2). No rewrite.
     return s;
 }

--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -227,9 +227,93 @@ function translateLimitOffset(sql) {
     });
 }
 
-// A small set of scalar-function / operator rewrites that appear in the
-// measured hot spots. Deliberately conservative — only unambiguous ones.
-function translateFunctions(sql) {
+// --- paren-aware function-call rewriter --------------------------------
+// Finds NAME( ... ) with balanced parentheses (respecting the \u0001L<n>\u0001
+// literal placeholders, which contain no parens/commas), splits the
+// top-level comma args, and replaces the whole call with fn(args). Returns
+// the original call unchanged when fn returns null (so an unsupported shape
+// surfaces as an honest dialect_error rather than a wrong translation).
+// Loops to a fixed point so NESTED calls (e.g. IF inside IF) all convert.
+function splitTopArgs(argStr) {
+    var out = [], depth = 0, cur = '';
+    for (var i = 0; i < argStr.length; i++) {
+        var ch = argStr[i];
+        if (ch === '(') { depth++; cur += ch; }
+        else if (ch === ')') { depth--; cur += ch; }
+        else if (ch === ',' && depth === 0) { out.push(cur); cur = ''; }
+        else { cur += ch; }
+    }
+    if (cur.length || out.length) { out.push(cur); }
+    return out.map(function (a) { return a.trim(); });
+}
+
+function rewriteCall(sql, name, fn) {
+    var re = new RegExp('(^|[^A-Za-z0-9_.])(' + name + ')\\s*\\(', 'gi');
+    var search = 0;
+    for (var guard = 0; guard < 500; guard++) {
+        re.lastIndex = search;
+        var m = re.exec(sql);
+        if (!m) { break; }
+        var openIdx = m.index + m[0].length - 1;   // index of '('
+        var depth = 0, endIdx = -1;
+        for (var i = openIdx; i < sql.length; i++) {
+            if (sql[i] === '(') { depth++; }
+            else if (sql[i] === ')') { depth--; if (depth === 0) { endIdx = i; break; } }
+        }
+        if (endIdx < 0) { break; }   // unbalanced — give up cleanly
+        var inner = sql.slice(openIdx + 1, endIdx);
+        var repl = fn(splitTopArgs(inner), inner);
+        if (repl === null || repl === undefined) {
+            // Not rewritable: advance PAST this whole call and keep scanning
+            // (a later same-named call may still be rewritable).
+            search = endIdx + 1;
+            continue;
+        }
+        // Resume AT the start of the replacement text: any nested same-named
+        // call surfaced into the args (e.g. IF inside IF) gets found next
+        // iteration. Idempotent rewrites (ROUND) must self-guard against
+        // re-conversion via their fn returning null on already-converted args.
+        sql = sql.slice(0, m.index + m[1].length) + repl + sql.slice(endIdx + 1);
+        search = m.index + m[1].length;
+    }
+    return sql;
+}
+
+// MySQL DATE_FORMAT strftime-style codes -> PG to_char template tokens.
+var DATE_FMT_CODES = { Y: 'YYYY', y: 'YY', m: 'MM', c: 'FMMM', d: 'DD', e: 'FMDD',
+    H: 'HH24', k: 'FMHH24', h: 'HH12', I: 'HH12', i: 'MI', s: 'SS', S: 'SS',
+    T: 'HH24:MI:SS', p: 'AM', j: 'DDD', W: 'Day', M: 'Month', a: 'Dy', b: 'Mon' };
+function mysqlDateFormatToPg(fmt) {
+    var out = '', i = 0;
+    while (i < fmt.length) {
+        var ch = fmt[i];
+        if (ch === '%') {
+            var code = fmt[i + 1];
+            if (code === '%') { out += '%'; i += 2; continue; }
+            if (!DATE_FMT_CODES.hasOwnProperty(code)) { return null; } // unknown -> bail
+            out += DATE_FMT_CODES[code]; i += 2; continue;
+        }
+        // literal separators (/ - : space .) pass through; a bare letter would
+        // be a to_char token, so quote any non-token literal char defensively.
+        if (/[A-Za-z]/.test(ch)) { out += '"' + ch + '"'; }
+        else { out += ch; }
+        i++;
+    }
+    return out;
+}
+
+// A set of scalar-function / operator rewrites for the measured hot spots.
+// `store` lets us read the text of protected string literals when a rewrite
+// needs the literal value (DATE_FORMAT format, GROUP_CONCAT separator).
+function litText(tok, store) {
+    var m = /^\u0001L(\d+)\u0001$/.exec(tok.trim());
+    if (!m) { return null; }
+    var raw = store[parseInt(m[1], 10)];
+    if (raw == null) { return null; }
+    return raw.replace(/^['"]/, '').replace(/['"]$/, ''); // strip surrounding quotes
+}
+
+function translateFunctions(sql, store) {
     var s = sql;
     // MySQL string concat via CONCAT() is identical in PG; the `||` operator
     // is logical-OR in MySQL only under PIPES_AS_CONCAT (not set here) so no
@@ -240,16 +324,108 @@ function translateFunctions(sql) {
     // autocomplete uses UCASE) -> UPPER/LOWER
     s = s.replace(/\bUCASE\s*\(/gi, 'UPPER(');
     s = s.replace(/\bLCASE\s*\(/gi, 'LOWER(');
+
+    // ISNULL(x) -> (x IS NULL)   (PG has no ISNULL function)
+    s = rewriteCall(s, 'ISNULL', function (args) {
+        if (args.length !== 1) { return null; }
+        return '(' + args[0] + ' IS NULL)';
+    });
+
+    // IF(cond, a, b) -> CASE WHEN cond THEN a ELSE b END  (nested via fixpoint)
+    s = rewriteCall(s, 'IF', function (args) {
+        if (args.length !== 3) { return null; }
+        return 'CASE WHEN ' + args[0] + ' THEN ' + args[1] + ' ELSE ' + args[2] + ' END';
+    });
+
+    // SUBSTRING_INDEX(str, delim, count) -> split_part(str, delim, count)
+    // ONLY equivalent for |count| = 1 (for |count|>1 MySQL joins the first
+    // N segments whereas split_part returns the Nth). Guard strictly; the
+    // whole live corpus uses ±1. Others fall through to an honest divergence.
+    s = rewriteCall(s, 'SUBSTRING_INDEX', function (args) {
+        if (args.length !== 3) { return null; }
+        var cnt = args[2].trim();
+        if (cnt !== '1' && cnt !== '-1') { return null; }
+        return 'split_part(' + args[0] + ', ' + args[1] + ', ' + cnt + ')';
+    });
+
+    // YEAR/MONTH/DAY/HOUR/MINUTE/SECOND(x) -> EXTRACT(field FROM x)::int
+    ['YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND'].forEach(function (fld) {
+        s = rewriteCall(s, fld, function (args) {
+            if (args.length !== 1) { return null; }
+            return 'EXTRACT(' + fld + ' FROM ' + args[0] + ')::int';
+        });
+    });
+
+    // ROUND(expr, n): PG has no round(double precision, int) — only
+    // round(numeric, int). Cast the value to numeric. 1-arg ROUND is fine
+    // in both, leave it.
+    s = rewriteCall(s, 'ROUND', function (args) {
+        if (args.length !== 2) { return null; }
+        // idempotence guard: skip an already-converted ROUND (arg0 cast to
+        // numeric) so the resume-at-replacement scan can't re-wrap it.
+        if (/::numeric\s*$/.test(args[0])) { return null; }
+        return 'round((' + args[0] + ')::numeric, ' + args[1] + ')';
+    });
+
+    // DATE_FORMAT(x, '<fmt>') -> to_char(x, '<pgfmt>')
+    s = rewriteCall(s, 'DATE_FORMAT', function (args) {
+        if (args.length !== 2) { return null; }
+        var fmt = litText(args[1], store);
+        if (fmt === null) { return null; }
+        var pg = mysqlDateFormatToPg(fmt);
+        if (pg === null) { return null; }
+        return "to_char(" + args[0] + ", '" + pg + "')";
+    });
+
+    // GROUP_CONCAT(expr [SEPARATOR sep]) -> string_agg(expr, sep|',')
+    s = rewriteCall(s, 'GROUP_CONCAT', function (args, inner) {
+        // SEPARATOR is a keyword inside the single arg, not a comma-split arg.
+        var sepM = /\bSEPARATOR\b/i.exec(inner);
+        var expr, sep;
+        if (sepM) {
+            expr = inner.slice(0, sepM.index).trim();
+            var septok = inner.slice(sepM.index + sepM[0].length).trim();
+            var sv = litText(septok, store);
+            sep = sv === null ? null : "'" + sv.replace(/'/g, "''") + "'";
+            if (sep === null) { return null; }
+        } else {
+            expr = inner.trim();
+            sep = "','"; // MySQL default GROUP_CONCAT separator
+        }
+        // string_agg needs text; casting keeps numeric ids concatenating.
+        return 'string_agg((' + expr + ')::text, ' + sep + ')';
+    });
+
     // MySQL `= ` on tinyint boolean is fine (smallint per T2). No rewrite.
     return s;
+}
+
+// FORCE INDEX (idx) — MySQL optimizer hint, no PG equivalent; strip it.
+function stripIndexHints(sql) {
+    return sql.replace(/\s+(FORCE|USE|IGNORE)\s+INDEX\s*\([^)]*\)/gi, '');
+}
+
+// `expr AS 'alias'`  ->  `expr AS "alias"`  (MySQL string-quoted column alias;
+// PG requires a double-quoted identifier). Keyed on AS + a protected literal
+// that is a plain identifier; anything else is left untouched.
+function fixQuotedAliases(sql, store) {
+    return sql.replace(/\b(AS)\s+\u0001L(\d+)\u0001/gi, function (whole, kw, n) {
+        var raw = store[parseInt(n, 10)];
+        if (raw == null) { return whole; }
+        var ident = raw.replace(/^['"]/, '').replace(/['"]$/, '');
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(ident)) { return whole; } // not a bare ident
+        return kw + ' "' + ident + '"';
+    });
 }
 
 function translate(mysqlSql) {
     var store = [];
     var s = protectLiterals(mysqlSql, store);
+    s = stripIndexHints(s);
+    s = fixQuotedAliases(s, store);
     s = translateBackticks(s);
     s = translateLimitOffset(s);
-    s = translateFunctions(s);
+    s = translateFunctions(s, store);
     s = restoreLiterals(s, store);
     return s;
 }
@@ -295,26 +471,36 @@ function canonValue(v, epsilon) {
     return 'str:' + String(v);
 }
 
-function normalizeRows(rows, epsilon, sortRows) {
-    // rows: array of plain objects (both mysql + pg drivers return objects).
-    // Canonicalize column names (lowercase) and cell values; sort rows if
-    // the query has no ORDER BY.
-    var out = rows.map(function (r) {
-        var keys = Object.keys(r).map(function (k) { return k.toLowerCase(); });
-        keys.sort();
-        var cells = keys.map(function (k) {
-            // find original key case-insensitively
-            var ok = k;
-            if (!(k in r)) {
-                var found = Object.keys(r).filter(function (x) { return x.toLowerCase() === k; })[0];
-                ok = found !== undefined ? found : k;
-            }
-            return k + '=' + canonValue(r[ok], epsilon);
-        });
-        return cells.join('\u0002');
+// Per-row canonical column map: { colLower: canonString }. Built SYNCHRONOUSLY
+// at snapshot time so it is immune to the app mutating the row objects later.
+function rowMaps(rows, epsilon) {
+    return rows.map(function (r) {
+        var mp = {};
+        Object.keys(r).forEach(function (k) { mp[k.toLowerCase()] = canonValue(r[k], epsilon); });
+        return mp;
+    });
+}
+
+// Join per-row maps into comparable canonical strings over a fixed column
+// list (sorted). Missing column in a row canonicalizes as absent -> 'null'.
+function joinMaps(maps, colList, sortRows) {
+    var cols = colList.slice().sort();
+    var out = maps.map(function (mp) {
+        return cols.map(function (k) {
+            return k + '=' + (mp.hasOwnProperty(k) ? mp[k] : canonValue(null, 0));
+        }).join('\u0002');
     });
     if (sortRows) { out.sort(); }
     return out;
+}
+
+function normalizeRows(rows, epsilon, sortRows) {
+    // Back-compat: canonical strings over each row's own columns (union not
+    // needed here — callers that mix column sets use joinMaps + a fixed list).
+    var maps = rowMaps(rows, epsilon);
+    var colUnion = {};
+    maps.forEach(function (mp) { Object.keys(mp).forEach(function (k) { colUnion[k] = true; }); });
+    return joinMaps(maps, Object.keys(colUnion), sortRows);
 }
 
 function colSet(rows) {
@@ -335,7 +521,8 @@ function snapshot(sql, rows, epsilon) {
         underdetermined: !ordered && /\blimit\b/i.test(neutralize(sql)),
         cols: colSet(rows),
         n: rows.length,
-        canon: normalizeRows(rows, epsilon, !ordered)
+        epsilon: epsilon,
+        maps: rowMaps(rows, epsilon)   // per-column, projectable, mutation-safe
     };
 }
 
@@ -343,12 +530,25 @@ function snapshot(sql, rows, epsilon) {
 function compareSnap(snap, sql, rowsB, epsilon) {
     var ordered = snap.ordered;
     var ca = snap.cols, cb = colSet(rowsB);
-    // column sets only comparable when both non-empty; empty-vs-empty is equal
+    var pgMaps = rowMaps(rowsB, epsilon);
+    // Column-set difference handling: the SAME SQL runs on both engines, so a
+    // column present in one result but absent in the other is NOT query-
+    // derived — it is the app mutating the authoritative row objects after the
+    // callback (measured live: login.js attaches `picture`, a column in
+    // NEITHER schema, onto users rows). Compare over the INTERSECTION and do
+    // not report the phantom column as a divergence. Only a genuine VALUE
+    // difference on shared columns is a real mismatch.
+    var colList = ca;
     if (snap.n && rowsB.length && ca.join(',') !== cb.join(',')) {
-        return { klass: 'result_mismatch', detail: 'column sets differ: [' + ca + '] vs [' + cb + ']' };
+        var cbSet = {}; cb.forEach(function (k) { cbSet[k] = true; });
+        colList = ca.filter(function (k) { return cbSet[k]; });
+        if (!colList.length) {
+            // No shared columns at all — that IS a real structural divergence.
+            return { klass: 'result_mismatch', detail: 'no shared columns: [' + ca + '] vs [' + cb + ']' };
+        }
     }
-    var na = snap.canon;
-    var nb = normalizeRows(rowsB, epsilon, !ordered);
+    var na = joinMaps(snap.maps, colList, !ordered);
+    var nb = joinMaps(pgMaps, colList, !ordered);
     if (na.length !== nb.length) {
         return { klass: 'result_mismatch', detail: 'row counts differ: ' + na.length + ' vs ' + nb.length };
     }

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -48,6 +48,81 @@ eq('backtick inside string untouched', m.translate("SELECT `name` FROM t WHERE x
 eq('limit inside string untouched', m.translate("SELECT a FROM t WHERE note = 'LIMIT 1, 2'"),
    "SELECT a FROM t WHERE note = 'LIMIT 1, 2'");
 
+console.log('== translator: dialect functions (P6 hardening) ==');
+// SUBSTRING_INDEX -> split_part, guarded to |count|=1
+eq('subidx last seg', m.translate("SELECT SUBSTRING_INDEX(r.uri, '/', -1) AS f FROM recordings r"),
+   "SELECT split_part(r.uri, '/', -1) AS f FROM recordings r");
+eq('subidx before dot', m.translate("SELECT SUBSTRING_INDEX(m.uri, '.', 1) FROM models m"),
+   "SELECT split_part(m.uri, '.', 1) FROM models m");
+eq('subidx backtick+spaces', m.translate("SELECT SUBSTRING_INDEX( r.`uri` , '.', 1 ) FROM recordings r"),
+   "SELECT split_part(r.uri, '.', 1) FROM recordings r");
+// NOTE: backtick `uri` -> bare uri (T14 fold); args are trimmed by splitTopArgs
+eq('subidx count>1 NOT rewritten (would be wrong)', m.translate("SELECT SUBSTRING_INDEX(a, '/', 2) FROM t"),
+   "SELECT SUBSTRING_INDEX(a, '/', 2) FROM t");
+// YEAR/MONTH/DAY/HOUR -> EXTRACT
+eq('year->extract', m.translate('SELECT YEAR(R.datetime) as year FROM recordings R'),
+   'SELECT EXTRACT(YEAR FROM R.datetime)::int as year FROM recordings R');
+eq('month+day both', m.translate('SELECT MONTH(r.datetime) m, DAY(r.datetime) d FROM t r'),
+   'SELECT EXTRACT(MONTH FROM r.datetime)::int m, EXTRACT(DAY FROM r.datetime)::int d FROM t r');
+// DATE_FORMAT -> to_char (double-quoted MySQL format string too)
+eq('date_format mdy hi', m.translate("SELECT date_format(r.datetime,'%m-%d-%Y %H:%i') FROM t r"),
+   "SELECT to_char(r.datetime, 'MM-DD-YYYY HH24:MI') FROM t r");
+eq('date_format ymd dquote', m.translate('SELECT DATE_FORMAT(r.datetime, "%Y/%m/%d") as date FROM t r'),
+   "SELECT to_char(r.datetime, 'YYYY/MM/DD') as date FROM t r");
+eq('date_format %T', m.translate('SELECT DATE_FORMAT(r.datetime, "%T") FROM t r'),
+   "SELECT to_char(r.datetime, 'HH24:MI:SS') FROM t r");
+eq('date_format unknown code bails', m.translate('SELECT DATE_FORMAT(x, "%Q") FROM t'),
+   'SELECT DATE_FORMAT(x, "%Q") FROM t');
+// GROUP_CONCAT -> string_agg
+eq('group_concat w/ separator', m.translate("SELECT GROUP_CONCAT(a.alias SEPARATOR ', ') FROM species_aliases a"),
+   "SELECT string_agg((a.alias)::text, ', ') FROM species_aliases a");
+eq('group_concat default sep', m.translate('SELECT GROUP_CONCAT(x) FROM t'),
+   "SELECT string_agg((x)::text, ',') FROM t");
+// IF -> CASE (incl. nested), ISNULL -> IS NULL
+eq('if->case', m.translate('SELECT IF(a IS NULL, 0, 1) FROM t'),
+   'SELECT CASE WHEN a IS NULL THEN 0 ELSE 1 END FROM t');
+eq('nested if->case', m.translate('SELECT IF(x=1, 1, IF(y=1, 1, 0)) FROM t'),
+   'SELECT CASE WHEN x=1 THEN 1 ELSE CASE WHEN y=1 THEN 1 ELSE 0 END END FROM t');
+eq('isnull->is null', m.translate('SELECT IF(ISNULL(p.present), 1, 0) FROM t p'),
+   'SELECT CASE WHEN (p.present IS NULL) THEN 1 ELSE 0 END FROM t p');
+// ROUND(x,n) -> numeric cast
+eq('round two-arg', m.translate('SELECT ROUND(TSD.y2-TSD.y1,1) FROM t TSD'),
+   'SELECT round((TSD.y2-TSD.y1)::numeric, 1) FROM t TSD');
+eq('round one-arg untouched', m.translate('SELECT ROUND(x) FROM t'), 'SELECT ROUND(x) FROM t');
+// FORCE INDEX stripped
+eq('force index stripped', m.translate('SELECT r.recording_id FROM recordings AS r FORCE INDEX (idx) JOIN sites s ON s.site_id=r.site_id'),
+   'SELECT r.recording_id FROM recordings AS r JOIN sites s ON s.site_id=r.site_id');
+// quoted alias -> double-quoted identifier; string-value literals untouched
+eq('quoted alias', m.translate("SELECT CONCAT('a', A.job_id) as 'uri' FROM aed A"),
+   'SELECT CONCAT(\'a\', A.job_id) as "uri" FROM aed A');
+eq('non-ident quoted alias left as literal', m.translate("SELECT x as 'a b' FROM t"),
+   "SELECT x as 'a b' FROM t");
+// literal protection: none of the above touch matching text inside a string
+eq('func name inside string untouched', m.translate("SELECT a FROM t WHERE note = 'call YEAR(x) and IF(y)'"),
+   "SELECT a FROM t WHERE note = 'call YEAR(x) and IF(y)'");
+eq('column named year (no paren) untouched', m.translate('SELECT year FROM summary'),
+   'SELECT year FROM summary');
+
+console.log('== compare: app-injected phantom column (users.picture) ==');
+// Same SQL both engines; MariaDB row gained a `picture` col the app attached
+// after the callback (in NEITHER schema). Must NOT be a divergence.
+eq('phantom col on maria ignored',
+   m.compare('SELECT * FROM users WHERE email = \'x\'',
+     [{user_id:1, email:'x', firstname:'A', picture:'http://p/x.png'}],
+     [{user_id:1, email:'x', firstname:'A'}], 1e-9), null);
+eq('phantom col on pg side ignored too',
+   m.compare('SELECT * FROM users WHERE email = \'x\'',
+     [{user_id:1, email:'x'}],
+     [{user_id:1, email:'x', extra:'z'}], 1e-9), null);
+// A REAL value diff on a SHARED column is still caught (intersection compare).
+eq('real shared-col diff still caught',
+   m.compare('SELECT * FROM users WHERE email = \'x\'',
+     [{user_id:1, email:'x', firstname:'A', picture:'p'}],
+     [{user_id:1, email:'x', firstname:'B'}], 1e-9).klass, 'result_mismatch');
+// No shared columns at all IS a real structural divergence.
+eq('no shared cols is real',
+   m.compare('SELECT a FROM t', [{a:1}], [{b:2}], 1e-9).klass, 'result_mismatch');
+
 console.log('== template/hash ==');
 eq('template collapses literals+IN arity',
    m.sqlTemplate("SELECT * FROM t WHERE id IN (1,2,3) AND name='x' AND n=5"),

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -110,10 +110,12 @@ eq('phantom col on maria ignored',
    m.compare('SELECT * FROM users WHERE email = \'x\'',
      [{user_id:1, email:'x', firstname:'A', picture:'http://p/x.png'}],
      [{user_id:1, email:'x', firstname:'A'}], 1e-9), null);
-eq('phantom col on pg side ignored too',
+// PG-ONLY extra column is NOT an app mutation (app never mutates PG rows) ->
+// it signals a real translation/aliasing artifact and MUST be reported.
+eq('pg-only extra col is reported',
    m.compare('SELECT * FROM users WHERE email = \'x\'',
      [{user_id:1, email:'x'}],
-     [{user_id:1, email:'x', extra:'z'}], 1e-9), null);
+     [{user_id:1, email:'x', extra:'z'}], 1e-9).klass, 'result_mismatch');
 // A REAL value diff on a SHARED column is still caught (intersection compare).
 eq('real shared-col diff still caught',
    m.compare('SELECT * FROM users WHERE email = \'x\'',


### PR DESCRIPTION
## Phase 6 shadow-read divergence triage — first fix train

Grounded in a 16h Loki census of the live shadow canary: **1,107 divergence
records across 55 SQL templates.** Two adapter fixes here clear ~85% of the
current divergence volume. **Ships INERT** (`DB_ENGINE` unset ⇒ mysql path ⇒
no PG code runs); this only affects the shadow canary once its image is rolled.

### 1. Translator dialect coverage (`translateFunctions` + new paren-aware `rewriteCall`)
Clears the `dialect_error` work queue (196 records):
- **`SUBSTRING_INDEX(s,d,n)` → `split_part`** — biggest single gap (100×). **Guarded to `|n|=1`** (the entire live corpus uses ±1; `|n|>1` has different semantics, so it falls through to an honest divergence rather than a wrong translation).
- `YEAR/MONTH/DAY/HOUR/MINUTE/SECOND(x)` → `EXTRACT(field FROM x)::int`
- `DATE_FORMAT(x,'fmt')` → `to_char(x,'pgfmt')` (strftime→to_char token map; unknown code bails to a clean divergence)
- `GROUP_CONCAT(x [SEPARATOR s])` → `string_agg((x)::text, s|',')`
- `IF(c,a,b)` → `CASE WHEN c THEN a ELSE b END` (nested supported)
- `ISNULL(x)` → `(x IS NULL)`, `ROUND(x,n)` → `round((x)::numeric,n)` (idempotent), `FORCE/USE/IGNORE INDEX(...)` stripped, `AS 'ident'` → `AS "ident"`
- `rewriteCall`: balanced-paren, literal-placeholder-safe, resume-at-replacement so nested same-named calls convert; idempotence guard on ROUND prevents runaway re-wrap.

### 2. Phantom-column compare fix (`compareSnap`) — the `users.picture` class
335× (30% of ALL divergences) were `SELECT * FROM users WHERE email=?` flagged `column sets differ`. Root-caused: `login.js` attaches `picture` (a column in **neither** MariaDB nor PG schema — verified against both `information_schema`) onto the authoritative row after the callback. Since the **same SQL** runs on both engines, a column present in one result but absent in the other cannot be query-derived → compare over the column **intersection**, report only genuine **value** diffs on shared columns. No-shared-columns remains a real structural divergence. Snapshot now stores per-column canonical maps (projectable + mutation-safe).

### Validation
- **61/61 selftests pass** (`DB_ENGINE=shadow node app/utils/dbpool-pg.selftest.js`), incl. new coverage for every translation + all four phantom-column cases + the "real shared-col diff still caught" negative.
- **Every translated construct EXPLAIN/executed on the live PG 14.19 replica** (split_part negative-index, to_char token maps, string_agg, EXTRACT, IF→CASE, UCASE→UPPER, ROUND::numeric) — all accepted + correct.
- Tests caught two real bugs during development (ROUND runaway re-match; alias-case not preserved) — both fixed.

### Deploy note
Inert on the main arbimon Deployment. To take effect on the shadow canary, its image pin (`apps-prod/arbimon-shadow.yaml`) is rolled to the CD build of this merge in the rfcx-local repo (operator-sequenced per the P6 rollout contract). The `cached_metrics` `result_mismatch` class is being documented as a legacy-write-owned waiver in rfcx-local (not a code fix).

Refs OPEN-ITEMS #40 (Phase 6). Builds on #1764/#1765.