### PR TITLE
mysql2pg P6: residual dialect train — dq-literals, FIELD, TIMESTAMPDIFF, GROUP BY strictness

### DIFF
--- a/app/model/audio-event-detections-clustering.js
+++ b/app/model/audio-event-detections-clustering.js
@@ -69,7 +69,12 @@ let AudioEventDetectionsClustering = {
         if (options.completed) {
             tables.push('JOIN jobs J ON JP.job_id = J.job_id')
             select.push('J.state')
-            constraints.push('J.state = "completed"')
+            // single-quoted: MySQL treats "completed" as a string but PG (via
+            // the dbpool-pg shadow adapter) reads it as an identifier — the
+            // jobs.completed column — producing 42883 job_state = smallint.
+            // The adapter also converts dq-literals now; this keeps the source
+            // engine-neutral at origin.
+            constraints.push("J.state = 'completed'")
         }
 
         if (options.aedCount) {

--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -52,7 +52,7 @@ let ClusteringJobs = {
 
         if (options.completed) {
             select.push("J.`state`");
-            constraints.push('J.state = "completed"');
+            constraints.push("J.state = 'completed'");
         }
 
         if (options.deleted !== undefined) {
@@ -214,7 +214,7 @@ let ClusteringJobs = {
 
         if (options.completed) {
             select.push("J.`state`");
-            constraints.push('J.state = "completed"');
+            constraints.push("J.state = 'completed'");
             tables.push("JOIN jobs J ON JP.job_id = J.job_id");
         }
 

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -65,7 +65,7 @@ var PatternMatchings = {
 
         if (options.completed !== undefined) {
             select.push("J.`completed`");
-            constraints.push('J.state = "completed"');
+            constraints.push("J.state = 'completed'");
         }
 
         if (options.citizen_scientist !== undefined) {
@@ -167,6 +167,26 @@ var PatternMatchings = {
                 "SUM(IF(PMR.consensus_validated IS NULL AND PMR.cs_val_present > 0 AND PMR.cs_val_not_present > 0 AND PMR.expert_validated IS NOT NULL, 1, 0)) as cs_conflict_resolved",
                 "SUM(IF(PMR.consensus_validated IS NULL AND PMR.cs_val_present > 0 AND PMR.cs_val_not_present > 0 AND PMR.expert_validated IS NULL, 1, 0)) as cs_conflict_unresolved",
             );
+        }
+
+        // PG GROUP BY strictness (42803): when aggregating per
+        // PM.pattern_matching_id, every joined N:1 table's selected columns
+        // must be grouped too (PG infers functional dependency only from the
+        // grouped table's own PK). Group by each joined table's PK — all are
+        // N:1 from PM (job → user, playlist, species, songtype), so group
+        // cardinality is unchanged; MySQL accepts the extra columns.
+        if (groupby.length) {
+            [
+                ['JOIN jobs J ',       'J.job_id'],
+                ['JOIN users U ',      'U.user_id'],
+                ['JOIN playlists P ',  'P.playlist_id'],
+                ['JOIN species Sp ',   'Sp.species_id'],
+                ['JOIN songtypes St ', 'St.songtype_id'],
+            ].forEach(([frag, pk]) => {
+                if (tables.some(t => (t + ' ').indexOf(frag) !== -1)) {
+                    groupby.push(pk);
+                }
+            });
         }
 
         postprocess.push((rows) => {

--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -569,7 +569,15 @@ var Projects = {
                     AND rv.project_id = pc.project_id
                 )`
             );
-            groupby_clause.push("pc.species_id", "pc.songtype_id");
+            // PG GROUP BY strictness (42803): also group by the pc PK (covers
+            // all pc.* via functional dependency) + the joined display columns
+            // (N:1 from pc, so groups are unchanged — with project_id pinned,
+            // (species_id, songtype_id) ↔ project_class_id is 1:1 per the
+            // project_classes__project_id unique index). MySQL accepts the
+            // extra columns; result identical on both engines.
+            groupby_clause.push("pc.species_id", "pc.songtype_id",
+                "pc.project_class_id", "st.taxon", "sp.scientific_name",
+                "so.songtype");
         }
 
         // Safe, whitelisted ORDER BY for the project-species list. The client

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -2209,6 +2209,12 @@ var Recordings = {
             ]);
             builder.setOrderBy('s.site_id');
             builder.setGroupBy('s.site_id');
+            // PG GROUP BY strictness (42803): s.name is covered by grouping
+            // s.site_id (sites PK, functional dependency) but pis.site_id is a
+            // DIFFERENT table. The LEFT JOIN pins pis.site_id = s.site_id (or
+            // NULL, never mixed within a site), so grouping it too leaves the
+            // groups unchanged; MySQL accepts the extra column.
+            builder.addGroupBy('pis.site_id');
             return dbpool.query(builder.getSQL());
         });
     },

--- a/app/model/soundscape-composition.js
+++ b/app/model/soundscape-composition.js
@@ -56,7 +56,9 @@ var SoundscapeComposition = {
         }
 
         if (options.isSystemClass) {
-            where.push("SCC.isSystemClass");
+            // engine-neutral: bare smallint truthiness is MySQL-only (PG 42804
+            // 'argument of WHERE must be type boolean'); values are 0/1 only.
+            where.push("SCC.isSystemClass = 1");
         }
 
         if(options.id){

--- a/app/model/species.js
+++ b/app/model/species.js
@@ -82,7 +82,11 @@ var Species = {
                 "OR sf.family LIKE %s \n"+
                 "OR st.taxon LIKE %s \n"+
                 "OR EXISTS (SELECT 1 FROM species_aliases a WHERE a.species_id = s.species_id AND a.alias LIKE %s) \n"+
-                "GROUP BY s.species_id \n"+
+                // sf.family/st.taxon are N:1-determined by s.species_id so the
+                // groups are unchanged; listing them satisfies PG GROUP BY
+                // strictness (42803) — PG only infers functional dependency
+                // from the grouped table's own PK, not across joins.
+                "GROUP BY s.species_id, sf.family, st.taxon \n"+
                 "LIMIT 100";
         var term = dbpool.escape('%'+squery+'%');
         q = util.format(q,

--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -211,6 +211,28 @@ function restoreLiterals(sql, store) {
     return sql.replace(/\u0001L(\d+)\u0001/g, function (_, n) { return store[parseInt(n, 10)]; });
 }
 
+// MySQL (without ANSI_QUOTES — our pools never set it) treats "..." as a
+// STRING literal; PG treats it as an IDENTIFIER. Live consequence (P6 canary):
+// `J.state = "completed"` resolved "completed" to the jobs.completed COLUMN
+// (smallint) → 42883 `job_state = smallint`, and in the PM shape where two
+// joined tables both have `completed` → 42702 ambiguous-column. Convert every
+// REMAINING double-quoted literal (fixQuotedAliases already consumed the
+// `AS "x"` cases before this runs) to a PG single-quoted literal.
+// Conservative: a literal containing a backslash is left unchanged (MySQL
+// backslash-escape semantics differ from PG standard_conforming_strings) —
+// it surfaces as an honest dialect_error instead of a silent wrong value.
+function restoreLiteralsPg(sql, store) {
+    return sql.replace(/\u0001L(\d+)\u0001/g, function (_, n) {
+        var raw = store[parseInt(n, 10)];
+        if (raw == null) { return _; }
+        if (raw.charAt(0) !== '"') { return raw; }         // sq literal: verbatim
+        var inner = raw.slice(1, -1);
+        if (inner.indexOf('\\') !== -1) { return raw; }    // backslash: punt
+        inner = inner.replace(/""/g, '"');                 // MySQL "" → "
+        return "'" + inner.replace(/'/g, "''") + "'";      // escape for PG
+    });
+}
+
 function translateBackticks(sql) {
     return sql.replace(/`([^`]+)`/g, function (_, ident) {
         var low = ident.toLowerCase();
@@ -396,6 +418,35 @@ function translateFunctions(sql, store) {
         return 'string_agg((' + expr + ')::text, ' + sep + ')';
     });
 
+    // ORDER BY FIELD(col, v1..vn) → COALESCE(array_position(ARRAY[v1..vn], col), 0)
+    // MySQL FIELD returns the 1-based index, 0 when absent (sorts FIRST asc);
+    // COALESCE(array_position(...), 0) reproduces that exactly. The ARRAY
+    // constructor also sidesteps PG's 100-argument function limit (54023 — the
+    // recordings.js visualizer-order query passes hundreds of ids). Guarded to
+    // all-numeric tail args (the only live shape).
+    s = rewriteCall(s, 'FIELD', function (args) {
+        if (args.length < 2) { return null; }
+        var tail = args.slice(1);
+        for (var i = 0; i < tail.length; i++) {
+            if (!/^-?\d+$/.test(tail[i].trim())) { return null; }
+        }
+        return 'COALESCE(array_position(ARRAY[' + tail.join(', ') + '], ' +
+               args[0] + '), 0)';
+    });
+
+    // TIMESTAMPDIFF(unit, a, b) → trunc(EXTRACT(EPOCH FROM (b - a)) / secs)::bigint
+    // (PG parses the bare unit as a column → 42703 `column "second" does not
+    // exist`, models.js joblength). MySQL truncates toward zero; trunc()
+    // matches. Guarded to the time units where epoch math is exact.
+    s = rewriteCall(s, 'TIMESTAMPDIFF', function (args) {
+        if (args.length !== 3) { return null; }
+        var unit = args[0].trim().toUpperCase();
+        var secs = { SECOND: 1, MINUTE: 60, HOUR: 3600, DAY: 86400 }[unit];
+        if (!secs) { return null; }
+        var diff = 'EXTRACT(EPOCH FROM ((' + args[2] + ') - (' + args[1] + ')))';
+        return 'trunc(' + (secs === 1 ? diff : diff + ' / ' + secs) + ')::bigint';
+    });
+
     // MySQL `= ` on tinyint boolean is fine (smallint per T2). No rewrite.
     return s;
 }
@@ -426,7 +477,7 @@ function translate(mysqlSql) {
     s = translateBackticks(s);
     s = translateLimitOffset(s);
     s = translateFunctions(s, store);
-    s = restoreLiterals(s, store);
+    s = restoreLiteralsPg(s, store);
     return s;
 }
 

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -71,8 +71,10 @@ eq('date_format ymd dquote', m.translate('SELECT DATE_FORMAT(r.datetime, "%Y/%m/
    "SELECT to_char(r.datetime, 'YYYY/MM/DD') as date FROM t r");
 eq('date_format %T', m.translate('SELECT DATE_FORMAT(r.datetime, "%T") FROM t r'),
    "SELECT to_char(r.datetime, 'HH24:MI:SS') FROM t r");
+// unknown code: the CALL bails (stays DATE_FORMAT -> honest 42883) but the
+// dq-literal is still converted to a PG string literal (see restoreLiteralsPg).
 eq('date_format unknown code bails', m.translate('SELECT DATE_FORMAT(x, "%Q") FROM t'),
-   'SELECT DATE_FORMAT(x, "%Q") FROM t');
+   "SELECT DATE_FORMAT(x, '%Q') FROM t");
 // GROUP_CONCAT -> string_agg
 eq('group_concat w/ separator', m.translate("SELECT GROUP_CONCAT(a.alias SEPARATOR ', ') FROM species_aliases a"),
    "SELECT string_agg((a.alias)::text, ', ') FROM species_aliases a");
@@ -98,6 +100,32 @@ eq('quoted alias', m.translate("SELECT CONCAT('a', A.job_id) as 'uri' FROM aed A
 eq('non-ident quoted alias left as literal', m.translate("SELECT x as 'a b' FROM t"),
    "SELECT x as 'a b' FROM t");
 // literal protection: none of the above touch matching text inside a string
+// -- double-quoted string literals (MySQL) -> single-quoted (PG). Live P6
+// canary classes: J.state = "completed" resolved as IDENTIFIER on PG ->
+// 42883 job_state=smallint (AED) / 42702 ambiguous "completed" (PM).
+eq('dq literal -> sq literal', m.translate('SELECT J.state FROM jobs J WHERE J.state = "completed"'),
+   "SELECT J.state FROM jobs J WHERE J.state = 'completed'");
+eq('dq literal with embedded sq', m.translate('SELECT a FROM t WHERE b = "it\'s"'),
+   "SELECT a FROM t WHERE b = 'it''s'");
+eq('dq literal doubled dq', m.translate('SELECT a FROM t WHERE b = "a""b"'),
+   "SELECT a FROM t WHERE b = 'a\"b'");
+eq('dq literal with backslash punts', m.translate('SELECT a FROM t WHERE b = "x\\\\y"'),
+   'SELECT a FROM t WHERE b = "x\\\\y"');
+eq('quoted alias still wins over dq-literal', m.translate("SELECT CONCAT(a,b) as 'uri' FROM t"),
+   'SELECT CONCAT(a,b) as "uri" FROM t');
+// -- ORDER BY FIELD -> COALESCE(array_position(...), 0) (54023 >100-arg class)
+eq('field -> array_position', m.translate('SELECT r.id FROM r ORDER BY FIELD(r.id, 5, 3, 9)'),
+   'SELECT r.id FROM r ORDER BY COALESCE(array_position(ARRAY[5, 3, 9], r.id), 0)');
+eq('field non-numeric tail bails', m.translate('SELECT FIELD(x, 1, col) FROM t'),
+   'SELECT FIELD(x, 1, col) FROM t');
+// -- TIMESTAMPDIFF -> epoch math (42703 column "second" class, models.js)
+eq('timestampdiff second', m.translate('SELECT TIMESTAMPDIFF(SECOND, a.c1, b.c2) as joblength FROM t'),
+   'SELECT trunc(EXTRACT(EPOCH FROM ((b.c2) - (a.c1))))::bigint as joblength FROM t');
+eq('timestampdiff minute', m.translate('SELECT TIMESTAMPDIFF(MINUTE, a, b) FROM t'),
+   'SELECT trunc(EXTRACT(EPOCH FROM ((b) - (a))) / 60)::bigint FROM t');
+eq('timestampdiff month bails (inexact)', m.translate('SELECT TIMESTAMPDIFF(MONTH, a, b) FROM t'),
+   'SELECT TIMESTAMPDIFF(MONTH, a, b) FROM t');
+
 eq('func name inside string untouched', m.translate("SELECT a FROM t WHERE note = 'call YEAR(x) and IF(y)'"),
    "SELECT a FROM t WHERE note = 'call YEAR(x) and IF(y)'");
 eq('column named year (no paren) untouched', m.translate('SELECT year FROM summary'),


### PR DESCRIPTION
Clears the residual divergence classes from the post-#1766 canary census (all root-caused to live shapes, all EXPLAIN'd/executed on the live PG replica, cross-engine raw-row-diffed):

**Commit 1 — translator (dbpool-pg.js):**
- **Double-quoted literals → single-quoted** (the REAL root of the census 'enum-compare' class: `J.state = "completed"` parsed as IDENTIFIER on PG → resolved to the jobs.completed COLUMN → 42883 `job_state = smallint` + the PM-shape 42702 ambiguous-column). Backslash literals punt honestly.
- **ORDER BY FIELD → COALESCE(array_position(ARRAY[…]), 0)** — fixes 42883 field-missing AND 54023 >100-args (visualizer ordered-ids). Numeric-tail guarded.
- **TIMESTAMPDIFF → epoch math** (SECOND/MINUTE/HOUR/DAY; MONTH+ punts — calendar semantics).
- Selftest 61 → **71 cases, ALL PASS**.

**Commit 2 — GROUP BY strictness (42803), per-query:** species search, projects getProjectClasses(countValidations), pattern_matchings find (conditional joined-PK grouping), recordings countProjectRecordings. Each proven group-cardinality-neutral: extended GROUP BY identical to original on MariaDB (77/137/52/12 rows raw-diffed) and identical MariaDB-vs-PG. Also `"completed"` → `'completed'` at 4 origin sites (engine-neutral).

**Commit 3 — soundscape isSystemClass bare-truthiness (42804) → `= 1`** (values 0/1 only, verified; 11 rows identical cross-engine).

**Inert-by-construction for MySQL execution:** translator only runs under DB_ENGINE=shadow/pg; the model edits are engine-neutral SQL MariaDB accepts identically (proven above). Canary re-verifies within hours of the image roll.