### PR TITLE
mysql2pg P6: fix alias and presence predicate residuals

### DIFF
--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -1500,10 +1500,10 @@ var Recordings = {
                 // Filter recordings by present/absent validations values from the Recording page.
                 if(parameters.presence){
                     if (parameters.presence === 'present') {
-                        constraints.push('CASE WHEN rv.present_review > 0 OR rv.present_aed > 0 THEN 1 ELSE rv.present END');
+                        constraints.push('(CASE WHEN rv.present_review > 0 OR rv.present_aed > 0 THEN 1 ELSE rv.present END) = 1');
                     }
                     if (parameters.presence === 'absent') {
-                        constraints.push('CASE WHEN rv.present = 0 AND rv.present_review = 0 AND rv.present_aed = 0 THEN 1 ELSE 0 END');
+                        constraints.push('(CASE WHEN rv.present = 0 AND rv.present_review = 0 AND rv.present_aed = 0 THEN 1 ELSE 0 END) = 1');
                     }
                 }
                 // Do not get deleted validations values in the filters result.

--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -463,9 +463,13 @@ function fixQuotedAliases(sql, store) {
     return sql.replace(/\b(AS)\s+\u0001L(\d+)\u0001/gi, function (whole, kw, n) {
         var raw = store[parseInt(n, 10)];
         if (raw == null) { return whole; }
-        var ident = raw.replace(/^['"]/, '').replace(/['"]$/, '');
-        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(ident)) { return whole; } // not a bare ident
-        return kw + ' "' + ident + '"';
+        var ident = raw.slice(1, -1);
+        // MySQL permits string-literal aliases, including spaces. PG requires
+        // identifier aliases. Convert `AS 'Playlist Name'` / `AS "Playlist Name"`
+        // to a quoted identifier; remaining non-alias double-quoted literals are
+        // converted later by restoreLiteralsPg into PG string literals.
+        ident = ident.replace(/""/g, '"');
+        return kw + ' "' + ident.replace(/"/g, '""') + '"';
     });
 }
 

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -97,8 +97,8 @@ eq('force index stripped', m.translate('SELECT r.recording_id FROM recordings AS
 // quoted alias -> double-quoted identifier; string-value literals untouched
 eq('quoted alias', m.translate("SELECT CONCAT('a', A.job_id) as 'uri' FROM aed A"),
    'SELECT CONCAT(\'a\', A.job_id) as "uri" FROM aed A');
-eq('non-ident quoted alias left as literal', m.translate("SELECT x as 'a b' FROM t"),
-   "SELECT x as 'a b' FROM t");
+eq('multi-word quoted alias -> identifier', m.translate("SELECT x as 'a b' FROM t"),
+   'SELECT x as "a b" FROM t');
 // literal protection: none of the above touch matching text inside a string
 // -- double-quoted string literals (MySQL) -> single-quoted (PG). Live P6
 // canary classes: J.state = "completed" resolved as IDENTIFIER on PG ->


### PR DESCRIPTION
## Summary
- Fix P6 shadow translator regression for MySQL string-literal aliases containing spaces, e.g. `AS "Playlist Name"`, by converting string-literal aliases to PG quoted identifiers before double-quoted value literals are restored.
- Keep #1767's value-literal fix intact (`J.state = "completed"` -> `'completed'`).
- Fix recording presence filters that used numeric CASE expressions as bare WHERE predicates by comparing them explicitly to `= 1`.

## Live evidence
- Canary post-#1767 Loki showed new `42601 syntax error at or near "'Playlist Name'"` for job-parameter display templates.
- Local translator proof now emits `AS "Playlist Name"` while still emitting `J.state = 'completed'`.
- Live PG replica EXPLAIN succeeds for the fixed multi-word aliases and fixed present/absent CASE predicates.

## Tests
- `node app/utils/dbpool-pg.selftest.js` -> ALL 71 PASS
- `node --check app/utils/dbpool-pg.js`
- `node --check app/model/recordings.js`
