### PR TITLE
fix: soundscapes missing storage import (pod-crash) + classification GROUP BY strictness

### DIFF
--- a/app/model/classifications.js
+++ b/app/model/classifications.js
@@ -245,7 +245,7 @@ var Classifications = {
                 c.job_id
             FROM classification_results c
             WHERE c.job_id = ?
-            GROUP BY c.species_id, c.songtype_id
+            GROUP BY c.species_id, c.songtype_id, c.job_id
         ) AS agg
         JOIN job_params_classification jpc
             ON jpc.job_id = agg.job_id

--- a/app/model/soundscapes.js
+++ b/app/model/soundscapes.js
@@ -13,6 +13,7 @@ let config       = require('../config');
 let arrays_util  = require('../utils/arrays');
 let tmpfilecache = require('../utils/tmpfilecache');
 const { arbimon2PublicUrl } = require('../utils/asset-url');
+const { createS3Client } = require('../utils/storage');
 const k8sConfig = config('k8s');
 const jsonTemplates = require('../utils/json-templates');
 const { Client } = require('kubernetes-client');


### PR DESCRIPTION
## Summary
Two independent fixes found during the P6 shadow-canary census (2026-07-22 night):

1. **soundscapes.js: missing `createS3Client` import — PROD POD-CRASH BUG (not P6-related).** The #1761 storage-centralization pass converted `soundscapes.js` to `createS3Client('aws')` at lines 118 (fetchSCIDXFile) + 519 (delete) but never added the `require('../utils/storage')` import — every other converted model has it. Any soundscape scidx fetch or delete throws an uncaught `ReferenceError` through the mysql callback (`Parser.js "Rethrow non-MySQL errors"`) and **kills the pod**. Live evidence today: 3 pod restarts across both main arbimon pods + the shadow canary, each with this exact traceback. One-line import fix.

2. **classifications.js `detail()`: GROUP BY strictness (42803).** The inner aggregate selects `c.job_id` but groups only by species/songtype — MySQL loose-GROUP-BY tolerates it (job_id is WHERE-pinned constant), PG rejects it. Adding `c.job_id` to the GROUP BY is provably cardinality-neutral (`WHERE c.job_id = ?` pins it). Same class as the four #1767 GROUP-BY fixes.

## Verification
- `node --check` clean on both files.
- GROUP BY fix proven on live data (job 168098): old-vs-new inner query rows IDENTICAL on MariaDB; new query executes on PG; MariaDB-vs-PG rows cross-engine identical; full outer join query executes on PG.
- Import fix: `createS3Client` verified exported by `app/utils/storage.js`; identical import pattern to classifications/training_sets/templates/recordings.
