### PR TITLE
fix(exports): RFM early-throw guard + remaining console.err typos

### DIFF
--- a/jobs/arbimon-recording-export-job/rfm-classification.js
+++ b/jobs/arbimon-recording-export-job/rfm-classification.js
@@ -9,23 +9,37 @@ const exportReportType = 'RFM Classification';
 const exportReportJob = `Arbimon Export ${exportReportType} job`
 
 async function collectData (projection_parameters, cb) {
-  const [res] = await getName(projection_parameters.rfmClassify)
-  const jobMeta = await getJobMeta(projection_parameters.rfmClassify).catch(() => null)
-  const filePath = path.join(__dirname, `rfm_${res.name}.csv`)
-  const targetFile = fs.createWriteStream(filePath, { flags: 'a' })
-  await exportRFMClassify(projection_parameters.rfmClassify, targetFile, async (err, data) => {
-    if (err) {
-      console.err('Error export RFM Classification', err)
-      targetFile.end()
-      return cb(err)
+  // Whole body guarded: an early throw here (e.g. res undefined for a
+  // nonexistent job id) previously escaped as an UNHANDLED REJECTION and
+  // killed the process before the row's error was recorded — the #1759
+  // poison-row class, surviving in this file (caught by the 2026-07-23
+  // forced-failure E2E). Also: console.err is not a function (same class as
+  // the #1759 pattern-matching fixes) — the catch handlers themselves threw.
+  try {
+    const [res] = await getName(projection_parameters.rfmClassify)
+    if (!res || !res.name) {
+      return cb(new Error(`classification job ${projection_parameters.rfmClassify} not found`))
     }
-    console.log(`${exportReportJob}: finished collecting chunks`)
-    targetFile.end()
-    cb(null, path.resolve(filePath), `rfm_${res.name}`, jobMeta)
-  }).catch((e) => {
-    console.err('Error export RFM Classification', e)
+    const jobMeta = await getJobMeta(projection_parameters.rfmClassify).catch(() => null)
+    const filePath = path.join(__dirname, `rfm_${res.name}.csv`)
+    const targetFile = fs.createWriteStream(filePath, { flags: 'a' })
+    await exportRFMClassify(projection_parameters.rfmClassify, targetFile, async (err, data) => {
+      if (err) {
+        console.error('Error export RFM Classification', err)
+        targetFile.end()
+        return cb(err)
+      }
+      console.log(`${exportReportJob}: finished collecting chunks`)
+      targetFile.end()
+      cb(null, path.resolve(filePath), `rfm_${res.name}`, jobMeta)
+    }).catch((e) => {
+      console.error('Error export RFM Classification', e)
+      cb(e)
+    })
+  } catch (e) {
+    console.error('Error export RFM Classification (early)', e)
     cb(e)
-  })
+  }
 }
 
 async function exportRFMClassify (jobId, targetFile, cb) {

--- a/jobs/arbimon-recording-export-job/soundscape.js
+++ b/jobs/arbimon-recording-export-job/soundscape.js
@@ -22,7 +22,7 @@ async function collectData (projection_parameters, filters, cb) {
    // 1. Export .csv file
   await exportAllSoundscapes(filters.project_id, projection_parameters.projectUrl, targetFile, async (err, data) => {
     if (err) {
-      console.err(`Error export ${exportReportType}`, err)
+      console.error(`Error export ${exportReportType}`, err)
       targetFile.end()
       return cb(err)
     }
@@ -34,7 +34,7 @@ async function collectData (projection_parameters, filters, cb) {
     await getProjectSoundscapesImages(soundscapes)
     cb(null, path.resolve(filePath))
   }).catch((e) => {
-    console.err(`Error export ${exportReportType}`, e)
+    console.error(`Error export ${exportReportType}`, e)
     cb(e)
   })
 }


### PR DESCRIPTION
E2E follow-up (3rd): the forced-failure test (rfmClassify with a nonexistent job id) crashed the process via an unhandled early throw in `rfm-classification.js collectData` (`res.name` on undefined) before any error recording — the #1759 poison-row class surviving in this file. Body guarded + explicit not-found error. Also fixed the remaining `console.err` (not-a-function) typos in soundscape.js + the rfm handlers — the crash-in-the-catch-handler class.