### PR TITLE
fix(delete-job): copy app/utils into the delete-job image (dbpool-pg MODULE_NOT_FOUND)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,6 +11,15 @@ COPY jobs /app/jobs
 
 # -- arbimon-recording-delete-job --
 FROM build as arbimon-recording-delete-job
+# jobs/db/index.js requires jobs/db/pg.js (exports PG backend, #1770) which
+# requires app/utils/dbpool-pg (the P6 translator). This stage never copied
+# app/utils, so the 2026-07-23 rebuild crashed at require-time
+# (MODULE_NOT_FOUND) and the daily delete cron failed. Copy app/utils like
+# the export-job stage does (dbpool-pg itself needs only crypto + the pg
+# package already present in jobs/package.json; it is INERT without
+# DB_ENGINE=pg/shadow).
+RUN mkdir -p /app/app/utils
+COPY app/utils /app/app/utils
 CMD ["node", "jobs/arbimon-recording-delete-job/index.js"]
 
 # -- arbimon-recording-export-job --


### PR DESCRIPTION
The arbimon-recording-delete-job CronJob has failed since the 2026-07-23 CD rebuild: #1770 made jobs/db/index.js require the PG backend (jobs/db/pg.js -> app/utils/dbpool-pg), but the delete-job Dockerfile stage copies only jobs/ — the CronJob rides rfcx-local-prod-latest, so the rebuild crashed at require-time (MODULE_NOT_FOUND x6 attempts at 15:00Z; user deletions won't process until fixed).

Fix: copy app/utils into the stage (same pattern as the export-job stage). Verified locally: --target arbimon-recording-delete-job builds and require('/app/jobs/db/index.js') resolves inside the built image. dbpool-pg is INERT without DB_ENGINE=pg/shadow, so the delete job's runtime behavior is unchanged.