### PR TITLE
fix(recordings): treat a trailing slash on a recording-id url as part of the id (PG 22P02 at the mysql2pg read cutover)

### DIFF
--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -118,8 +118,24 @@ var Recordings = {
                 deferred.resolve({
                     id    : rec_match[ 1] | 0
                 });
-            // match recording ids
-            } else if((rec_match = /^(\d+)$/.exec(recording_url))){
+            // match recording ids (optionally with a trailing slash)
+            //
+            // rfcx-local 2026-07-25 (mysql2pg Phase 6 shadow finding): the
+            // trailing slash matters. A url like "310984658/" did NOT match the
+            // bare-id pattern, so it fell through to the generic
+            // site-year-month branch below, where group(1) becomes the SITE —
+            // producing a predicate of `site_id = '310984658/'`.
+            //
+            // MySQL silently coerces that trailing-garbage string to a number
+            // (0 rows, no error), so the bug is invisible today. PostgreSQL
+            // correctly rejects it: `invalid input syntax for type bigint:
+            // "310984658/"` (SQLSTATE 22P02). Verified on both live engines.
+            //
+            // Left unfixed, the arbimon2 MariaDB->PostgreSQL read cutover would
+            // turn a benign "no results" into a 500 on these URLs. Treating a
+            // trailing slash as part of the id (rather than as a site name) is
+            // also simply the correct reading of the url.
+            } else if((rec_match = /^(\d+)\/?$/.exec(recording_url))){
                 patternFound = true;
                 deferred.resolve({
                     id    : rec_match[ 1] | 0


### PR DESCRIPTION
## Problem

A recording url with a trailing slash — `310984658/` — does **not** match `parseUrl()`'s bare-id pattern `/^(\d+)$/`, so it falls through to the generic `site-year-month-day` branch, where capture group 1 becomes the **site**. Legacy then builds a predicate of:

```sql
site_id = '310984658/'
```

**MySQL silently coerces** that trailing-garbage string to a number (0 rows, no error), so the defect is invisible in production today. **PostgreSQL correctly rejects it:**

```
ERROR: invalid input syntax for type bigint: "310984658/"   (SQLSTATE 22P02)
```

Both behaviours were verified directly against the live engines.

## How it was found

The mysql2pg Phase-6 shadow-read canary replays read-only statements against the PostgreSQL copy and diffs the results. This template showed up as a recurring `dialect_error` (SQLSTATE 22P02) — 4 hits in ~2 hours.

Worth stating explicitly: the `SUBSTRING_INDEX(R.uri,'/',-1)` in the same query was **ruled out** as the cause. Its translation to `split_part(R.uri, '/', -1)` is correct, and returns an identical value to MySQL on live PostgreSQL 14.19.

## Why it matters

Today MariaDB serves the response and the shadow only logs, so users see nothing. After the arbimon2 MariaDB → PostgreSQL **read cutover**, this same url turns a benign "no results" into a **500**.

Reading a trailing slash as part of the id (rather than as a site name) is also simply the correct interpretation of the url.

## The change

One anchor, in one regex:

```diff
-} else if((rec_match = /^(\d+)$/.exec(recording_url))){
+} else if((rec_match = /^(\d+)\/?$/.exec(recording_url))){
```

Scope is deliberately minimal because `parseUrl` sits on a hot read path.

## Verification

Checked 15 url shapes and confirmed that **exactly one** routing decision changes — the trailing-slash id:

| url | before | after |
|---|---|---|
| `310984658/` | generic → **site** | **id** ✅ *(the fix)* |
| `310984658` | id | id |
| `310984658.flac` / `.wav` / `.opus` | file | file |
| `MySite`, `MySite-2026`, `MySite-2026-07`, `MySite-2026-07-18` | generic | generic |
| `!q:123` (site-id query form) | generic | generic |
| `last` (special flag) | generic | generic |
| `310984658//`, `/310984658`, `abc/` | generic | generic |

`node --check` clean.