### PR TITLE
fix(shadow): guard checked-out pg client errors so a PG failover cannot kill the app

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -801,17 +801,50 @@ function shadowAfterRead(finalSql, mariaRows, meta) {
             emitStat({ ev: 'connect_error', err: String(err && err.message || err).slice(0, 200) });
             return;
         }
+        // CHECKED-OUT CLIENT ERROR GUARD (rfcx-local 2026-07-26).
+        // The pool-level `_pool.on('error')` in getPool() only covers clients
+        // sitting IDLE in the pool. A client that is CHECKED OUT and mid-query
+        // when its server connection dies emits 'error' on ITSELF; with no
+        // listener, Node rethrows it as an uncaught exception and the PROCESS
+        // EXITS. A PG failover (or a pgbouncer restart) kills exactly these
+        // in-flight connections.
+        //
+        // Observed in production 2026-07-25: Patroni failed over TL 61->62 at
+        // 23:36:17Z and the shadow pod died 6s later at 23:36:23Z with
+        // "Error: Connection terminated unexpectedly / Emitted 'error' event on
+        // Client instance" — 4 restarts in ~3.5h across repeated failovers
+        // (5 failovers in 6 days on this cluster). The shadow is meant to be
+        // strictly fire-and-forget: it must NEVER be able to kill the app.
+        // This matters most at the Phase-6 stage-3 rollout, where DB_ENGINE=
+        // shadow moves onto the MAIN user-facing replicas.
+        //
+        // Counted as pg_error (a connection fault), never as a divergence.
+        var clientDead = false;
+        client.on('error', function (cerr) {
+            if (clientDead) { return; }
+            clientDead = true;
+            _counters.pg_error++;
+            emitStat({ ev: 'client_error',
+                err: String(cerr && cerr.message || cerr).slice(0, 200) });
+            // Release with the error so pg DESTROYS this client instead of
+            // returning a broken connection to the pool.
+            try { release(cerr); } catch (e) { /* already released */ }
+            finish();
+        });
+
         // pgbouncer is transaction-pooled: wrap everything in ONE explicit
         // read-only transaction so the timeout guard + SELECT share a server
         // connection, and ROLLBACK always releases it clean. SET LOCAL scopes
         // the timeout to this transaction only.
         var begin = 'BEGIN READ ONLY; SET LOCAL statement_timeout=' + Math.round(TIMEOUT_MS) + ';';
         client.query(begin, function (gerr) {
+            if (clientDead) { return; }   // client already failed + released
             if (gerr) {
                 try { client.query('ROLLBACK', function () { release(); }); } catch (e) { release(); }
                 finish(); _counters.pg_error++; return;
             }
             client.query(pgSql, function (qerr, pgRes) {
+                if (clientDead) { return; }   // client already failed + released
                 // Always end the transaction + release the client.
                 try { client.query('ROLLBACK', function () { release(); }); } catch (e) { release(); }
                 finish();


### PR DESCRIPTION
## Problem

The Phase-6 shadow reader **crashes the Node process when PostgreSQL fails over.**

Observed in production 2026-07-25:

- Patroni failover **TL 61→62 at 23:36:17Z**
- Shadow pod terminated `reason=Error` at **23:36:23Z** — six seconds later
- **4 restarts in ~3.5h**; this cluster saw **5 failovers in 6 days**, so it recurs

```
Error: Connection terminated unexpectedly
    at Connection.<anonymous> (/app/node_modules/pg/lib/client.js:199:73)
Emitted 'error' event on Client instance at:
    at Client._handleErrorEvent (/app/node_modules/pg/lib/client.js:417:10)
```

## Root cause

`getPool()` installs `_pool.on('error', …)` — correct, and it covers clients sitting **idle in the pool**.

It does **not** cover a client that is **checked out and mid-query** when its server connection dies. That `Client` emits `'error'` on *itself*; with no listener, Node rethrows it as an uncaught exception and the process exits.

A PG failover (or a pgbouncer restart) kills precisely those in-flight connections. The `pool.connect` / `client.query` callbacks handle **query** errors, not **connection-lifetime** `error` events.

## Fix

Attach `client.on('error', …)` as soon as the client is checked out:

- count it as `pg_error` (a connection fault — **never** a divergence)
- emit a `client_error` stat for observability
- call `release(err)` so `pg` **destroys** the broken client instead of returning it to the pool
- a `clientDead` flag makes the query callbacks no-ops afterwards, so a late error can't double-release or escape

## Why this matters beyond the canary

Today only the 1-replica shadow sibling sets `DB_ENGINE=shadow`, so a crash costs a restart of a non-user-facing pod — the main pods are inert and were unaffected (verified: 0 `DB_ENGINE` entries).

**Phase-6 stage 3 moves `DB_ENGINE=shadow` onto the MAIN user-facing replicas.** At that point this same failover would crash **both of them simultaneously**, turning a routine, correctly-handled HA event into a site outage. The shadow is meant to be strictly fire-and-forget and must never be able to take down the request path.

## Verification

- `dbpool-pg.selftest.js` **75/75 PASS**; `node --check` clean.
- Standalone repro of the exact mechanism (a checked-out client emitting `'error'` mid-query):

```
WITHOUT the guard: RESULT: PROCESS WOULD CRASH -> Connection terminated unexpectedly
WITH the guard:    guard caught: Connection terminated unexpectedly
                   release(err) called -> client destroyed, not pooled
                   RESULT: SURVIVED (app still running, counted as pg_error)
```

**Rollout acceptance test:** force a Patroni switchover and confirm the canary logs `client_error`, keeps serving, and does **not** restart. That test is the real gate — the previous design claim ("background idle-client errors must never crash the app") was falsified by these 4 restarts.