### PR TITLE
fix(shadow): idempotent release() — #1780 was incomplete, crashed on a live failover test

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -820,15 +820,32 @@ function shadowAfterRead(finalSql, mariaRows, meta) {
         //
         // Counted as pg_error (a connection fault), never as a divergence.
         var clientDead = false;
+        // release() is reachable from SEVERAL paths (the client 'error'
+        // handler, the BEGIN callback, the query callback, and the ROLLBACK
+        // callback nested inside those). pg-pool THROWS on a double release
+        // ("Release called on client which has already been released to the
+        // pool") and that throw is itself uncaught -> process exit. So funnel
+        // every path through one idempotent wrapper.
+        // PROVEN NECESSARY: the first version of this fix guarded only the
+        // outer callbacks with `clientDead`, but an in-flight ROLLBACK callback
+        // still fired release() after the error handler had already released,
+        // and the pod died with the double-release throw during a live Patroni
+        // switchover acceptance test (2026-07-26).
+        var released = false;
+        var releaseOnce = function (relErr) {
+            if (released) { return; }
+            released = true;
+            try { release(relErr); } catch (e) { /* pool already reclaimed it */ }
+        };
         client.on('error', function (cerr) {
             if (clientDead) { return; }
             clientDead = true;
             _counters.pg_error++;
             emitStat({ ev: 'client_error',
                 err: String(cerr && cerr.message || cerr).slice(0, 200) });
-            // Release with the error so pg DESTROYS this client instead of
+            // Release WITH the error so pg DESTROYS this client instead of
             // returning a broken connection to the pool.
-            try { release(cerr); } catch (e) { /* already released */ }
+            releaseOnce(cerr);
             finish();
         });
 
@@ -840,13 +857,13 @@ function shadowAfterRead(finalSql, mariaRows, meta) {
         client.query(begin, function (gerr) {
             if (clientDead) { return; }   // client already failed + released
             if (gerr) {
-                try { client.query('ROLLBACK', function () { release(); }); } catch (e) { release(); }
+                try { client.query('ROLLBACK', function () { releaseOnce(); }); } catch (e) { releaseOnce(); }
                 finish(); _counters.pg_error++; return;
             }
             client.query(pgSql, function (qerr, pgRes) {
                 if (clientDead) { return; }   // client already failed + released
                 // Always end the transaction + release the client.
-                try { client.query('ROLLBACK', function () { release(); }); } catch (e) { release(); }
+                try { client.query('ROLLBACK', function () { releaseOnce(); }); } catch (e) { releaseOnce(); }
                 finish();
                 if (qerr) {
                     // 57014 = query_canceled (our statement_timeout): a slow


### PR DESCRIPTION
## What happened

**#1780 was incomplete.** A live Patroni switchover acceptance test (2026-07-26 04:57Z) proved it: the new guard fired correctly — **7 `client_error` lines logged** — but the pod **still crashed**, just with a different error:

```
/app/node_modules/pg-pool/index.js:27
  throw new Error('Release called on client which has already been released to the pool.')
    at Query.callback (/app/app/utils/dbpool-pg.js:843:62)
```

Canary restarts went **0 → 1** during the test.

## Why the first fix missed it

#1780 guarded only the **outer** callbacks with a `clientDead` flag. The real ordering (from the production stack trace) is:

1. the **query callback fires first**, with an error, while `clientDead` is still `false`
2. it issues `ROLLBACK`; the ROLLBACK callback calls `release()` → the pool reclaims the client
3. **then** the client emits `'error'` → the handler calls `release()` a **second time**

`pg-pool` throws on double release, and that throw is itself uncaught → process exit. So the crash didn't go away, it **moved** — from `Connection terminated unexpectedly` to the double-release throw.

## Fix

Funnel **every** release path — the client `'error'` handler, the `BEGIN` callback, the query callback, and the `ROLLBACK` callbacks nested inside them — through a single idempotent `releaseOnce()` wrapper.

## Verification

A repro matching the **real callback ordering** (query-callback-first, then the `'error'` event):

```
v1 (the build that failed live): RESULT: PROCESS CRASHES -> Release called on client which has already been released to the pool.
v2 (this fix):                   RESULT: SURVIVED
```

Plus `dbpool-pg.selftest.js` **75/75** and `node --check` clean.

## Worth keeping

This is exactly why the acceptance test exists. The first fix looked correct, its unit repro passed, and it was **only falsified by forcing a real failover in production**. My initial repro also failed to reproduce the bug because I guessed the callback ordering — matching the actual stack trace was what made it faithful.

**Re-run the switchover test after this rolls**, and treat a clean switchover (restart count unchanged) as the gate before Phase-6 stage 3.