### PR TITLE
shadow: decode MySQL literal escapes + stop miscounting connection faults + 6.4 pg routing (inert)

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -1045,21 +1045,42 @@ if (ENGINE === 'shadow') { startStatHeartbeat(); }
 
 var PG_ROUTE_FALLBACK = (process.env.DB_PG_FALLBACK || '1') !== '0';
 
-// Build lowercase -> original-case map for every identifier-ish token in the
-// source SQL that is not already all-lowercase. Cheap (one regex pass) and
-// only ever ADDs casing that MySQL would have returned.
-var _CASE_TOKEN_RE = /[`"]?\b([A-Za-z_][A-Za-z0-9_$]*)\b[`"]?/g;
+// Build lowercase -> original-case map for the MIXED-CASE identifiers in the
+// source SQL. Only ever restores casing MySQL itself would have returned.
+//
+// SELF-REVIEW DEFECT, CAUGHT + FIXED BEFORE MERGE (2026-07-27) — keep this,
+// it is the #1780 lesson repeating: the first version scanned every word in
+// the raw SQL, so STRING-LITERAL CONTENTS and SQL KEYWORDS became map
+// entries. Reproduced concretely:
+//   SELECT j.job_id, j.completed FROM jobs j WHERE j.state = 'Completed'
+// mapped completed -> 'Completed' and RENAMED the real jobs.completed result
+// key to `Completed` — i.e. the exact silent key-shape corruption this
+// function exists to PREVENT, introduced by the fix itself.
+// Three guards now:
+//   1. literals are stripped first, reusing the translator's own
+//      protectLiterals() so literal text can never be scanned;
+//   2. an all-UPPERCASE token is never treated as an identifier (SQL keywords
+//      are written uppercase throughout this codebase; arbimon2 has ZERO
+//      all-uppercase column names — verified live against
+//      information_schema, count = 0). Genuine camelCase (`typeId`,
+//      `isSystemClass`, `recUri`) always contains a lowercase char, so this
+//      excludes keywords without excluding any real column;
+//   3. only the trailing component of a qualified name is used (`SCC.typeId`
+//      -> `typeId`), since that is what appears as the result key.
+var _CASE_TOKEN_RE = /[A-Za-z_][A-Za-z0-9_$]*/g;
 function columnCaseMap(mysqlSql) {
+    var litStore = [];
+    var stripped = protectLiterals(String(mysqlSql), litStore)
+        .replace(/\u0001L\d+\u0001/g, ' ');   // drop literal placeholders entirely
     var map = null;
     var m;
     _CASE_TOKEN_RE.lastIndex = 0;
-    while ((m = _CASE_TOKEN_RE.exec(mysqlSql)) !== null) {
-        var tok = m[1];
+    while ((m = _CASE_TOKEN_RE.exec(stripped)) !== null) {
+        var tok = m[0];
         var low = tok.toLowerCase();
-        if (low === tok) { continue; }          // already lowercase: nothing to restore
+        if (low === tok) { continue; }              // already lowercase
+        if (tok === tok.toUpperCase()) { continue; } // SQL keyword, not a column
         if (!map) { map = {}; }
-        // First occurrence wins; SQL keywords are uppercase too but they never
-        // collide with a returned column key, so a stray entry is inert.
         if (!Object.prototype.hasOwnProperty.call(map, low)) { map[low] = tok; }
     }
     return map;

--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -218,18 +218,76 @@ function restoreLiterals(sql, store) {
 // joined tables both have `completed` → 42702 ambiguous-column. Convert every
 // REMAINING double-quoted literal (fixQuotedAliases already consumed the
 // `AS "x"` cases before this runs) to a PG single-quoted literal.
-// Conservative: a literal containing a backslash is left unchanged (MySQL
-// backslash-escape semantics differ from PG standard_conforming_strings) —
-// it surfaces as an honest dialect_error instead of a silent wrong value.
+//
+// BACKSLASH ESCAPES (rfcx-local 2026-07-27, stage-3 day-1 finding).
+// Previously ANY literal containing a backslash was punted verbatim, which
+// produced TWO live failure modes because the mysql driver's SqlString
+// escaper emits backslash escapes for `' " \ \0 \b \n \r \t \Z`:
+//   (a) LOUD: a value containing a quote — e.g. the real site name
+//       `SNR ''Kraljevac''` (site_id 88347, created 2026-07-27T10:18:26Z) —
+//       arrives as 'SNR \'\'Kraljevac\'\'' and PG (standard_conforming_strings
+//       = on, verified live) raises 42601 `syntax error at or near "\"`.
+//       Same shape for any O'Brien-class name.
+//   (b) SILENT + WORSE: a value containing a newline/tab arrives as 'a\nb';
+//       under standard_conforming_strings=on PG reads that as a LITERAL
+//       backslash + 'n' (proven live on the replica: 'a\nb' = E'a\nb' is
+//       FALSE, length('a\nb') = 4). No error — just a wrong comparison, and
+//       at the 6.4 read flip, wrong RESULTS.
+// So we now DECODE MySQL escape semantics and RE-ENCODE as a standard PG
+// literal. This is safe to do here and only here: protectLiterals() guarantees
+// no other translator pass has seen the literal's contents.
+//
+// Decoder semantics are MEASURED against the live master (sql_mode='', i.e.
+// NO_BACKSLASH_ESCAPES off — verified 2026-07-27), not assumed:
+//   \0 \b \n \r \t \Z  -> NUL BS LF CR TAB SUB
+//   \' \" \\           -> ' " \
+//   \% \_              -> KEEP THE BACKSLASH (MySQL leaves these intact so
+//                         LIKE metacharacter escaping survives; live:
+//                         LENGTH('a\%b') = 4). Decoding them would silently
+//                         change LIKE semantics.
+//   \<other>           -> the bare character (live: '[a\qb]' -> [aqb])
+// A literal containing NUL is punted honestly: PG text cannot represent \0,
+// so there is no correct translation (an honest dialect_error beats a wrong
+// value — the same principle the original punt was reaching for).
+var MYSQL_ESCAPE_MAP = { '0': '\0', 'b': '\b', 'n': '\n', 'r': '\r',
+                         't': '\t', 'Z': '\x1a' };
+
+function decodeMysqlLiteral(inner, quoteChar) {
+    // Doubled quote chars (MySQL accepts '' inside '...' and "" inside "...").
+    var out = '';
+    for (var i = 0; i < inner.length; i++) {
+        var ch = inner.charAt(i);
+        if (ch === '\\' && i + 1 < inner.length) {
+            var nx = inner.charAt(i + 1);
+            if (nx === '%' || nx === '_') { out += '\\' + nx; i++; continue; }
+            out += Object.prototype.hasOwnProperty.call(MYSQL_ESCAPE_MAP, nx)
+                 ? MYSQL_ESCAPE_MAP[nx] : nx;
+            i++;
+            continue;
+        }
+        if (ch === quoteChar && inner.charAt(i + 1) === quoteChar) {
+            out += quoteChar; i++; continue;
+        }
+        out += ch;
+    }
+    return out;
+}
+
+function encodePgLiteral(value) {
+    if (value.indexOf('\0') !== -1) { return null; }   // unrepresentable in PG text
+    return "'" + value.replace(/'/g, "''") + "'";
+}
+
 function restoreLiteralsPg(sql, store) {
     return sql.replace(/\u0001L(\d+)\u0001/g, function (_, n) {
         var raw = store[parseInt(n, 10)];
         if (raw == null) { return _; }
-        if (raw.charAt(0) !== '"') { return raw; }         // sq literal: verbatim
-        var inner = raw.slice(1, -1);
-        if (inner.indexOf('\\') !== -1) { return raw; }    // backslash: punt
-        inner = inner.replace(/""/g, '"');                 // MySQL "" → "
-        return "'" + inner.replace(/'/g, "''") + "'";      // escape for PG
+        var q = raw.charAt(0);
+        if (q !== '"' && q !== "'") { return raw; }
+        var decoded = decodeMysqlLiteral(raw.slice(1, -1), q);
+        var encoded = encodePgLiteral(decoded);
+        // NUL: punt verbatim -> honest dialect_error rather than a wrong value.
+        return encoded === null ? raw : encoded;
     });
 }
 
@@ -340,7 +398,15 @@ function litText(tok, store) {
     if (!m) { return null; }
     var raw = store[parseInt(m[1], 10)];
     if (raw == null) { return null; }
-    return raw.replace(/^['"]/, '').replace(/['"]$/, ''); // strip surrounding quotes
+    var q = raw.charAt(0);
+    if (q !== '"' && q !== "'") { return null; }
+    // Decode MySQL escape semantics for the same reason restoreLiteralsPg does
+    // (2026-07-27): callers here (DATE_FORMAT fmt, GROUP_CONCAT SEPARATOR)
+    // re-encode the text into a PG literal, so an undecoded `\'` would be
+    // re-emitted wrong. Today's live corpus uses escape-free literals
+    // (SEPARATOR ', ', plain date formats) — this keeps it correct if that
+    // ever changes, rather than depending on the corpus staying tame.
+    return decodeMysqlLiteral(raw.slice(1, -1), q);
 }
 
 function translateFunctions(sql, store) {
@@ -875,6 +941,30 @@ function shadowAfterRead(finalSql, mariaRows, meta) {
                             tmpl: sqlTemplate(text).slice(0, 200) });
                         return;
                     }
+                    // CONNECTION-LIFETIME error, not a SQL error (rfcx-local
+                    // 2026-07-27). A server-side connection death (failover,
+                    // pgbouncer restart, admin terminate) surfaces here as an
+                    // Error with NO SQLSTATE `.code` — e.g. "Connection
+                    // terminated unexpectedly" / "server conn crashed?". The
+                    // client 'error' handler above catches these when it wins
+                    // the race, but the QUERY callback frequently fires first
+                    // (that ordering is exactly what #1781 established), so the
+                    // same fault also lands here.
+                    // Counting it as dialect_error corrupted the O5 gate's
+                    // headline metric: MEASURED on 2026-07-27, the ~07:03Z
+                    // TL68->69 organic failover pushed pod r4h9l's
+                    // dialect_error counter 0->1 with NO divergence record
+                    // (the emission was swallowed by the per-template emit cap),
+                    // making a clean day look dirty and costing a triage cycle
+                    // to reconcile counters against Loki. A dialect_error must
+                    // mean "PG rejected or mis-executed our SQL", nothing else.
+                    if (!qerr.code) {
+                        _counters.pg_error++;
+                        emitStat({ ev: 'query_conn_error',
+                            err: String(qerr && qerr.message || qerr).slice(0, 200),
+                            hash: templateHash(text) });
+                        return;
+                    }
                     _counters.dialect_error++;
                     var dhash = templateHash(text);
                     if (divergenceEmitAllowed(dhash)) {
@@ -916,10 +1006,178 @@ function startStatHeartbeat() {
 }
 if (ENGINE === 'shadow') { startStatHeartbeat(); }
 
+// ==================================================================
+// PHASE 6.4 — `DB_ENGINE=pg` RESPONSE ROUTING (ships INERT)
+// ==================================================================
+// Everything below is unreachable unless DB_ENGINE=pg, which NOTHING sets
+// today (stage-0 pattern: land the code dark, flip the env later under an
+// operator-gated milestone). In `shadow` and `mysql` modes this section is
+// dead weight of one boolean.
+//
+// WHY THIS IS NOT "just run the translated SQL":
+//
+// **THE COLUMN-CASE TRAP (measured 2026-07-27, would have broken flip day).**
+// PG folds unquoted identifiers to lowercase, and the migrated arbimon schema
+// is all-lowercase (`information_schema`: `typeid`, `issystemclass`). MariaDB
+// returns the column's DECLARED case. So `SELECT SCC.typeId, SCC.isSystemClass`
+// yields keys {typeId, isSystemClass} on MariaDB but {typeid, issystemclass}
+// on PG. Any consumer reading `row.isSystemClass` silently gets `undefined`.
+// Live example: app/model/soundscape-composition.js:104 branches on
+// `scClass.isSystemClass` — under naive pg routing that branch inverts and the
+// project-class INSERT fires for system classes.
+//
+// The SHADOW COULD NOT HAVE CAUGHT THIS: rowMaps() lowercases every key before
+// comparing (by design, so casing noise never masks value diffs), so the
+// divergence stream is structurally blind to it. Zero divergences across the
+// whole clock says nothing about column casing — which is exactly why this
+// needed a code read + schema measurement, not more soak time.
+//
+// Affected surface, MEASURED not guessed (live information_schema): 8 camelCase
+// columns across 4 tables (model_types.usesSsim/usesRansac,
+// project_soundscape_composition_classes.projectId/scclassId,
+// recording_soundscape_composition_annotations.recordingId/scclassId,
+// soundscape_composition_classes.typeId/isSystemClass) plus ~20 camelCase SQL
+// aliases across 9 app/model files (`as recUri`, `as maxSiteId`, …).
+//
+// FIX: rebuild MySQL-shaped keys from the ORIGINAL SQL. Any identifier/alias
+// carrying uppercase is mapped lower->original and re-applied to PG rows, so
+// consumers see byte-identical key casing on both engines.
+
+var PG_ROUTE_FALLBACK = (process.env.DB_PG_FALLBACK || '1') !== '0';
+
+// Build lowercase -> original-case map for every identifier-ish token in the
+// source SQL that is not already all-lowercase. Cheap (one regex pass) and
+// only ever ADDs casing that MySQL would have returned.
+var _CASE_TOKEN_RE = /[`"]?\b([A-Za-z_][A-Za-z0-9_$]*)\b[`"]?/g;
+function columnCaseMap(mysqlSql) {
+    var map = null;
+    var m;
+    _CASE_TOKEN_RE.lastIndex = 0;
+    while ((m = _CASE_TOKEN_RE.exec(mysqlSql)) !== null) {
+        var tok = m[1];
+        var low = tok.toLowerCase();
+        if (low === tok) { continue; }          // already lowercase: nothing to restore
+        if (!map) { map = {}; }
+        // First occurrence wins; SQL keywords are uppercase too but they never
+        // collide with a returned column key, so a stray entry is inert.
+        if (!Object.prototype.hasOwnProperty.call(map, low)) { map[low] = tok; }
+    }
+    return map;
+}
+
+function restoreRowCase(rows, caseMap) {
+    if (!caseMap || !rows || !rows.length) { return rows; }
+    return rows.map(function (r) {
+        var out = {};
+        Object.keys(r).forEach(function (k) {
+            var want = Object.prototype.hasOwnProperty.call(caseMap, k) ? caseMap[k] : k;
+            out[want] = r[k];
+        });
+        return out;
+    });
+}
+
+// Only statements the SAME allowlist classifier accepts may be served from PG.
+// Everything else (writes, transactions, anything non-plain) stays on MariaDB.
+function pgRouteEligible(sql) {
+    return classify(sqlText(sql)).replayable;
+}
+
+/**
+ * Execute a read on PG and return MySQL-shaped rows (6.4 response routing).
+ * cb(err, rows). On any PG-side failure with DB_PG_FALLBACK enabled (default),
+ * cb is called with a sentinel so dbpool.js can retry on MariaDB — a read flip
+ * must degrade to the old engine, never to an error page.
+ */
+function pgReadQuery(finalSql, cb) {
+    var text = sqlText(finalSql);
+    var pool = getPool();
+    if (!pool) { return cb({ pgRouteFallback: true, message: 'pg pool unavailable' }); }
+    var pgSql;
+    try { pgSql = translate(text); } catch (e) {
+        _counters.dialect_error++;
+        emitDivergence({ v: 1, ts: new Date().toISOString(), klass: 'dialect_error',
+            phase: 'translate-pg', hash: templateHash(text),
+            tmpl: sqlTemplate(text).slice(0, 400),
+            detail: String(e && e.message || e).slice(0, 200) });
+        return cb({ pgRouteFallback: true, message: 'translate failed' });
+    }
+    var caseMap = columnCaseMap(text);
+    pool.connect(function (err, client, release) {
+        if (err) {
+            _counters.pg_error++;
+            emitStat({ ev: 'pg_route_connect_error',
+                err: String(err && err.message || err).slice(0, 200) });
+            return cb({ pgRouteFallback: true, message: 'connect failed' });
+        }
+        var released = false;
+        var releaseOnce = function (e) {
+            if (released) { return; } released = true;
+            try { release(e); } catch (x) { /* pool already reclaimed it */ }
+        };
+        var settled = false;
+        var settle = function (e, rows) {
+            if (settled) { return; } settled = true;
+            cb(e, rows);
+        };
+        // Same #1781 discipline as the shadow path: a checked-out client that
+        // dies mid-query emits 'error' on ITSELF; unlistened, Node rethrows and
+        // the PROCESS EXITS. Under DB_ENGINE=pg that would be a user-facing
+        // outage, so the guard is mandatory here too.
+        client.on('error', function (cerr) {
+            _counters.pg_error++;
+            emitStat({ ev: 'pg_route_client_error',
+                err: String(cerr && cerr.message || cerr).slice(0, 200) });
+            releaseOnce(cerr);
+            settle({ pgRouteFallback: true, message: 'client error' });
+        });
+        client.query('BEGIN READ ONLY; SET LOCAL statement_timeout=' +
+                     Math.round(TIMEOUT_MS) + ';', function (gerr) {
+            if (gerr) {
+                try { client.query('ROLLBACK', function () { releaseOnce(); }); }
+                catch (e) { releaseOnce(); }
+                _counters.pg_error++;
+                return settle({ pgRouteFallback: true, message: 'begin failed' });
+            }
+            client.query(pgSql, function (qerr, pgRes) {
+                try { client.query('ROLLBACK', function () { releaseOnce(); }); }
+                catch (e) { releaseOnce(); }
+                if (qerr) {
+                    // Connection-lifetime faults carry no SQLSTATE (see the
+                    // shadow path's matching guard) — never a dialect error.
+                    if (!qerr.code) {
+                        _counters.pg_error++;
+                        emitStat({ ev: 'pg_route_conn_error',
+                            err: String(qerr && qerr.message || qerr).slice(0, 200) });
+                    } else if (qerr.code === '57014') {
+                        _counters.pg_timeout++;
+                        emitStat({ ev: 'pg_route_timeout', hash: templateHash(text) });
+                    } else {
+                        _counters.dialect_error++;
+                        emitDivergence({ v: 1, ts: new Date().toISOString(),
+                            klass: 'dialect_error', phase: 'execute-pg',
+                            hash: templateHash(text), tmpl: sqlTemplate(text).slice(0, 400),
+                            detail: String(qerr && qerr.message || qerr).slice(0, 240),
+                            pg_code: qerr.code });
+                    }
+                    return settle({ pgRouteFallback: true, message: 'query failed' });
+                }
+                _counters.ok++;
+                settle(null, restoreRowCase((pgRes && pgRes.rows) || [], caseMap));
+            });
+        });
+    });
+}
+
 module.exports = {
     engine: ENGINE,
     enabled: ENABLED,
     isShadow: ENGINE === 'shadow',
+    // Phase 6.4 response routing (INERT unless DB_ENGINE=pg):
+    isPg: ENGINE === 'pg',
+    pgFallbackEnabled: PG_ROUTE_FALLBACK,
+    pgRouteEligible: pgRouteEligible,
+    pgReadQuery: pgReadQuery,
     // dbpool.js hook (shadow):
     shadowAfterRead: shadowAfterRead,
     // exported for the self-test + potential Phase-6.4 pg mode:
@@ -931,5 +1189,7 @@ module.exports = {
     sqlTemplate: sqlTemplate,
     templateHash: templateHash,
     normalizeRows: normalizeRows,
+    columnCaseMap: columnCaseMap,
+    restoreRowCase: restoreRowCase,
     _counters: _counters
 };

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -121,8 +121,42 @@ eq('dq literal with embedded sq', m.translate('SELECT a FROM t WHERE b = "it\'s"
    "SELECT a FROM t WHERE b = 'it''s'");
 eq('dq literal doubled dq', m.translate('SELECT a FROM t WHERE b = "a""b"'),
    "SELECT a FROM t WHERE b = 'a\"b'");
-eq('dq literal with backslash punts', m.translate('SELECT a FROM t WHERE b = "x\\\\y"'),
-   'SELECT a FROM t WHERE b = "x\\\\y"');
+// -- MySQL backslash-escape DECODING (rfcx-local 2026-07-27).
+// Supersedes the former "backslash punts" assertion: punting produced live
+// 42601s (site name `SNR ''Kraljevac''`, 2026-07-27T10:18:26Z) and, worse,
+// SILENT wrong values for \n/\t (PG standard_conforming_strings=on reads
+// 'a\nb' as literal backslash+n — proven live). Expected values below are
+// MEASURED cross-engine, not assumed.
+// MySQL "x\\y" is the 3-char string x\y (live: LENGTH=3); PG writes that as
+// 'x\y' with standard_conforming_strings=on (live: length=3).
+eq('dq literal backslash decodes', m.translate('SELECT a FROM t WHERE b = "x\\\\y"'),
+   "SELECT a FROM t WHERE b = 'x\\y'");
+// THE LIVE 42601 CASE: mysql driver escapes ' as \' — site 88347.
+eq('sq literal escaped quotes (live Kraljevac 42601)',
+   m.translate("SELECT count(*) as count FROM sites WHERE name = 'SNR \\'\\'Kraljevac\\'\\'' AND project_id = 8740"),
+   "SELECT count(*) as count FROM sites WHERE name = 'SNR ''''Kraljevac''''' AND project_id = 8740");
+eq('sq literal single escaped quote (O\'Brien class)',
+   m.translate("SELECT a FROM t WHERE b = 'O\\'Brien'"),
+   "SELECT a FROM t WHERE b = 'O''Brien'");
+// THE SILENT CASE: \n must become a REAL newline, not backslash+n.
+eq('sq literal newline decodes to real newline',
+   m.translate("SELECT a FROM t WHERE b = 'a\\nb'"),
+   "SELECT a FROM t WHERE b = 'a\nb'");
+eq('sq literal tab decodes to real tab',
+   m.translate("SELECT a FROM t WHERE b = 'a\\tb'"),
+   "SELECT a FROM t WHERE b = 'a\tb'");
+// LIKE metacharacter escapes: MySQL KEEPS the backslash (live: LENGTH('a\\%b')
+// = 4), so decoding them would silently change LIKE semantics.
+eq('sq literal keeps \\% for LIKE', m.translate("SELECT a FROM t WHERE b LIKE 'a\\%b'"),
+   "SELECT a FROM t WHERE b LIKE 'a\\%b'");
+eq('sq literal keeps \\_ for LIKE', m.translate("SELECT a FROM t WHERE b LIKE 'a\\_b'"),
+   "SELECT a FROM t WHERE b LIKE 'a\\_b'");
+// Unknown escape -> bare char (live: '[a\\qb]' -> [aqb]).
+eq('sq literal unknown escape drops backslash', m.translate("SELECT a FROM t WHERE b = 'a\\qb'"),
+   "SELECT a FROM t WHERE b = 'aqb'");
+// NUL is unrepresentable in PG text -> punt verbatim (honest dialect_error).
+eq('sq literal NUL punts verbatim', m.translate("SELECT a FROM t WHERE b = 'a\\0b'"),
+   "SELECT a FROM t WHERE b = 'a\\0b'");
 eq('quoted alias still wins over dq-literal', m.translate("SELECT CONCAT(a,b) as 'uri' FROM t"),
    'SELECT CONCAT(a,b) as "uri" FROM t');
 // -- ORDER BY FIELD -> COALESCE(array_position(...), 0) (54023 >100-arg class)
@@ -197,6 +231,41 @@ eq('float within epsilon equal', m.compare('SELECT a FROM t', [{a:1.0000000001}]
 // null vs empty NOT equal (T4 policy)
 var ne = m.compare('SELECT a FROM t', [{a:null}], [{a:''}], 1e-9);
 eq('null != empty (T4)', ne && ne.klass, 'result_mismatch');
+
+// -- Phase 6.4 response routing: COLUMN-CASE RESTORATION -------------------
+// PG folds unquoted identifiers to lowercase and the migrated schema is
+// all-lowercase, so PG returns `typeid` where MariaDB returns `typeId`. The
+// shadow's comparator lowercases keys before diffing, so it is structurally
+// BLIND to this class — these tests are the only guard. Live surface measured
+// 2026-07-27: 8 camelCase columns / 4 tables + ~20 camelCase aliases.
+var ccm = m.columnCaseMap('SELECT SCC.id, SCC.name, SCC.isSystemClass, SCC.typeId FROM soundscape_composition_classes SCC');
+eq('caseMap picks up isSystemClass', ccm && ccm.issystemclass, 'isSystemClass');
+eq('caseMap picks up typeId', ccm && ccm.typeid, 'typeId');
+// The real live shape from app/model/soundscape-composition.js:104.
+var pgRow = [{ id: 7, name: 'Birds', issystemclass: 1, typeid: 2 }];
+var restored = m.restoreRowCase(pgRow, ccm);
+eq('restored row exposes isSystemClass', restored[0].isSystemClass, 1);
+eq('restored row exposes typeId', restored[0].typeId, 2);
+eq('restored row keeps lowercase cols', restored[0].name, 'Birds');
+eq('restored row drops folded key', restored[0].issystemclass, undefined);
+// camelCase ALIASES must round-trip too (`as recUri`, `as maxSiteId`, …).
+var am = m.columnCaseMap('SELECT r.uri as recUri, MAX(s.site_id) as maxSiteId FROM recordings r');
+eq('caseMap picks up alias recUri', am && am.recuri, 'recUri');
+var ar = m.restoreRowCase([{ recuri: 'a/b.flac', maxsiteid: 9 }], am);
+eq('restored alias recUri', ar[0].recUri, 'a/b.flac');
+eq('restored alias maxSiteId', ar[0].maxSiteId, 9);
+// All-lowercase SQL must be a no-op (no map, rows untouched by identity).
+eq('all-lowercase sql -> no case map',
+   m.columnCaseMap('select site_id, name from sites where project_id = 1'), null);
+eq('no-op restore returns rows unchanged',
+   m.restoreRowCase([{ site_id: 1 }], null)[0].site_id, 1);
+// Routing eligibility mirrors the shadow allowlist: writes never route to PG.
+eq('pgRouteEligible allows plain select',
+   m.pgRouteEligible('SELECT a FROM t WHERE b = 1'), true);
+eq('pgRouteEligible refuses update',
+   m.pgRouteEligible('UPDATE t SET a = 1 WHERE b = 2'), false);
+eq('pgRouteEligible refuses insert',
+   m.pgRouteEligible('INSERT INTO t (a) VALUES (1)'), false);
 
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -259,6 +259,30 @@ eq('all-lowercase sql -> no case map',
    m.columnCaseMap('select site_id, name from sites where project_id = 1'), null);
 eq('no-op restore returns rows unchanged',
    m.restoreRowCase([{ site_id: 1 }], null)[0].site_id, 1);
+// REGRESSION GUARDS for the self-review defect (2026-07-27): string-literal
+// contents and SQL keywords must NEVER become case-map entries. The first
+// version of columnCaseMap mapped completed -> 'Completed' from the literal
+// below and renamed the real jobs.completed result key.
+var litMap = m.columnCaseMap("SELECT j.job_id, j.completed FROM jobs j WHERE j.state = 'Completed'");
+eq('literal contents never enter case map', litMap, null);
+eq('literal case defect: completed key preserved',
+   m.restoreRowCase([{ job_id: 5, completed: 1 }], litMap)[0].completed, 1);
+eq('literal case defect: no Completed key',
+   m.restoreRowCase([{ job_id: 5, completed: 1 }], litMap)[0].Completed, undefined);
+// dq literals too (MySQL string literals).
+eq('dq literal contents never enter case map',
+   m.columnCaseMap('SELECT a FROM t WHERE b = "MixedCase"'), null);
+// Uppercase SQL keywords must not be treated as identifiers.
+eq('keywords never enter case map',
+   m.columnCaseMap('SELECT a FROM t WHERE b IS NOT NULL ORDER BY a DESC'), null);
+// ...while a genuine camelCase column in the same shape still resolves.
+var mixMap = m.columnCaseMap("SELECT SCC.typeId FROM soundscape_composition_classes SCC WHERE SCC.name = 'Birds' ORDER BY SCC.typeId DESC");
+eq('camelCase survives alongside literals+keywords', mixMap && mixMap.typeid, 'typeId');
+eq('camelCase map has no literal entry', mixMap && mixMap.birds, undefined);
+// Qualified names map on their trailing component (the result key).
+eq('qualified name maps trailing component',
+   m.columnCaseMap('SELECT SCC.isSystemClass FROM t SCC').issystemclass, 'isSystemClass');
+
 // Routing eligibility mirrors the shadow allowlist: writes never route to PG.
 eq('pgRouteEligible allows plain select',
    m.pgRouteEligible('SELECT a FROM t WHERE b = 1'), true);

--- a/app/utils/dbpool.js
+++ b/app/utils/dbpool.js
@@ -172,6 +172,45 @@ var dbpool = {
     },
 
     queryHandler: function (query, options, callback) {
+        // -------- Phase 6.4 read flip (INERT unless DB_ENGINE=pg) ----------
+        // Serve eligible plain SELECTs from PostgreSQL. Writes and anything the
+        // allowlist classifier does not positively identify as a plain read fall
+        // through to MariaDB untouched (legacy still OWNS writes until Phase 7).
+        // Any PG-side failure falls back to MariaDB (DB_PG_FALLBACK=0 disables),
+        // so a read flip degrades to the previous engine rather than to an error
+        // page. Placed at the SAME chokepoint the shadow taps, so the code path
+        // validated for a week by shadow is the code path that now serves.
+        if (pgshadow.isPg) {
+            if (callback === undefined && options instanceof Function) {
+                callback = options;
+                options = undefined;
+            }
+            var pgRaw = (typeof query === 'string') ? query
+                : (query && typeof query.sql === 'string') ? query.sql : null;
+            if (pgRaw !== null && pgshadow.pgRouteEligible(pgRaw)) {
+                var pgFinal = null;
+                try {
+                    pgFinal = mysql.format(pgRaw, options, false, config('db').timezone || 'Z');
+                } catch (e) { pgFinal = null; }
+                if (pgFinal !== null) {
+                    var mysqlFallback = function () {
+                        dbpool.getConnection(function (err, connection) {
+                            if (err) { return callback(err); }
+                            dbpool.queryWithConnHandler(connection, query, options, true, callback);
+                        });
+                    };
+                    return pgshadow.pgReadQuery(pgFinal, function (pgErr, rows) {
+                        if (pgErr) {
+                            if (pgErr.pgRouteFallback && pgshadow.pgFallbackEnabled) {
+                                return mysqlFallback();
+                            }
+                            return callback(pgErr);
+                        }
+                        callback(null, rows, null);
+                    });
+                }
+            }
+        }
         if (EXPORTS_PG_ENGINE) {
             if(callback === undefined && options instanceof Function){
                 callback = options;


### PR DESCRIPTION
## Summary

Three changes found by the **stage-3 day-1 census** (7-day O5 clock T0 = `2026-07-27T05:55:38Z`). Two are correctness fixes to the shadow path; the third is the operator-gated **Phase 6.4** read-flip code, shipped **INERT**.

Landing this **restarts the 7-day O5 clock** (any adapter/translator fix does). Deliberate: day 1 was already dirty from finding (1), and a restart on day 1 is the cheapest it will ever be — which is why (3) rides along in the same roll rather than costing a second restart later in the week.

## 1. MySQL backslash-escape decoding (was: punt verbatim)

`restoreLiteralsPg()` passed any backslash-bearing literal through unchanged. The mysql driver escapes `' " \ \0 \b \n \r \t \Z`, so this produced two live failure modes:

- **LOUD** — real site name `SNR ''Kraljevac''` (site_id 88347, created `2026-07-27T10:18:26Z`) arrives as `'SNR \'\'Kraljevac\'\''` → PG **42601** `syntax error at or near "\"`. Any `O'Brien`-class name hits it.
- **SILENT, and worse** — `'a\nb'` is read by PG as literal backslash+n, not a newline (live replica: `'a\nb' = E'a\nb'` is **false**; `length` 4 vs 3). No error — just a wrong comparison, and at 6.4 wrong **results**.

Decoder semantics are **measured against the live master** (`sql_mode=''`), including the two traps a naive decoder gets wrong:
- `\%` and `\_` **keep** their backslash (LIKE metacharacter escaping; live `LENGTH('a\%b')` = 4)
- unknown escapes collapse to the bare char (live `'[a\qb]'` → `[aqb]`)
- **NUL punts verbatim** — PG text can't represent it, so an honest `dialect_error` beats a wrong value.

## 2. Connection faults no longer counted as `dialect_error`

A connection death (failover, pgbouncer restart) reaches the query callback as an Error with **no SQLSTATE `.code`**, and was being counted as `dialect_error` — the O5 gate's headline metric.

**Measured:** the ~07:03Z `TL68→69` organic failover pushed pod `r4h9l`'s `dialect_error` 0→1 with **no divergence record** (emission swallowed by the per-template emit cap), making a clean day look dirty and costing a triage cycle to reconcile counters against Loki. Now `pg_error` + `ev:query_conn_error`.

## 3. Phase 6.4 `DB_ENGINE=pg` response routing — inert

Routes only statements the **same allowlist classifier** accepts; writes and non-plain reads stay on MariaDB (legacy owns writes until Phase 7). Falls back to MariaDB on any PG-side failure (`DB_PG_FALLBACK=0` disables), so a read flip degrades to the old engine, never to an error page. Carries the #1781 checked-out-client guard + idempotent release — under `DB_ENGINE=pg` that crash would be user-facing.

### ⚠️ The column-case trap — why this needed writing, not just enabling

PG folds unquoted identifiers to lowercase and the migrated schema is all-lowercase, so `SELECT SCC.typeId, SCC.isSystemClass` returns `{typeid, issystemclass}` on PG vs `{typeId, isSystemClass}` on MariaDB. `app/model/soundscape-composition.js:104` branches on `scClass.isSystemClass` → naive routing **silently inverts that branch**.

**The shadow could not have caught this:** `rowMaps()` lowercases every key before comparing, so the divergence stream is structurally blind to column casing. *Zero divergences across the whole clock says nothing about it.* Measured surface: **8 camelCase columns / 4 tables** + ~20 camelCase aliases across 9 model files. Fixed by rebuilding MySQL-shaped keys from the original SQL.

## Verified

- **selftest 75 → 97, ALL PASS**; `node --check` clean on both modified files.
- **Live cross-engine on the real row:** MariaDB original SQL = `1`, PG translated SQL = `1` (was 42601). `EXPLAIN` on the live replica uses `Index Scan using sites__name`.
- **Newline semantics** on the live replica: decoded length 3 vs undecoded 4.
- **Inertness proven** by module probe: `DB_ENGINE=mysql`/`shadow` both give `isPg=false` and never load the `pg` lib. Live cluster has exactly one `DB_ENGINE` anywhere and it is `shadow`.

## Corrected assertion

The selftest case `dq literal with backslash punts` encoded the **punt**, not correctness: MySQL `"x\\y"` is the 3-char string `x\y` (live `LENGTH`=3) and PG writes it `'x\y'` (live `length`=3). Replaced with the decode assertions.

## Out of scope

- **Enabling** `DB_ENGINE=pg` (operator-gated 6.4 milestone).
- The W1/W2/W4/W5/W6 waived divergence set is untouched.