### PR TITLE
shadow/6.4: reproduce MySQL ci-collation semantics per column + complete the #1779 numeric-coercion fix

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -539,6 +539,297 @@ function translateFunctions(sql, store) {
     return s;
 }
 
+// ------------------------------------------------- collation / case folding
+// THE PROBLEM (measured live 2026-07-27, stage-3 clock-week day 1):
+// every string column in arbimon2 carries a *_ci collation (99
+// utf8mb3_general_ci + 21 latin1_swedish_ci; ZERO *_bin, zero binary/blob),
+// so MariaDB compares EVERY string case-insensitively. PG compares
+// varchar/text case-SENSITIVELY. schema/096 (T13) gave citext to the 9 UNIQUE
+// identity keys only — deliberately (TYPE-POLICY T13 defers the rest to
+// "Phase-6 app-audit territory"; SCHEMA-WISHLIST W5). This is that audit.
+//
+// Live consequence, measured on the real species.search() SQL (uncapped):
+//   'bird'    MariaDB 34620  vs  PG 967
+//   'ANTBIRD' MariaDB   147  vs  PG   0     <- user search returns NOTHING
+// and it fails OPEN (no error), so DB_PG_FALLBACK cannot catch it.
+//
+// THE TWO COLLATIONS DISAGREE ON ACCENTS — measured on the live master,
+// with true single-byte latin1 values (a first attempt that put UTF-8 bytes
+// into _latin1 literals compared on LENGTH, not collation, and produced a
+// convincing but FALSE result — hence the byte-level test):
+//     pair    latin1_swedish_ci   utf8mb3_general_ci
+//     é vs e         1                    1
+//     ç vs c         1                    1
+//     ñ vs n         1                    1
+//     å ä ö ü        0 (DISTINCT)         1 (folded)
+// Confirmed on real rows: templates.name (swedish) 'Zaunkonig' finds 0 but
+// 'Zaunkönig' finds 2, while pattern_matchings.name 'Tocon' == 'Tocón' == 8;
+// sites.name (general) 'Marco' == 'Março' == 16.
+// So a BLANKET accent-insensitive rule would OVER-match German/Nordic names.
+//
+// WHY NOT native COLLATE: per-column nondeterministic ICU collations would
+// need no translator change at all, but PG rejects them —
+// "nondeterministic collations are not supported for LIKE" (tested).
+// WHY NOT unaccent(): not installed, and STABLE (not IMMUTABLE) so not
+// indexable. translate(lower()) is IMMUTABLE and reproduces both foldings
+// exactly — 8/8 parity vs MariaDB on live rows.
+// GENERATED - do not hand-edit. Source: live arbimon2
+// information_schema.COLUMNS (MariaDB is the truth for collation).
+// Regenerate: data-stores/arbimon-pg/tools/gen-collation-map.sh
+// 120 string columns: 21 latin1_swedish_ci (sv), 99 utf8mb3_general_ci (gen).
+//
+// sv  = latin1_swedish_ci   : folds case + acute/cedilla/tilde,
+//                             KEEPS a-ring/a-uml/o-uml/u-uml distinct.
+// gen = utf8mb3_general_ci  : folds case + ALL accents incl. umlauts.
+// Both MEASURED on the live master 2026-07-27; see
+// runbooks/mysql2pg-p6-collation-case-sensitivity-2026-07-27.md
+//
+// Only the SV set is enumerated: it is small (21) and stable, and every
+// other string column is general_ci. A column absent from BOTH sets is
+// UNRESOLVED and its predicate is left untouched (fail-safe).
+var COLLATION_SV = {
+    'audio_event_detections_clustering.uri_vector': 1,
+    'cached_metrics.key': 1,
+    'classification_stats.json_stats': 1,
+    'job_params_audio_event_clustering.name': 1,
+    'job_params_audio_event_clustering.parameters': 1,
+    'job_params_audio_event_detection_clustering.name': 1,
+    'job_params_audio_event_detection_clustering.parameters': 1,
+    'job_task_types.identifier': 1,
+    'job_task_types.name': 1,
+    'job_task_types.typedef': 1,
+    'job_tasks.args': 1,
+    'job_tasks.remark': 1,
+    'job_tasks.status': 1,
+    'pattern_matchings.name': 1,
+    'pattern_matchings.parameters': 1,
+    'recordings_export_parameters.error': 1,
+    'recordings_export_parameters.filters': 1,
+    'recordings_export_parameters.projection_parameters': 1,
+    'recordings_export_parameters.user_email': 1,
+    'templates.name': 1,
+    'templates.uri': 1,
+};
+
+// The full known-column set (sv + gen). A qualified operand that
+// resolves into this set gets a fold; anything else is left alone.
+var COLLATION_KNOWN = {
+    'audio_event_detections_clustering.uri_vector': 1,
+    'cached_metrics.key': 1,
+    'classification_stats.json_stats': 1,
+    'job_params_audio_event_clustering.name': 1,
+    'job_params_audio_event_clustering.parameters': 1,
+    'job_params_audio_event_detection.name': 1,
+    'job_params_audio_event_detection.statistics': 1,
+    'job_params_audio_event_detection_clustering.name': 1,
+    'job_params_audio_event_detection_clustering.parameters': 1,
+    'job_params_classification.name': 1,
+    'job_params_soundscape.name': 1,
+    'job_params_soundscape.threshold_type': 1,
+    'job_params_training.name': 1,
+    'job_queues.arch': 1,
+    'job_queues.host': 1,
+    'job_queues.platform': 1,
+    'job_queues.run_types': 1,
+    'job_task_types.identifier': 1,
+    'job_task_types.name': 1,
+    'job_task_types.typedef': 1,
+    'job_tasks.args': 1,
+    'job_tasks.remark': 1,
+    'job_tasks.status': 1,
+    'job_types.description': 1,
+    'job_types.identifier': 1,
+    'job_types.name': 1,
+    'job_types.run_type': 1,
+    'job_types.script': 1,
+    'jobs.remarks': 1,
+    'jobs.state': 1,
+    'jobs.uri': 1,
+    'model_stats.json_stats': 1,
+    'model_types.description': 1,
+    'model_types.name': 1,
+    'models.name': 1,
+    'models.uri': 1,
+    'pattern_matchings.name': 1,
+    'pattern_matchings.parameters': 1,
+    'permissions.description': 1,
+    'permissions.name': 1,
+    'playlist_types.name': 1,
+    'playlists.metadata': 1,
+    'playlists.name': 1,
+    'playlists.uri': 1,
+    'project_news.data': 1,
+    'project_news_types.description': 1,
+    'project_news_types.message_format': 1,
+    'project_news_types.name': 1,
+    'projects.country': 1,
+    'projects.external_id': 1,
+    'projects.name': 1,
+    'projects.state': 1,
+    'projects.url': 1,
+    'recordings.bit_rate': 1,
+    'recordings.filename': 1,
+    'recordings.meta': 1,
+    'recordings.mic': 1,
+    'recordings.recorder': 1,
+    'recordings.sample_encoding': 1,
+    'recordings.uri': 1,
+    'recordings.version': 1,
+    'recordings_errors.error': 1,
+    'recordings_export_parameters.error': 1,
+    'recordings_export_parameters.filters': 1,
+    'recordings_export_parameters.projection_parameters': 1,
+    'recordings_export_parameters.user_email': 1,
+    'roles.description': 1,
+    'roles.icon': 1,
+    'roles.name': 1,
+    'site_types.description': 1,
+    'site_types.name': 1,
+    'sites.country_code': 1,
+    'sites.external_id': 1,
+    'sites.name': 1,
+    'sites.timezone': 1,
+    'songtypes.description': 1,
+    'songtypes.songtype': 1,
+    'soundscape_aggregation_types.description': 1,
+    'soundscape_aggregation_types.identifier': 1,
+    'soundscape_aggregation_types.name': 1,
+    'soundscape_aggregation_types.scale': 1,
+    'soundscape_composition_class_types.type': 1,
+    'soundscape_composition_classes.name': 1,
+    'soundscape_regions.name': 1,
+    'soundscape_regions.threshold_type': 1,
+    'soundscape_tags.tag': 1,
+    'soundscape_tags.type': 1,
+    'soundscapes.name': 1,
+    'soundscapes.threshold_type': 1,
+    'soundscapes.uri': 1,
+    'species.code_name': 1,
+    'species.description': 1,
+    'species.image': 1,
+    'species.scientific_name': 1,
+    'species_aliases.alias': 1,
+    'species_families.family': 1,
+    'species_taxons.image': 1,
+    'species_taxons.taxon': 1,
+    'tags.tag': 1,
+    'templates.name': 1,
+    'templates.uri': 1,
+    'training_set_roi_set_data.uri': 1,
+    'training_set_types.description': 1,
+    'training_set_types.identifier': 1,
+    'training_set_types.name': 1,
+    'training_sets.metadata': 1,
+    'training_sets.name': 1,
+    'user_account_support_request.hash': 1,
+    'user_account_support_request.params': 1,
+    'user_account_support_type.description': 1,
+    'user_account_support_type.name': 1,
+    'users.email': 1,
+    'users.firstname': 1,
+    'users.lastname': 1,
+    'users.login': 1,
+    'users.password': 1,
+    'users.rfcx_id': 1,
+    'validation_set.name': 1,
+    'validation_set.params': 1,
+    'validation_set.uri': 1,
+};
+
+// PG-ENUM EXCLUSION (measured 2026-07-27 — this is a HARD error, not a nicety).
+// These columns are native PG enum types in the migrated schema, and
+// lower()/translate() have no enum overload:
+//   SELECT ... WHERE translate(lower(state), ...) = ...
+//   ERROR: No function matches the given name and argument types
+// jobs.state is the HOTTEST predicate in the live PG jobs plane (5.5 flip),
+// so folding it would break production reads at 6.4. Enum vocabularies are
+// machine-written and case-exact anyway ('completed'/'error'/'canceled'),
+// so MySQL's ci comparison is never load-bearing for them.
+// Source: pg_type.typtype='e' on the live arbimon copy.
+var COLLATION_ENUM = {
+    'job_params_soundscape.threshold_type': 1,
+    'job_tasks.status': 1,
+    'job_types.run_type': 1,
+    'jobs.state': 1,
+    'soundscape_regions.threshold_type': 1,
+    'soundscape_tags.type': 1,
+    'soundscapes.threshold_type': 1,
+};
+
+// The two folds. Applied to BOTH sides of a predicate.
+var FOLD_GEN = "translate(lower(%s),'áàâãäåéèêëíìîïóòôõöúùûüçñýÿ','aaaaaaeeeeiiiiooooouuuucny.')";
+var FOLD_SV  = "translate(lower(%s),'áàâãéèêëíìîïóòôõúùûçñýÿ','aaaaeeeeiiiioooouuucny.')";
+
+function foldExpr(expr, cls) {
+    return (cls === 'sv' ? FOLD_SV : FOLD_GEN).replace('%s', expr);
+}
+
+// Resolve FROM/JOIN aliases so `T.name` can be mapped to a real table.
+// REQUIRED, not optional: the same alias means different tables in different
+// queries (T = templates/sv in the template search, T = tags/gen in the tag
+// autocomplete), and 5 bare column names are ambiguous across the two
+// collation classes — `name` alone spans 27 columns (4 sv / 23 gen).
+var _ALIAS_RE = /\b(?:FROM|JOIN)\s+`?([A-Za-z_]\w*)`?(?:\s+(?:AS\s+)?`?([A-Za-z_]\w*)`?)?/gi;
+var _ALIAS_KW = /^(SELECT|WHERE|ON|GROUP|ORDER|BY|LEFT|RIGHT|INNER|OUTER|CROSS|JOIN|LIMIT|OFFSET|UNION|SET|USING|AND|OR|AS|HAVING|WHEN|THEN|ELSE|END)$/i;
+
+function aliasMap(sql) {
+    var map = {};
+    var m;
+    _ALIAS_RE.lastIndex = 0;
+    while ((m = _ALIAS_RE.exec(sql)) !== null) {
+        var table = m[1].toLowerCase();
+        var alias = m[2];
+        map[table] = table;
+        if (alias && !_ALIAS_KW.test(alias)) { map[alias.toLowerCase()] = table; }
+    }
+    return map;
+}
+
+// Resolve a qualified operand to its collation class, or null when unknown.
+// NULL IS THE FAIL-SAFE: an unfolded predicate reproduces today's KNOWN and
+// census-reported behaviour, whereas guessing 'gen' would silently apply the
+// wrong semantics to the 21 latin1_swedish_ci columns. Never guess.
+function collationClass(operand, amap) {
+    var parts = String(operand).split('.');
+    if (parts.length !== 2) { return null; }   // bare column -> ambiguous -> skip
+    var tbl = amap[parts[0].toLowerCase()];
+    if (!tbl) { return null; }
+    var key = tbl + '.' + parts[1].toLowerCase();
+    if (!COLLATION_KNOWN[key]) { return null; }
+    // PG native enum: folding is a hard type error (measured). Skip.
+    if (COLLATION_ENUM[key]) { return null; }
+    return COLLATION_SV[key] ? 'sv' : 'gen';
+}
+
+// Rewrite string predicates so PG reproduces MySQL's ci (and per-collation
+// accent) semantics. Runs on literal-PROTECTED sql, so a placeholder operand
+// is a literal and is folded as a literal.
+//   <col> [NOT] LIKE <rhs>   -> fold(col) [NOT] LIKE fold(rhs)
+//   <col> = | <> | != <rhs>  -> fold(col) = | <> | != fold(rhs)
+// Only fires when the LEFT operand resolves to a known column.
+var _PRED_RE = /([A-Za-z_]\w*\.[A-Za-z_]\w*)\s*(NOT\s+LIKE|LIKE|<=>|<>|!=|=)\s*(\u0001L\d+\u0001|\?|[A-Za-z_]\w*\.[A-Za-z_]\w*)/gi;
+
+function translateCollation(sql) {
+    var amap = aliasMap(sql);
+    return sql.replace(_PRED_RE, function (whole, lhs, op, rhs) {
+        var cls = collationClass(lhs, amap);
+        if (!cls) { return whole; }             // UNRESOLVED -> untouched
+        // Only fold the RHS when it is a literal/placeholder or another known
+        // string column; a mismatched-class column pair is left alone rather
+        // than silently coerced to one side's semantics.
+        var rhsIsCol = /^[A-Za-z_]\w*\.[A-Za-z_]\w*$/.test(rhs);
+        if (rhsIsCol) {
+            var rcls = collationClass(rhs, amap);
+            if (rcls !== cls) { return whole; }
+        }
+        var o = op.toUpperCase().replace(/\s+/g, ' ');
+        // <=> is MySQL null-safe equality; folding it would change NULL
+        // semantics, so leave it entirely.
+        if (o === '<=>') { return whole; }
+        return foldExpr(lhs, cls) + ' ' + o + ' ' + foldExpr(rhs, cls);
+    });
+}
+
 // FORCE INDEX (idx) — MySQL optimizer hint, no PG equivalent; strip it.
 function stripIndexHints(sql) {
     return sql.replace(/\s+(FORCE|USE|IGNORE)\s+INDEX\s*\([^)]*\)/gi, '');
@@ -569,6 +860,7 @@ function translate(mysqlSql) {
     s = translateBackticks(s);
     s = translateLimitOffset(s);
     s = translateFunctions(s, store);
+    s = translateCollation(s);
     s = restoreLiteralsPg(s, store);
     return s;
 }
@@ -1211,6 +1503,9 @@ module.exports = {
     templateHash: templateHash,
     normalizeRows: normalizeRows,
     columnCaseMap: columnCaseMap,
+    translateCollation: translateCollation,
+    aliasMap: aliasMap,
+    collationClass: collationClass,
     restoreRowCase: restoreRowCase,
     _counters: _counters
 };

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -384,5 +384,22 @@ eq('collation: literal text is not an operand',
        out.indexOf(g('P2.name')) >= 0, true);
 })();
 
+// -- ADVERSARIAL GUARDS: only *_ci STRING columns may be folded.
+// COLLATION_KNOWN is built from information_schema rows with a non-NULL
+// COLLATION_NAME, so numeric/date/binary columns are structurally absent and
+// hit the UNRESOLVED fail-safe. These pin that property: folding a bigint
+// would be a PG type error, and folding a join key would wreck plans.
+function unfolded(sql) { return m.translate(sql).indexOf('translate(lower(') < 0; }
+eq('collation: numeric columns never fold (recording_id)',
+   unfolded('SELECT 1 FROM recordings R WHERE R.recording_id = 42'), true);
+eq('collation: numeric columns never fold (site_id)',
+   unfolded('SELECT 1 FROM sites S WHERE S.site_id = 5'), true);
+eq('collation: tinyint flags never fold',
+   unfolded('SELECT 1 FROM pattern_matchings PM WHERE PM.deleted = 0'), true);
+eq('collation: datetime never folds',
+   unfolded("SELECT 1 FROM recordings R WHERE R.datetime = '2026-01-01'"), true);
+eq('collation: numeric JOIN keys never fold',
+   unfolded('SELECT 1 FROM recordings R JOIN sites S ON S.site_id = R.site_id'), true);
+
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -291,5 +291,98 @@ eq('pgRouteEligible refuses update',
 eq('pgRouteEligible refuses insert',
    m.pgRouteEligible('INSERT INTO t (a) VALUES (1)'), false);
 
+// ---------------------------------------------------------------- collation
+// MySQL compares every arbimon2 string ci; PG compares varchar/text cs.
+// The fold reproduces MySQL semantics PER COLLATION (the two disagree on
+// umlauts). Measured live 2026-07-27; runbook:
+// runbooks/mysql2pg-p6-collation-case-sensitivity-2026-07-27.md
+var GEN = "translate(lower(%s),'áàâãäåéèêëíìîïóòôõöúùûüçñýÿ','aaaaaaeeeeiiiiooooouuuucny.')";
+var SV  = "translate(lower(%s),'áàâãéèêëíìîïóòôõúùûçñýÿ','aaaaeeeeiiiioooouuucny.')";
+function g(x) { return GEN.replace('%s', x); }
+function v(x) { return SV.replace('%s', x); }
+
+// -- alias resolution (REQUIRED: the same alias means different tables)
+eq('collation: alias T -> tags (gen)',
+   m.collationClass('T.tag', m.aliasMap('SELECT T.tag FROM tags T WHERE T.tag LIKE ?')),
+   'gen');
+eq('collation: alias T -> templates (sv)',
+   m.collationClass('T.name', m.aliasMap('SELECT T.name FROM templates as T WHERE T.name LIKE ?')),
+   'sv');
+eq('collation: pattern_matchings.name is sv',
+   m.collationClass('PM.name', m.aliasMap('SELECT PM.name FROM pattern_matchings as PM WHERE PM.name LIKE ?')),
+   'sv');
+eq('collation: projects.name is gen',
+   m.collationClass('P.name', m.aliasMap('SELECT P.name FROM projects P WHERE P.name LIKE ?')),
+   'gen');
+
+// -- FAIL-SAFE: never guess. Unresolvable -> untouched.
+eq('collation: bare column is UNRESOLVED',
+   m.collationClass('name', m.aliasMap('SELECT name FROM templates WHERE name LIKE ?')),
+   null);
+eq('collation: unknown alias is UNRESOLVED',
+   m.collationClass('X.name', m.aliasMap('SELECT a FROM (SELECT name FROM templates) X')),
+   null);
+eq('collation: unknown column is UNRESOLVED',
+   m.collationClass('T.no_such_col', m.aliasMap('SELECT 1 FROM templates T')),
+   null);
+eq('collation: unresolved predicate left untouched',
+   m.translate('SELECT a FROM nosuchtable T WHERE T.whatever LIKE ?'),
+   'SELECT a FROM nosuchtable T WHERE T.whatever LIKE ?');
+
+// -- the folds actually applied
+eq('collation: LIKE on a gen column folds accents+case',
+   m.translate('SELECT T.tag FROM tags T WHERE T.tag LIKE ?'),
+   'SELECT T.tag FROM tags T WHERE ' + g('T.tag') + ' LIKE ' + g('?'));
+eq('collation: LIKE on an sv column keeps umlauts distinct',
+   m.translate('SELECT T.name FROM templates as T WHERE T.name LIKE ?'),
+   'SELECT T.name FROM templates as T WHERE ' + v('T.name') + ' LIKE ' + v('?'));
+eq('collation: NOT LIKE is folded too (negation must not invert)',
+   m.translate('SELECT T.tag FROM tags T WHERE T.tag NOT LIKE ?'),
+   'SELECT T.tag FROM tags T WHERE ' + g('T.tag') + ' NOT LIKE ' + g('?'));
+eq('collation: = is folded (the surface is LARGER than LIKE)',
+   m.translate('SELECT T.tag FROM tags T WHERE T.tag = ?'),
+   'SELECT T.tag FROM tags T WHERE ' + g('T.tag') + ' = ' + g('?'));
+eq('collation: <> is folded',
+   m.translate('SELECT T.tag FROM tags T WHERE T.tag <> ?'),
+   'SELECT T.tag FROM tags T WHERE ' + g('T.tag') + ' <> ' + g('?'));
+
+// -- REGRESSION GUARDS for the defects found while building this
+// (1) PG native enums: folding is a HARD type error. jobs.state is the
+//     hottest predicate in the LIVE PG jobs plane. Caught by an existing
+//     test failing -- exactly what regression tests are for.
+eq('collation: enum jobs.state NEVER folded (hard PG type error)',
+   m.translate('SELECT J.state FROM jobs J WHERE J.state = "completed"'),
+   "SELECT J.state FROM jobs J WHERE J.state = 'completed'");
+eq('collation: enum resolves to null',
+   m.collationClass('J.state', m.aliasMap('SELECT 1 FROM jobs J')),
+   null);
+eq('collation: enum job_tasks.status never folded',
+   m.collationClass('JT.status', m.aliasMap('SELECT 1 FROM job_tasks JT')),
+   null);
+// (2) <=> is MySQL null-safe equality; folding would change NULL semantics.
+eq('collation: <=> left alone (null-safe equality)',
+   m.translate('SELECT T.tag FROM tags T WHERE T.tag <=> ?'),
+   'SELECT T.tag FROM tags T WHERE T.tag <=> ?');
+// (3) a cross-collation column pair must NOT be coerced to one side.
+eq('collation: sv vs gen column pair left alone',
+   m.translate('SELECT 1 FROM templates T JOIN projects P ON T.name = P.name'),
+   'SELECT 1 FROM templates T JOIN projects P ON T.name = P.name');
+// (4) literal contents must never be scanned as identifiers (the #1782 lesson).
+eq('collation: literal text is not an operand',
+   m.translate("SELECT T.tag FROM tags T WHERE T.tag = 'P.name = x'"),
+   "SELECT T.tag FROM tags T WHERE " + g('T.tag') + " = " + g("'P.name = x'"));
+
+// -- the real divergent template resolves BOTH classes in ONE query
+(function () {
+    var sql = 'SELECT count(*) FROM templates as T JOIN projects P ON T.project_id = P.project_id '
+            + 'LEFT JOIN projects P2 ON T.source_project_id = P2.project_id '
+            + 'WHERE T.name LIKE ? OR P2.name LIKE ?';
+    var out = m.translate(sql);
+    eq('collation: mixed sv+gen in one query (templates sv)',
+       out.indexOf(v('T.name')) >= 0, true);
+    eq('collation: mixed sv+gen in one query (projects gen)',
+       out.indexOf(g('P2.name')) >= 0, true);
+})();
+
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);

--- a/app/utils/sqlutil.js
+++ b/app/utils/sqlutil.js
@@ -95,6 +95,39 @@ var sqlutil = {
 
     },
 
+    /** Subjects that are NUMERIC columns in the schema. A non-numeric operand
+     *  compared against these is a malformed-URL artifact, never a real match.
+     *
+     *  rfcx-local 2026-07-27 (mysql2pg Phase 6): PR #1779 fixed ONE malformed
+     *  shape ("310984658/") by anchoring the bare-id regex, but its divergence
+     *  hash 9e9c53dfe45588a0 kept firing afterwards. Root cause: every OTHER
+     *  malformed shape ("//", "/x", "?q=", leading slash, trailing space)
+     *  still falls through to the generic site-year-month branch, where
+     *  capture group 1 becomes the SITE and is string-escaped here.
+     *
+     *  MySQL silently coerces the garbage to a number (0 rows, no error), so
+     *  the defect is invisible today. PostgreSQL rejects it:
+     *      invalid input syntax for type bigint: "310556559/"  (SQLSTATE 22P02)
+     *  Verified on BOTH live engines 2026-07-27. Left unfixed, the arbimon2
+     *  read cutover turns a benign "no results" into a 500 on these URLs.
+     *
+     *  '1 = 0' is the faithful translation of MySQL's coerce-to-no-match and
+     *  is engine-independent (it also spares MariaDB a pointless compare).
+     */
+    NUMERIC_SUBJECTS: {
+        'R.recording_id': 1,
+        'S.site_id': 1,
+        'r.recording_id': 1,
+        's.site_id': 1,
+    },
+
+    /** True when v is safely usable as a numeric SQL operand. */
+    isNumericOperand: function(v){
+        if (typeof v === 'number') { return isFinite(v); }
+        if (typeof v !== 'string') { return false; }
+        return /^-?\d+(\.\d+)?$/.test(v.trim());
+    },
+
     /** Returns a logical expression on a subject, given a query constraint.
      *  @param {String} subject - the lhs of the expression.
      *  @param {Object} query - the query constraint object. Must have only one attribute
@@ -108,6 +141,19 @@ var sqlutil = {
      */
     apply_query_contraint: function(subject, query){
         if(query){
+            // Numeric-subject guard (see NUMERIC_SUBJECTS above): a non-numeric
+            // operand can never match, and string-escaping it produces a PG
+            // 22P02 at the 6.4 read flip. MySQL's own answer is "no rows".
+            var numericSubject = sqlutil.NUMERIC_SUBJECTS[subject];
+            if (numericSubject) {
+                var vals = query['='] !== undefined ? [query['=']]
+                         : query.IN !== undefined ? [].concat(query.IN)
+                         : query.BETWEEN !== undefined ? [].concat(query.BETWEEN)
+                         : null;
+                if (vals && !vals.every(sqlutil.isNumericOperand)) {
+                    return '1 = 0';
+                }
+            }
             if (query['=']) {
                 return subject + ' = ' + mysql.escape(query['=']);
             } else if (query.IN) {


### PR DESCRIPTION
## Summary

Two **6.4 read-flip blockers** found on clock-week day 1, both measured on the live engines, both fixed here. Either alone restarts the O5 clock, so they ship together (operator-confirmed).

Base: `0a2d3fe2` (#1782). Selftest **105 → 131, ALL PASS**.

## 1. The collation / case-sensitivity class

Every string column in arbimon2 carries a `*_ci` collation (99 `utf8mb3_general_ci` + 21 `latin1_swedish_ci`; **zero** `*_bin`), so MariaDB compares every string case-insensitively. PG compares `varchar`/`text` case-**sensitively**. `schema/096` (T13) gave `citext` to the 9 UNIQUE identity keys only — deliberately; TYPE-POLICY T13 records the rest as *"Phase-6 app-audit territory"* and SCHEMA-WISHLIST **W5** defers exactly this. **This PR is that audit landing on schedule, not an escaped defect.**

Measured on the real `species.search()` SQL, uncapped:

```
'bird'     MariaDB 34620  vs  PG   967
'ANTBIRD'  MariaDB   147  vs  PG     0    <- user search returns NOTHING
```

Not sync lag — the four species tables are cell-identical on both engines at the same instant. **It fails OPEN** (short/empty results, no error), so `DB_PG_FALLBACK` cannot catch it.

### The two collations disagree on accents

| | `latin1_swedish_ci` | `utf8mb3_general_ci` |
|---|---|---|
| é / ç / ñ | folds | folds |
| å ä ö ü | **DISTINCT** | folded |

Confirmed on real rows: `templates.name` `Zaunkonig`→0 but `Zaunkönig`→2; `pattern_matchings.name` `Tocon`==`Tocón`==8; `sites.name` `Marco`==`Março`==16. **A blanket accent-insensitive rule would over-match German/Nordic names** — hence a per-collation fold.

### Why this shape

- **Native `COLLATE` is impossible**: PG raises *"nondeterministic collations are not supported for LIKE"* (tested in a scratch DB, dropped immediately).
- **`unaccent()` rejected**: not installed, and `STABLE` not `IMMUTABLE` (unindexable). `translate(lower())` is `IMMUTABLE` and reproduces both foldings exactly.
- **The map must key on `table.column`**: 5 bare names are ambiguous; `name` alone spans 27 columns (4 sv / 23 gen). Operands are alias-qualified and the same alias means different tables in different queries (`T`=templates/sv vs `T`=tags/gen), so a FROM/JOIN alias resolver is **required**.
- **UNRESOLVED leaves the predicate untouched** — reproducing today's known, census-reported behaviour rather than guessing a collation. Never guess.

The map is **generated** from live `information_schema` (`data-stores/arbimon-pg/tools/gen-collation-map.sh` in the rfcx-local PR), never hand-maintained.

## 2. PR #1779 was incomplete

Its hash `9e9c53dfe45588a0` kept firing **after** the `0a2d3fe` roll (the fix is genuinely deployed — verified inside the running pod). `/^(\d+)\/?$/` absorbs exactly one trailing slash; `//`, `/x`, `?q=`, leading slash and `site/NNN/` still reach the site branch, where `apply_query_contraint()` string-escapes the operand → `S.site_id = '310556559/'`. Live: MariaDB coerces (0 rows, no error), **PG raises 22P02 → 500 at 6.4**.

Fixed at the point of use, not with a 7th regex: a non-numeric operand on a known numeric subject emits `1 = 0` — the faithful translation of MySQL's coerce-to-no-match, engine-independent, and already the idiom used for `query.no_match`.

## A regression test caught a defect in my own fix

The existing *"dq literal → sq literal"* test failed on the first draft. Root cause: **`jobs.state` is a native PG enum** (`job_state`), and `lower()`/`translate()` have no enum overload — *"No function matches the given name and argument types"*. `jobs.state` is the **hottest predicate in the live PG jobs plane** (5.5 flip), so this would have broken production reads. Added `COLLATION_ENUM` (7 columns from `pg_type.typtype='e'`) to the fail-safe path; enum vocabularies are machine-written and case-exact, so ci comparison is never load-bearing. Pinned by two guards.

A second self-check **corrected a test rather than the code**: I expected a trailing-space numeric to become `1 = 0`, but measured that PG accepts numeric literals with surrounding whitespace (0 rows, no 22P02) exactly like MariaDB. Forcing `1 = 0` would have been over-tightening.

## Verified (live: PG leader `postgres-1-0`, MariaDB master `mariadb-0`)

- **50/50 exact row-count parity** across 10 terms × 5 real query shapes, including every accent case: `Zaunkonig` 0/0 and `Zaunkönig` 2/2 (umlaut kept distinct on the sv column), `Tocon` 8/8 == `Tocón` 8/8, `Marco` 16/16 == `Março` 16/16, and bird/Bird/BIRD/owl identical across species search, tags, templates, pattern_matchings, sites.
- The formerly-22P02 SQL now executes on PG and agrees with MariaDB (0/0); a real accented site name (`01- El Cañón San Cristobal`) matches 1/1.
- **Inertness re-proven**: `DB_ENGINE` unset → `engine=mysql`, `isPg`/`isShadow` false, the `pg` lib never loads, `translate()` stays pure.
- **Exports worker** (`EXPORTS_DB_ENGINE=pg` — ships HOT, not inert): its `IN_PROGRESS` sentinel query selects identically folded vs unfolded on live data (1 == 1) and resolves to the correct sv fold.
- Adversarial guards pinned: numeric/date/tinyint columns and numeric JOIN keys never fold (structurally impossible — `COLLATION_KNOWN` only contains columns with a non-NULL `COLLATION_NAME`).

## Out of scope

- No schema change; `citext` for the non-unique columns remains SCHEMA-WISHLIST **W5**. This is the app-layer half.
- The fold defeats index usage — a non-issue for these leading-wildcard predicates (they already seq-scan; measured identical cost 1037.78). If an anchored `LIKE 'x%'` or high-volume `=` is ever routed, re-check the plan; both folds are `IMMUTABLE` so an expression index is available.

## Deployment note

Merging CD-deploys to the main arbimon pods and **restarts the 7-day O5 divergence clock** (operator-accepted: day-1 restart costs one day, day-6 costs six). Companion rfcx-local PR #626 carries the analysis runbook, the map generator, and the census discriminator.