### PR TITLE
shadow: canonicalize floats at %.6g half-even — stop calling identical float4 data different

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -872,18 +872,66 @@ function translate(mysqlSql) {
 var _ORDER_BY_RE = /\border\s+by\b/i;
 function hasOrderBy(sql) { return _ORDER_BY_RE.test(sql); }
 
+// --- float canonicalization (rfcx-local 2026-07-28, clock-week finding) ---
+// MariaDB renders float/double to client text with C printf %.6g semantics
+// (6 significant digits, HALF-EVEN rounding); PG renders shortest-roundtrip.
+// Same stored float32 bits therefore arrive as DIFFERENT JS numbers
+// (measured inside a live pod, same row: mysql driver 7.92533 vs pg driver
+// 7.9253335; bit-level proof on the master: time_min = CAST(7.9253335 AS
+// FLOAT) -> 1). The old epsilon quantization (1e-9, absolute-scale) cannot
+// bridge a ~3.5e-6 RELATIVE gap, so identical data emitted as
+// result_mismatch — measured at ~20% of the day-1 clock census across 6
+// templates (recording_tags t0/f0/t1/f1, pattern_matching_rois x1/x2/score,
+// audio_event_detections_clustering time/frequency).
+//
+// FIX: canonicalize non-integer numbers at 6 significant digits with
+// HALF-EVEN rounding — the SAME convention the delta-sync fingerprint
+// compare has always used (delta_sync.py::_fp_norm, '%.6g' % float(v), the
+// P2-checksums normalizer). Fidelity proven against C printf %.6g on a
+// 20,000-value random-float32 fuzz (0 mismatches).
+//
+// Rejected shapes (tested, see the p6 collation runbook §7g):
+//   - Math.fround: a 6-digit truncation loses MORE than a float32 ulp, so
+//     fround cannot re-converge the two renderings.
+//   - bare toPrecision(6): JS rounds half-AWAY; fails on the live value
+//     21281.25 (maria %.6g half-even -> 21281.2, toPrecision -> 21281.3).
+//   - raising epsilon: it is an absolute-scale quantum; no single value
+//     works across magnitudes (22171.9 needs ~1e-1, 0.691209 needs ~1e-6).
+function g6HalfEven(x) {
+    if (!isFinite(x)) { return String(x); }
+    if (x === 0) { return '0'; }
+    var neg = x < 0;
+    var ax = Math.abs(x);
+    var exp = Math.floor(Math.log10(ax));
+    var scale = Math.pow(10, 5 - exp);       // 6 significant digits
+    var scaled = ax * scale;
+    var fl = Math.floor(scaled);
+    var frac = scaled - fl;
+    var r;
+    // half-even at the rounding boundary (C printf semantics; MariaDB's
+    // renderer). 1e-7 tolerance identifies an exact-half within float64 noise.
+    if (Math.abs(frac - 0.5) < 1e-7) { r = (fl % 2 === 0) ? fl : fl + 1; }
+    else { r = Math.round(scaled); }
+    var out = r / scale;
+    var s = out.toPrecision(6);
+    // strip trailing zeros ONLY when a decimal point exists — a bare
+    // /\.?0+$/ eats integer zeros ('28000.0' is safe, '28000' would become
+    // '28'; that exact bug appeared in this fix's own first fuzz harness).
+    if (s.indexOf('e') < 0 && s.indexOf('.') >= 0) {
+        s = s.replace(/0+$/, '').replace(/\.$/, '');
+    }
+    return neg ? '-' + s : s;
+}
+
 function canonValue(v, epsilon) {
     if (v === null || v === undefined) { return 'null'; }
     if (typeof v === 'boolean') { return 'num:' + (v ? 1 : 0); }
     if (typeof v === 'number') {
         if (Number.isInteger(v)) { return 'num:' + v; }
-        if (epsilon > 0) {
-            if (v === 0) { return 'num:0'; }
-            var q = Math.round(v / epsilon) * epsilon;
-            if (Number.isInteger(q)) { return 'num:' + q; }
-            return 'num:' + q;
-        }
-        return 'num:' + v;
+        // Non-integer: 6-sig-digit half-even canonicalization (see g6HalfEven
+        // above). Subsumes the old epsilon quantization — %.6g is coarser than
+        // 1e-9 at every magnitude and is scale-free, which epsilon is not.
+        return 'num:' + g6HalfEven(v);
     }
     if (typeof v === 'bigint') { return 'num:' + v.toString(); }
     if (Buffer.isBuffer(v)) {
@@ -901,7 +949,7 @@ function canonValue(v, epsilon) {
     if (typeof v === 'string' && /^-?\d+(\.\d+)?$/.test(v)) {
         var f = parseFloat(v);
         if (Number.isInteger(f)) { return 'num:' + f; }
-        return 'num:' + f;
+        return 'num:' + g6HalfEven(f);
     }
     return 'str:' + String(v);
 }
@@ -1503,6 +1551,7 @@ module.exports = {
     templateHash: templateHash,
     normalizeRows: normalizeRows,
     columnCaseMap: columnCaseMap,
+    g6HalfEven: g6HalfEven,
     translateCollation: translateCollation,
     aliasMap: aliasMap,
     collationClass: collationClass,

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -401,5 +401,44 @@ eq('collation: datetime never folds',
 eq('collation: numeric JOIN keys never fold',
    unfolded('SELECT 1 FROM recordings R JOIN sites S ON S.site_id = R.site_id'), true);
 
+// ------------------------------------------------- float4 canonicalization
+// MariaDB renders float32 as C %.6g (half-even); PG renders shortest-
+// roundtrip. canonValue must converge the two renderings of the SAME stored
+// value while keeping genuinely different values apart. All 'live pairs'
+// below were MEASURED on production rows 2026-07-28 (aedc 240283170 batch +
+// pm_rois 1140661357); see the p6 collation runbook §7f-7g.
+function cv(x) { return m.compare('SELECT a FROM t ORDER BY a',
+    [{ a: x }], [{ a: x }], 1e-9); }
+function cvPair(a, b) { return m.compare('SELECT a FROM t ORDER BY a',
+    [{ a: a }], [{ a: b }], 1e-9); }
+
+// -- live pairs: maria-rendering vs pg-rendering of the SAME float32
+[[7.92533, 7.9253335], [9.25867, 9.258667], [22171.9, 22171.875],
+ [18843.8, 18843.75], [21281.2, 21281.25], [30.1547, 30.154667],
+ [1734.38, 1734.375], [11.1573, 11.157333], [52.0475, 52.047527],
+ [0.691209, 0.69120884]].forEach(function (p) {
+    eq('float4: live pair equal ' + p[0] + '~' + p[1], cvPair(p[0], p[1]), null);
+});
+// -- genuinely different values MUST still diverge
+[[7.92533, 7.92534], [22171.9, 22172.0], [0.691209, 0.69121],
+ [1.0, 1.00001]].forEach(function (p) {
+    eq('float4: distinct pair differs ' + p[0] + ' vs ' + p[1],
+       cvPair(p[0], p[1]) !== null, true);
+});
+// -- g6HalfEven unit behaviour
+eq('g6: half-even rounds 21281.25 DOWN (C semantics, not JS half-away)',
+   m.g6HalfEven(21281.25), '21281.2');
+eq('g6: integer-like float32 keeps its zeros (the fuzz-harness bug class)',
+   m.g6HalfEven(28000.0000001), '28000');
+eq('g6: negative values', m.g6HalfEven(-93579.953125), '-93580');
+eq('g6: small values scale-free', m.g6HalfEven(0.69120884), '0.691209');
+eq('g6: zero', m.g6HalfEven(0), '0');
+// -- integers are untouched (fast-path unchanged)
+eq('float4: integer columns unaffected', cvPair(42, 42), null);
+eq('float4: integer mismatch still fires', cvPair(42, 43) !== null, true);
+// -- decimal-as-string tail path uses the SAME canonicalization
+eq('float4: pg-numeric string vs mysql float converge',
+   cvPair('7.9253335', 7.92533), null);
+
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);

--- a/app/utils/g6-fuzz.js
+++ b/app/utils/g6-fuzz.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// g6-fuzz.js — fuzz g6HalfEven against C printf %.6g via python3.
+//
+// WHY: canonValue's float canonicalization claims C %.6g half-even fidelity
+// (MariaDB's client-text renderer). This harness proves it on N random
+// float32 values rather than trusting the 10 live pairs in the selftest.
+//
+// USAGE: node app/utils/g6-fuzz.js [N]      (default 20000; needs python3)
+//
+// LESSON BAKED IN: the first version of this harness reported 196 false
+// mismatches from its own trailing-zero normalization bug
+// (replace(/\.?0+$/,'') turns '28000' into '28'). Comparison is therefore
+// numeric (parseFloat both sides), never string-normalized.
+var child = require('child_process');
+var N = parseInt(process.argv[2] || '20000', 10);
+
+var m = require('./dbpool-pg.js');
+
+var py = "import random, struct\n" +
+  "random.seed()\n" +
+  "for _ in range(" + N + "):\n" +
+  "    v = random.uniform(-100000, 100000)\n" +
+  "    v32 = struct.unpack('f', struct.pack('f', v))[0]\n" +
+  "    print('%r\\t%s' % (v32, '%.6g' % v32))\n";
+
+var out = child.execFileSync('python3', ['-c', py], { maxBuffer: 64 * 1024 * 1024 })
+    .toString().trim().split('\n');
+
+var mismatch = 0, shown = 0;
+out.forEach(function (line) {
+    var parts = line.split('\t');
+    var v = parseFloat(parts[0]);
+    var expected = parts[1];
+    var got = m.g6HalfEven(v);
+    // numeric comparison: both renderings parse to the same 6-sig-digit value
+    if (parseFloat(got) !== parseFloat(expected)) {
+        mismatch++;
+        if (shown++ < 10) {
+            console.log('MISMATCH v=' + parts[0] + '  c=' + expected + '  js=' + got);
+        }
+    }
+});
+console.log(N + ' random float32s vs C printf %.6g: ' + mismatch + ' mismatches');
+process.exit(mismatch ? 1 : 0);


### PR DESCRIPTION
## Summary

Comparator-only fix: `canonValue()` now canonicalizes non-integer numbers at **6 significant digits, half-even** (`g6HalfEven`) — MariaDB's own client-text rendering rule (C printf `%.6g`) — so identical stored float32 data stops being reported as `result_mismatch`.

Base: `a89306fb` (#1783). Selftest **131 → 153, ALL PASS**. 50k-value fuzz vs C printf: **0 mismatches**.

## The problem (measured, not inferred)

MariaDB renders `float` to client text as C `%.6g` (half-even); PG renders shortest-roundtrip. Same stored bits → different JS numbers. Measured inside a live pod, both prod drivers, same row: mysql `7.92533` vs pg `7.9253335`; bit-level proof on the master: `time_min = CAST(7.9253335 AS FLOAT)` → 1.

**Blast radius:** 6 recurring shadow templates select float4 columns (`recording_tags` t0/f0/t1/f1, `pattern_matching_rois` x1/x2/score, `audio_event_detections_clustering` time/frequency) = **117/576 records (20%) of the day-1 clock census**, polluting the unsigned tail mislabeled as generic value-diff since stage 1. A mechanism-scoped waiver was considered and **withdrawn** — the emitted records carry no cell values, so it would be unauditable and degrade to a hash blanket absorbing real drift.

## Why this exact shape (each alternative tested and rejected)

- **`Math.fround`** — a 6-digit truncation loses more than a float32 ulp; provably cannot re-converge the renderings.
- **bare `toPrecision(6)`** — JS rounds half-away; **fails on live value 21281.25** (maria → `21281.2`, JS → `21281.3`). This one value exposed the half-even requirement.
- **raising epsilon** — absolute-scale quantum; no single value works across magnitudes. `%.6g` is scale-free.
- **Repo precedent:** `delta_sync.py::_fp_norm` has always used `'%.6g' % float(v)` for the fingerprint compare (P2-checksums convention). This ports the established rule to the shadow.

## Verified

- The **real shadow path** (`snapshot`/`compareSnap`) on the exact live driver outputs: aedc row 240283170 → EQUAL; pm_rois row 1140661357 → EQUAL; injected genuine drift → still fires.
- Side-effect sweep: lat/lon doubles keep sub-meter sensitivity; Date/string/int paths untouched; sub-epsilon noise still equal. **Stated trade-off:** differences below the 6th significant digit now compare equal — that is MariaDB's own client-text precision floor (the shadow cannot see what MariaDB never sends).
- Standing fuzz harness committed (`app/utils/g6-fuzz.js`); its own first version had a trailing-zero bug producing 196 false mismatches — the lesson is baked into its header, and comparison is numeric-only.
- Inertness: `DB_ENGINE` unset → `pg` lib never loads.

## Deployment note

Merging CD-deploys to the main arbimon pods and **restarts the 7-day O5 clock** (operator GO 2026-07-27 23:15 EDT; clock was <6h old — restart costs hours, removes ~20% of census volume permanently). Exports workers must be hand-rolled post-merge (CD does not auto-roll them). Full re-review record: rfcx-local PR #627 runbook §7f–7g.