### PR TITLE
shadow/6.4: CONCAT NULL-propagation + ORDER BY per-collation fold

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -411,9 +411,47 @@ function litText(tok, store) {
 
 function translateFunctions(sql, store) {
     var s = sql;
-    // MySQL string concat via CONCAT() is identical in PG; the `||` operator
-    // is logical-OR in MySQL only under PIPES_AS_CONCAT (not set here) so no
-    // rewrite needed. RAND()/NOW() are classifier-forbidden so never arrive.
+    // CONCAT(a,b,..) -> (a::text || b || ..)
+    // MySQL CONCAT returns NULL if ANY argument is NULL; PG's concat()
+    // FUNCTION ignores NULLs (measured live: MariaDB
+    // CONCAT('https://x/', NULL) IS NULL -> 1; PG -> 'https://x/'). The old
+    // comment here claimed CONCAT was identical in PG -- true for the
+    // non-NULL case only, and the difference is user-visible: a template
+    // with a NULL `uri` rendered `uri:"https://arbimon.org/"` on PG instead
+    // of null (census template 257746653328cfc7, the largest unsigned
+    // bucket on the 429b167 clock; live exposure 1060/77383 templates.uri
+    // NULL across 239 projects, plus 441 training_set_roi_set_data.uri).
+    // PG's `||` operator DOES propagate NULL (verified live:
+    // ('a' || NULL || 'b') IS NULL -> t), so it is the faithful translation.
+    //
+    // WHY NOT a CASE guard: `CASE WHEN a IS NULL OR b IS NULL THEN NULL ELSE
+    // a||b END` duplicates every operand -- which would DOUBLE any `?`
+    // placeholder and shift parameter positions. `||` needs each operand
+    // exactly once.
+    //
+    // The leading ::text cast is REQUIRED: PG has no `int || int` operator
+    // (anynonarray||text / text||anynonarray only), so an all-numeric CONCAT
+    // would raise 42883. Casting only the FIRST operand is sufficient because
+    // `||` is left-associative: (int::text || int) -> text -> text || .. .
+    // A NULL cast to text stays NULL, so propagation is preserved.
+    s = rewriteCall(s, 'CONCAT', function (args) {
+        if (!args.length) { return null; }
+        // idempotence guard: an already-converted call starts with a cast
+        // operand (the resume-at-replacement scan must not re-wrap).
+        if (args.length === 1 && /::text\s*$/.test(args[0])) { return null; }
+        var parts = args.map(function (a, i) {
+            return i === 0 ? '(' + a + ')::text' : '(' + a + ')';
+        });
+        return '(' + parts.join(' || ') + ')';
+    });
+
+    // NOTE: GROUP_CONCAT is NOT affected -- rewriteCall's name boundary is
+    // `(^|[^A-Za-z0-9_.])`, and GROUP_CONCAT's `CONCAT` is preceded by `_`,
+    // so the CONCAT rule cannot match inside it. (GROUP_CONCAT keeps its own
+    // string_agg rewrite below, whose MySQL semantics DO skip NULLs.)
+    //
+    // `||` is logical-OR in MySQL only under PIPES_AS_CONCAT (not set here).
+    // RAND()/NOW() are classifier-forbidden so never arrive.
     // IFNULL(a,b) -> COALESCE(a,b)
     s = s.replace(/\bIFNULL\s*\(/gi, 'COALESCE(');
     // UCASE/LCASE are MySQL aliases (first live-canary dialect_error: tags
@@ -830,6 +868,155 @@ function translateCollation(sql) {
     });
 }
 
+// ---- ORDER BY per-collation fold (P6, 2026-07-28) -------------------------
+// PR #1783 folded string PREDICATES (WHERE) but left ORDER BY alone. MariaDB
+// SORTS case-insensitively too; the `arbimon` PG copy is C.UTF-8, so it sorts
+// by byte value ('#Birds' before '#bird'; MariaDB puts it after).
+//
+// This is NOT cosmetic when the query is paginated: the ordering decides WHICH
+// rows land on the page. MEASURED on the exact post-#1783 translated shape vs
+// the MariaDB master, tags.search at the app's real LIMIT 20:
+//     term '%owl%' -> 6 of 20 rows LOST (and 6 wrong rows shown)
+//     term '%ird%' / '%ana%' -> 1 of 20
+// With this fold: 0 differences on every term tested (12 random terms x 40-row
+// sequences, DESC, mixed string+numeric keys, and both collation classes).
+// It fails OPEN (a full-looking page of wrong rows), so DB_PG_FALLBACK cannot
+// catch it -- same signature as the collation class itself.
+//
+// SCOPE, deliberately narrow (fail-safe mirrors translateCollation):
+//   - only a sort key that is EXACTLY a qualified `alias.column` (with an
+//     optional ASC/DESC) is folded. Bare columns are UNRESOLVED (5 bare names
+//     are ambiguous across the two collation classes) and expressions are left
+//     alone -- both reproduce today's behaviour, which the census reports
+//     honestly.
+//   - the column must resolve via the SAME generated table.column map and be
+//     non-enum (a fold on a PG enum is a hard type error).
+//
+// COST: negligible on real shapes. An unfiltered whole-table sort would lose
+// its index (sites: index-scan cost 5.05 -> sort cost 4794), but every live
+// query filters first (project_id), where the plan is IDENTICAL apart from
+// ~0.4% (6.88 -> 6.93, same Index Scan on sites__project_id). Both folds are
+// translate(lower()) and both functions are IMMUTABLE, so an expression index
+// is available if a hot unfiltered sort ever appears.
+//
+// NOT FIXED HERE (documented, needs an app change): where the sort key has
+// TIES and the query is paginated, page boundaries stay underdetermined on
+// both engines -- measured, 2 of 8 common tag terms straddle a tie at row
+// 20/21. A tiebreak column in the app's ORDER BY is the only remedy and it
+// would change MariaDB's output too.
+//
+// NULL PLACEMENT: MySQL sorts NULLs first ASC / last DESC; PG is the opposite.
+// Live exposure is currently ZERO (0 NULLs in every string sort key measured:
+// sites.name, tags.tag, templates.name, pattern_matchings.name,
+// soundscapes.name), so no NULLS FIRST/LAST is emitted here -- but any future
+// NULLABLE string sort key needs one. Recorded in the P6 ordering runbook.
+var _ORDERBY_CLAUSE_RE = /\border\s+by\b/gi;
+var _SORTKEY_RE = /^([A-Za-z_]\w*\.[A-Za-z_]\w*)(\s+(?:ASC|DESC))?$/i;
+// Clause terminators at the ORDER BY's own paren depth.
+var _ORDERBY_END_RE = /^(LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR|INTO|FETCH|WINDOW|HAVING)$/i;
+
+// Find the extent of an ORDER BY clause starting at `from` (index just past
+// the keyword). Ends at a depth-0 terminator keyword, an unbalanced ')'
+// (i.e. the enclosing subquery closing), a ';', or end of string.
+function orderByExtent(sql, from) {
+    var depth = 0, i = from, word = '', wordStart = -1;
+    for (; i < sql.length; i++) {
+        var ch = sql[i];
+        if (ch === '(') { depth++; word = ''; wordStart = -1; continue; }
+        if (ch === ')') {
+            if (depth === 0) { return i; }   // closes the enclosing subquery
+            depth--; word = ''; wordStart = -1; continue;
+        }
+        if (ch === ';') { return i; }
+        if (/[A-Za-z_]/.test(ch)) {
+            if (wordStart < 0) { wordStart = i; word = ''; }
+            word += ch;
+            continue;
+        }
+        if (word && depth === 0 && _ORDERBY_END_RE.test(word)) { return wordStart; }
+        word = ''; wordStart = -1;
+    }
+    if (word && depth === 0 && _ORDERBY_END_RE.test(word)) { return wordStart; }
+    return sql.length;
+}
+
+// SELF-REVIEW GUARDS (found by running the fix against live PG before merge --
+// the fix contained the exact defect class it exists to prevent, cf. #1780).
+// Two PG rules make a FOLDED sort key a HARD ERROR where the bare column works:
+//
+//  (G1) SELECT DISTINCT: "for SELECT DISTINCT, ORDER BY expressions must
+//       appear in select list" (42P10, reproduced live). `ORDER BY t.tag` is
+//       legal because the column is selected; the translate() wrapper is a new
+//       expression and is not.
+//  (G2) UNION/INTERSECT/EXCEPT: a trailing ORDER BY binds to the SET-OPERATION
+//       output, where only output column names/ordinals are in scope. A
+//       qualified operand raises "missing FROM-clause entry for table t"
+//       (42P01, reproduced live).
+//
+// Both shapes are live in this app (6 SELECT DISTINCT sites; UNION builders in
+// jobs.js/projects.js/recordings.js incl. the W5 jobs-progress template), so
+// both guards are load-bearing, not theoretical. In both cases we leave the
+// ORDER BY untouched -- today's behaviour, which the census reports honestly.
+//
+// G2 is applied per-clause (a set-operation keyword ANYWHERE at depth 0 before
+// the clause disables it) rather than whole-query, so an ORDER BY inside a
+// parenthesised UNION BRANCH -- which is scoped to that branch and is safe --
+// still folds.
+var _SETOP_RE = /\b(UNION|INTERSECT|EXCEPT)\b/i;
+var _DISTINCT_RE = /\bSELECT\s+DISTINCT\b/i;
+
+// Is there a set-operation keyword at paren-depth 0 in sql[0..end)?
+function hasTopLevelSetOp(sql, end) {
+    var depth = 0, word = '', i;
+    for (i = 0; i < end; i++) {
+        var ch = sql[i];
+        if (ch === '(') { depth++; word = ''; continue; }
+        if (ch === ')') { depth--; word = ''; continue; }
+        if (/[A-Za-z]/.test(ch)) { word += ch; continue; }
+        if (word && depth === 0 && _SETOP_RE.test(word)) { return true; }
+        word = '';
+    }
+    return !!(word && depth === 0 && _SETOP_RE.test(word));
+}
+
+function translateOrderByCollation(sql) {
+    // G1: whole-query -- a DISTINCT anywhere makes folding unsafe for the
+    // clause that belongs to it, and correlating which SELECT owns which
+    // ORDER BY is not worth the risk. Skip the query entirely (fail-safe).
+    if (_DISTINCT_RE.test(sql)) { return sql; }
+    var amap = aliasMap(sql);
+    var out = '', cursor = 0;
+    _ORDERBY_CLAUSE_RE.lastIndex = 0;
+    var m;
+    while ((m = _ORDERBY_CLAUSE_RE.exec(sql)) !== null) {
+        var clauseStart = m.index + m[0].length;
+        var clauseEnd = orderByExtent(sql, clauseStart);
+        // G2: a set-operation at depth 0 before this clause means the clause
+        // binds to the set-operation output -> qualified names are out of
+        // scope. Leave it untouched.
+        if (hasTopLevelSetOp(sql, m.index)) {
+            _ORDERBY_CLAUSE_RE.lastIndex = clauseEnd;
+            continue;
+        }
+        var clause = sql.slice(clauseStart, clauseEnd);
+        var keys = splitTopArgs(clause);
+        var rebuilt = keys.map(function (k) {
+            var km = _SORTKEY_RE.exec(k.trim());
+            if (!km) { return k.trim(); }                 // expression -> untouched
+            var cls = collationClass(km[1], amap);
+            if (!cls) { return k.trim(); }                // UNRESOLVED -> untouched
+            return foldExpr(km[1], cls) + (km[2] || '');
+        }).join(', ');
+        // Preserve the original leading/trailing whitespace shape.
+        var lead = /^\s*/.exec(clause)[0];
+        var trail = /\s*$/.exec(clause)[0];
+        out += sql.slice(cursor, clauseStart) + lead + rebuilt + trail;
+        cursor = clauseEnd;
+        _ORDERBY_CLAUSE_RE.lastIndex = clauseEnd;
+    }
+    return out + sql.slice(cursor);
+}
+
 // FORCE INDEX (idx) — MySQL optimizer hint, no PG equivalent; strip it.
 function stripIndexHints(sql) {
     return sql.replace(/\s+(FORCE|USE|IGNORE)\s+INDEX\s*\([^)]*\)/gi, '');
@@ -861,6 +1048,7 @@ function translate(mysqlSql) {
     s = translateLimitOffset(s);
     s = translateFunctions(s, store);
     s = translateCollation(s);
+    s = translateOrderByCollation(s);
     s = restoreLiteralsPg(s, store);
     return s;
 }
@@ -1553,6 +1741,7 @@ module.exports = {
     columnCaseMap: columnCaseMap,
     g6HalfEven: g6HalfEven,
     translateCollation: translateCollation,
+    translateOrderByCollation: translateOrderByCollation,
     aliasMap: aliasMap,
     collationClass: collationClass,
     restoreRowCase: restoreRowCase,

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -107,8 +107,11 @@ eq('backtick plain ident still bare',
 eq('force index stripped', m.translate('SELECT r.recording_id FROM recordings AS r FORCE INDEX (idx) JOIN sites s ON s.site_id=r.site_id'),
    'SELECT r.recording_id FROM recordings AS r JOIN sites s ON s.site_id=r.site_id');
 // quoted alias -> double-quoted identifier; string-value literals untouched
+// NOTE (2026-07-28): the expected CONCAT form changed when CONCAT gained
+// NULL-propagating `||` translation. The SUBJECT of this test is the quoted
+// ALIAS, which is unchanged; only the (now-translated) CONCAT body moved.
 eq('quoted alias', m.translate("SELECT CONCAT('a', A.job_id) as 'uri' FROM aed A"),
-   'SELECT CONCAT(\'a\', A.job_id) as "uri" FROM aed A');
+   'SELECT ((\'a\')::text || (A.job_id)) as "uri" FROM aed A');
 eq('multi-word quoted alias -> identifier', m.translate("SELECT x as 'a b' FROM t"),
    'SELECT x as "a b" FROM t');
 // literal protection: none of the above touch matching text inside a string
@@ -157,8 +160,10 @@ eq('sq literal unknown escape drops backslash', m.translate("SELECT a FROM t WHE
 // NUL is unrepresentable in PG text -> punt verbatim (honest dialect_error).
 eq('sq literal NUL punts verbatim', m.translate("SELECT a FROM t WHERE b = 'a\\0b'"),
    "SELECT a FROM t WHERE b = 'a\\0b'");
+// (same note as 'quoted alias' above: the alias is the subject, the CONCAT
+// body is now `||`-translated for MySQL NULL-propagation parity.)
 eq('quoted alias still wins over dq-literal', m.translate("SELECT CONCAT(a,b) as 'uri' FROM t"),
-   'SELECT CONCAT(a,b) as "uri" FROM t');
+   'SELECT ((a)::text || (b)) as "uri" FROM t');
 // -- ORDER BY FIELD -> COALESCE(array_position(...), 0) (54023 >100-arg class)
 eq('field -> array_position', m.translate('SELECT r.id FROM r ORDER BY FIELD(r.id, 5, 3, 9)'),
    'SELECT r.id FROM r ORDER BY COALESCE(array_position(ARRAY[5, 3, 9], r.id), 0)');
@@ -439,6 +444,73 @@ eq('float4: integer mismatch still fires', cvPair(42, 43) !== null, true);
 // -- decimal-as-string tail path uses the SAME canonicalization
 eq('float4: pg-numeric string vs mysql float converge',
    cvPair('7.9253335', 7.92533), null);
+
+console.log('== CONCAT NULL-propagation (P6 2026-07-28) ==');
+// MySQL CONCAT returns NULL if ANY arg is NULL; PG's concat() FUNCTION ignores
+// NULLs, but the `||` OPERATOR propagates. Measured live: MariaDB
+// CONCAT('https://x/', NULL) IS NULL -> 1; PG concat(...) -> 'https://x/'.
+eq('concat: 2-arg -> || with leading text cast',
+   m.translate("SELECT CONCAT('https://x/', T.uri) FROM templates T"),
+   "SELECT (('https://x/')::text || (T.uri)) FROM templates T");
+eq('concat: numeric operands get a text cast (PG has no int||int)',
+   m.translate('SELECT CONCAT(a, b) FROM t'),
+   'SELECT ((a)::text || (b)) FROM t');
+eq('concat: 3-arg',
+   m.translate("SELECT CONCAT(a, ' ', b) FROM t"),
+   "SELECT ((a)::text || (' ') || (b)) FROM t");
+// GROUP_CONCAT must be untouched by the CONCAT rule: rewriteCall's name
+// boundary is (^|[^A-Za-z0-9_.]) and GROUP_CONCAT's CONCAT is preceded by '_'.
+eq('concat: GROUP_CONCAT still becomes string_agg, not ||',
+   m.translate("SELECT GROUP_CONCAT(sa.alias SEPARATOR ', ') FROM species_aliases sa"),
+   "SELECT string_agg((sa.alias)::text, ', ') FROM species_aliases sa");
+eq('concat: nested CONCAT resolves (author expression shape)',
+   /\(\(\(/.test(m.translate("SELECT CONCAT(CONCAT(a,b),' ',CONCAT(c,d)) FROM t")), true);
+eq('concat: no || left un-parenthesised inside GROUP_CONCAT',
+   /string_agg/.test(m.translate("SELECT GROUP_CONCAT(CONCAT(a,b) SEPARATOR ',') FROM t")), true);
+
+console.log('== ORDER BY per-collation fold (P6 2026-07-28) ==');
+var OB = function (sql) { var p = m.translate(sql).split(/order\s+by/i); return p.length > 1 ? p.slice(1).join(' ') : ''; };
+var isFolded = function (sql) { return /translate\(lower\(/.test(OB(sql)); };
+// gen-class column (utf8mb3_general_ci)
+eq('orderby: tags.tag folds (gen)',
+   /translate\(lower\(T\.tag\),'áàâãäåéèêëíìîïóòôõöúùûüçñýÿ'/.test(OB(
+     'SELECT T.tag FROM tags T ORDER BY T.tag LIMIT 20')), true);
+// sv-class column (latin1_swedish_ci) -- MUST use the swedish fold, which
+// KEEPS umlauts distinct (measured: MariaDB sorts apple,zebra,äpple)
+eq('orderby: templates.name folds with the SV fold (umlauts distinct)',
+   /translate\(lower\(T\.name\),'áàâãéèêëíìîïóòôõúùûçñýÿ'/.test(OB(
+     'SELECT T.name FROM templates T ORDER BY T.name DESC')), true);
+eq('orderby: direction preserved', /DESC/.test(OB(
+   'SELECT T.name FROM templates T ORDER BY T.name DESC')), true);
+eq('orderby: mixed keys -- only the string key folds',
+   /translate\(lower\(S\.name\).*ASC, S\.site_id ASC/.test(OB(
+     'SELECT S.site_id FROM sites S ORDER BY S.name ASC, S.site_id ASC LIMIT 10')), true);
+// fail-safe cases: never guess
+eq('orderby: bare column UNRESOLVED -> untouched',
+   isFolded('SELECT a FROM templates T ORDER BY date_created DESC LIMIT 5'), false);
+eq('orderby: numeric column -> untouched',
+   isFolded('SELECT SCC.id FROM soundscape_composition_classes SCC ORDER BY SCC.typeId, SCC.isSystemClass DESC'), false);
+eq('orderby: expression -> untouched',
+   isFolded('SELECT user_id FROM users WHERE email LIKE ? ORDER BY (email = ?) DESC, email ASC LIMIT 10'), false);
+eq('orderby: PG enum (jobs.state) -> untouched (a fold is a hard type error)',
+   isFolded('SELECT J.job_id FROM jobs J ORDER BY J.state'), false);
+// ---- guards pinned from the ADVERSARIAL SELF-REVIEW (both reproduced live
+// as hard PG errors before the guards existed; cf. the #1780 lesson) ----
+eq('orderby GUARD G1: SELECT DISTINCT -> untouched (42P10 otherwise)',
+   isFolded('SELECT DISTINCT t.tag FROM tags t ORDER BY t.tag LIMIT 3'), false);
+eq('orderby GUARD G2: trailing ORDER BY after UNION -> untouched (42P01 otherwise)',
+   isFolded('SELECT t.tag FROM tags t UNION SELECT s.name FROM sites s ORDER BY t.tag LIMIT 3'), false);
+eq('orderby GUARD G2: W5 jobs-progress UNION shape untouched',
+   isFolded("(SELECT J.job_id FROM jobs J WHERE J.state='processing') UNION (SELECT J.job_id FROM jobs J WHERE J.state='waiting') ORDER BY job_id DESC"), false);
+eq('orderby: ORDER BY inside a parenthesised UNION branch still folds',
+   isFolded('(SELECT t.tag FROM tags t ORDER BY t.tag LIMIT 1) UNION (SELECT s.name FROM sites s LIMIT 1)'), true);
+// clause-extent correctness: the fold must not swallow LIMIT/OFFSET
+eq('orderby: LIMIT/OFFSET preserved verbatim after a folded key',
+   /LIMIT \? OFFSET \?/.test(m.translate(
+     'SELECT T.tag FROM tags T ORDER BY T.tag LIMIT ? OFFSET ?')), true);
+eq('orderby: WHERE fold and ORDER BY fold coexist on the same column',
+   (m.translate('SELECT T.tag FROM tags T WHERE T.tag LIKE ? ORDER BY T.tag LIMIT ?')
+      .match(/translate\(lower\(T\.tag\)/g) || []).length, 2);
 
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);


### PR DESCRIPTION
Two engine-semantics classes found on the `429b167` clock, both **user-visible at the 6.4 read flip** and both failing **OPEN** (wrong data, no error — `DB_PG_FALLBACK` cannot catch either). Bundled into one PR so the 7-day O5 clock restarts **once**.

`translate()`-only. No routing/classifier change; `DB_ENGINE=pg` stays inert.

---

## 1. CONCAT NULL-propagation

MySQL `CONCAT` returns NULL if **any** argument is NULL; PG's `concat()` **function** ignores NULLs. The old code passed `CONCAT` through with a comment asserting the two were identical — true only for the non-NULL case.

**Measured live:** MariaDB `CONCAT('https://x/', NULL) IS NULL` → `1`; PG → `'https://x/'`.

**Live effect** — census template `257746653328cfc7` (project-templates listing, the **largest unsigned bucket** on this clock, 17 records). The 597-row project-3941 listing was cell-identical on *every* column except `CONCAT(prefix, T.uri)` on its single NULL-uri row, where PG rendered a bogus asset URL instead of `null`.

**Exposure:** `templates.uri` NULL on **1060/77383** rows across **239 projects**, plus **441** `training_set_roi_set_data.uri` (same shape, ×3 call sites).

**Fix:** `CONCAT(a,b,..)` → `((a)::text || (b) || ..)`. PG's `||` operator *does* propagate NULL (verified live). The leading `::text` cast is required (PG has no `int||int`); left-associativity makes casting only the first operand sufficient, and NULL-cast-to-text stays NULL.

- *Rejected:* a `CASE` guard would duplicate every operand → doubling any `?` placeholder and shifting parameter positions.
- `GROUP_CONCAT` is **provably** unaffected: `rewriteCall`'s name boundary is `(^|[^A-Za-z0-9_.])` and `GROUP_CONCAT`'s `CONCAT` is preceded by `_`. Test pins it.

## 2. ORDER BY per-collation fold

#1783 folded string **predicates** but left `ORDER BY` alone. MariaDB **sorts** case-insensitively too; the `arbimon` PG copy is `C.UTF-8` and sorts by byte value. On a **paginated** query the order decides *which rows land on the page*.

Measured on the exact post-#1783 translated shape vs the MariaDB master, `tags.search` at the app's real `LIMIT 20`:

| term | rows LOST pre-fix | post-fix |
|---|---:|---:|
| `%a%` | **7 / 20** | 0 |
| `%owl%` | **6 / 20** | 0 |
| `%ird%` `%ana%` `%er%` | 1 / 20 | 0 |

**Post-fix live comparison:** value sequence identical to MariaDB on **8/8** terms, **0 rows lost**; `sites.name` (gen) and `templates.name` (sv, live umlaut data — `Geburtshelferkröte`) sequences identical.

Scope mirrors `translateCollation`'s fail-safe: only a sort key that is exactly a qualified `alias.column` (optional ASC/DESC) folds, resolved through the **same generated** `table.column` map. Bare columns, expressions, numerics and PG enums are untouched — **never guess a collation**.

**Cost:** negligible on real shapes. An unfiltered whole-table sort would lose its index (sites `5.05` → `4794`), but every live query filters first — measured `6.88` → `6.93` (**~0.4%**), same `Index Scan using sites__project_id`. Both folds are `translate(lower())` and **IMMUTABLE**, so an expression index is available if a hot unfiltered sort ever appears.

---

## ⚠️ Self-review caught two defects in the fix itself (the #1780 lesson, again)

Running the new fold against **live PG before merging** found two shapes where a folded sort key is a **hard error** while the bare column works:

- **G1 `SELECT DISTINCT`** → `42P10 for SELECT DISTINCT, ORDER BY expressions must appear in select list`
- **G2 trailing `ORDER BY` after `UNION`/`INTERSECT`/`EXCEPT`** → `42P01 missing FROM-clause entry` (the clause binds to the set-operation output)

**Both shapes are live in this app** (6 `SELECT DISTINCT` sites; UNION builders in `jobs.js`/`projects.js`/`recordings.js` including the **W5 jobs-progress** template), so both guards are load-bearing, not theoretical. Both now skip the fold (= today's behaviour, census-visible). G2 is applied **per-clause** via a depth-0 set-op scan, so an `ORDER BY` inside a parenthesised UNION **branch** — correctly scoped — still folds.

## Verified

- **selftest 153 → 173, ALL PASS** (20 new: 6 CONCAT, 14 ORDER BY, incl. 3 pinning the G1/G2 self-review defects + 1 asserting the UNION-branch case still folds).
- Live PG execution of the **real translated statements**: no errors; 597-row templates listing now cell-identical including the NULL-uri row.
- Two pre-existing selftest expectations updated — they asserted `CONCAT` passed through verbatim (the premise this PR corrects). Their actual subject, quoted-alias handling, is unchanged and still asserted.

## Known residual (documented, NOT fixed here)

Where a sort key has **ties** and the query is paginated, page boundaries stay underdetermined on **both** engines (measured: 2 of 8 common tag terms straddle a tie at row 20/21). The only remedy is a tiebreak column in the app's `ORDER BY`, which would change MariaDB's output too → Phase-7 app work.

Separately, the **M2 tie-underdetermination** class (95% of `ordering_only` volume) is **not fixable** in the translator — MariaDB returned **3 distinct orderings in 10 consecutive runs** of the same query — and is proposed as waiver **W8** in rfcx-local.

## Clock

Merging restarts the 7-day O5 clock (T0 = the later main pod's `startTime`, both replicas on the new image, 0 restarts). Day-1-economics call, consistent with the three restarts already taken this week.

⚠️ **Post-merge, same session:** `arbimon-export-consumer` (Deployment) + `arbimon-export-reconciler` (CronJob) run the `arbimon-recording-export-job` image, which CD **builds but never rolls**. They execute this same `translate()` with `EXPORTS_DB_ENGINE=pg`, so they must be hand-rolled and their repo pins reconciled, or they run the old translator against live PG.