### PR TITLE
shadow/6.4: fold bare-= and IN-list string comparisons (=-surface completion)

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -1017,6 +1017,118 @@ function translateOrderByCollation(sql) {
     return out + sql.slice(cursor);
 }
 
+// ---- bare-`=` + IN-list collation fold (P6 =-surface, 2026-07-28) ----------
+// The =-surface enumeration (runbooks/mysql2pg-p6-eq-surface-enumeration-
+// 2026-07-28.md) found ~9 live read shapes comparing string columns WITHOUT an
+// alias qualifier (create-time dup-checks: sites.js:214, tags.js:192,
+// templates.js:266, training_sets.js:97, models.js:239, soundscapes.js:471)
+// plus 2 alias-qualified IN-list filters (recordings.js:1865, jobs.js:570).
+// The deployed qualified fold cannot see bare operands (5 bare names are
+// ambiguous across collation classes), so at 6.4 these compare case-
+// sensitively: a dup-check misses a case-variant existing row -> duplicate
+// creation / tag fragmentation (1918 live case-variant tag groups measured).
+//
+// RESOLUTION RULE for a bare column: FROM-NARROWING. Collect the query's
+// FROM/JOIN tables (the aliasMap's table set); find which carry this column
+// in the generated map; if EXACTLY ONE COLLATION CLASS results (and no enum
+// membership), fold — else leave untouched. `FROM sites WHERE name = ?` is
+// unambiguous (only sites.name is in scope) even though `name` spans 27
+// columns schema-wide. Never guess.
+//
+// STATEMENT GATE (load-bearing, not paranoia): translate() has one caller
+// that is NOT SELECT-gated — the EXPORTS_DB_ENGINE path (dbpool.js). In an
+// UPDATE, a bare `col = ?` inside SET is an ASSIGNMENT; folding it would
+// corrupt a write. The bare/IN passes therefore run ONLY when the statement
+// is a SELECT/WITH. (The qualified pass keeps its deployed behaviour: an
+// alias-qualified operand cannot appear in a SET clause of our SQL corpus,
+// and changing its gating would alter shipped behaviour.)
+var _SELECT_STMT_RE = /^\s*\(*\s*(SELECT|WITH)\b/i;
+
+// Which collation class does a BARE column resolve to under this query's
+// FROM set? null = ambiguous/unknown/enum -> untouched.
+function resolveBareColumn(col, amap) {
+    var name = String(col).toLowerCase();
+    var tables = {};
+    for (var k in amap) { tables[amap[k]] = true; }
+    var cls = null, hits = 0;
+    for (var t in tables) {
+        var key = t + '.' + name;
+        if (!COLLATION_KNOWN[key]) { continue; }
+        if (COLLATION_ENUM[key]) { return null; }   // enum in scope -> never fold
+        var c = COLLATION_SV[key] ? 'sv' : 'gen';
+        hits++;
+        if (cls === null) { cls = c; }
+        else if (cls !== c) { return null; }        // two classes in scope -> ambiguous
+    }
+    return hits > 0 ? cls : null;
+}
+
+// bare `col <op> <literal|placeholder>` — the RHS is restricted to literals/
+// placeholders (bare col-to-col equality is not in the measured surface and
+// resolving BOTH sides bare doubles the ambiguity risk). The leading guard
+// excludes `.` (qualified operands already handled), `\u0001` (literal
+// tokens), quotes, and word chars.
+var _BARE_PRED_RE = /(^|[^\w.\u0001'"`])([A-Za-z_]\w*)\s*(NOT\s+LIKE|LIKE|<>|!=|=)\s*(\u0001L\d+\u0001|\?)/gi;
+// SQL keywords that can precede `=`-looking text but are never columns.
+var _BARE_STOP = /^(SELECT|WHERE|AND|OR|NOT|ON|BY|AS|IN|IS|NULL|LIKE|BETWEEN|CASE|WHEN|THEN|ELSE|END|LIMIT|OFFSET|SET|VALUES|FROM|JOIN|HAVING|GROUP|ORDER|UNION|ALL|DISTINCT|EXISTS|IF|COALESCE|CONCAT|COUNT|SUM|MIN|MAX|AVG|LEFT|RIGHT|INNER|OUTER|CROSS|USING|INTERVAL|TRUE|FALSE|DIV|MOD)$/i;
+
+function translateBareCollation(sql) {
+    if (!_SELECT_STMT_RE.test(sql)) { return sql; }
+    var amap = aliasMap(sql);
+    return sql.replace(_BARE_PRED_RE, function (whole, lead, col, op, rhs) {
+        if (_BARE_STOP.test(col)) { return whole; }
+        var cls = resolveBareColumn(col, amap);
+        if (!cls) { return whole; }                 // UNRESOLVED -> untouched
+        var o = op.toUpperCase().replace(/\s+/g, ' ');
+        return lead + foldExpr(col, cls) + ' ' + o + ' ' + foldExpr(rhs, cls);
+    });
+}
+
+// `col [NOT] IN (member, member, ...)` — qualified OR bare LHS, every member a
+// literal/placeholder. A subquery RHS (contains SELECT) is left untouched.
+// mysql.format expands array placeholders BEFORE translate, so live IN-lists
+// arrive as literal lists here.
+var _IN_LHS_RE = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)?)(\s+NOT)?\s+IN\s*\(/gi;
+
+function translateInCollation(sql) {
+    if (!_SELECT_STMT_RE.test(sql)) { return sql; }
+    var amap = aliasMap(sql);
+    var search = 0;
+    for (var guard = 0; guard < 200; guard++) {
+        _IN_LHS_RE.lastIndex = search;
+        var m = _IN_LHS_RE.exec(sql);
+        if (!m) { break; }
+        var lhs = m[1], neg = m[2] || '';
+        var openIdx = m.index + m[0].length - 1;
+        var depth = 0, endIdx = -1;
+        for (var i = openIdx; i < sql.length; i++) {
+            if (sql[i] === '(') { depth++; }
+            else if (sql[i] === ')') { depth--; if (depth === 0) { endIdx = i; break; } }
+        }
+        if (endIdx < 0) { break; }
+        var inner = sql.slice(openIdx + 1, endIdx);
+        search = endIdx + 1;
+        if (/\bSELECT\b/i.test(inner)) { continue; }         // subquery -> untouched
+        var cls;
+        if (lhs.indexOf('.') >= 0) { cls = collationClass(lhs, amap); }
+        else {
+            if (_BARE_STOP.test(lhs)) { continue; }
+            cls = resolveBareColumn(lhs, amap);
+        }
+        if (!cls) { continue; }                              // UNRESOLVED -> untouched
+        var members = splitTopArgs(inner);
+        var ok = members.length > 0 && members.every(function (a) {
+            return /^(\u0001L\d+\u0001|\?)$/.test(a.trim());
+        });
+        if (!ok) { continue; }                               // non-literal member -> untouched
+        var folded = members.map(function (a) { return foldExpr(a.trim(), cls); }).join(', ');
+        var repl = foldExpr(lhs, cls) + neg + ' IN (' + folded + ')';
+        sql = sql.slice(0, m.index) + repl + sql.slice(endIdx + 1);
+        search = m.index + repl.length;
+    }
+    return sql;
+}
+
 // FORCE INDEX (idx) — MySQL optimizer hint, no PG equivalent; strip it.
 function stripIndexHints(sql) {
     return sql.replace(/\s+(FORCE|USE|IGNORE)\s+INDEX\s*\([^)]*\)/gi, '');
@@ -1048,6 +1160,8 @@ function translate(mysqlSql) {
     s = translateLimitOffset(s);
     s = translateFunctions(s, store);
     s = translateCollation(s);
+    s = translateBareCollation(s);
+    s = translateInCollation(s);
     s = translateOrderByCollation(s);
     s = restoreLiteralsPg(s, store);
     return s;
@@ -1742,6 +1856,9 @@ module.exports = {
     g6HalfEven: g6HalfEven,
     translateCollation: translateCollation,
     translateOrderByCollation: translateOrderByCollation,
+    translateBareCollation: translateBareCollation,
+    translateInCollation: translateInCollation,
+    resolveBareColumn: resolveBareColumn,
     aliasMap: aliasMap,
     collationClass: collationClass,
     restoreRowCase: restoreRowCase,

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -135,9 +135,12 @@ eq('dq literal doubled dq', m.translate('SELECT a FROM t WHERE b = "a""b"'),
 eq('dq literal backslash decodes', m.translate('SELECT a FROM t WHERE b = "x\\\\y"'),
    "SELECT a FROM t WHERE b = 'x\\y'");
 // THE LIVE 42601 CASE: mysql driver escapes ' as \' — site 88347.
+// (2026-07-28: expectation updated for the bare-= fold — `name = <lit>` on a
+// FROM-narrowed sites query now folds. The SUBJECT of this test is the
+// escaped-literal decoding, which must survive INSIDE the fold arguments.)
 eq('sq literal escaped quotes (live Kraljevac 42601)',
    m.translate("SELECT count(*) as count FROM sites WHERE name = 'SNR \\'\\'Kraljevac\\'\\'' AND project_id = 8740"),
-   "SELECT count(*) as count FROM sites WHERE name = 'SNR ''''Kraljevac''''' AND project_id = 8740");
+   "SELECT count(*) as count FROM sites WHERE translate(lower(name),'áàâãäåéèêëíìîïóòôõöúùûüçñýÿ','aaaaaaeeeeiiiiooooouuuucny.') = translate(lower('SNR ''''Kraljevac'''''),'áàâãäåéèêëíìîïóòôõöúùûüçñýÿ','aaaaaaeeeeiiiiooooouuuucny.') AND project_id = 8740");
 eq('sq literal single escaped quote (O\'Brien class)',
    m.translate("SELECT a FROM t WHERE b = 'O\\'Brien'"),
    "SELECT a FROM t WHERE b = 'O''Brien'");
@@ -490,8 +493,15 @@ eq('orderby: bare column UNRESOLVED -> untouched',
    isFolded('SELECT a FROM templates T ORDER BY date_created DESC LIMIT 5'), false);
 eq('orderby: numeric column -> untouched',
    isFolded('SELECT SCC.id FROM soundscape_composition_classes SCC ORDER BY SCC.typeId, SCC.isSystemClass DESC'), false);
-eq('orderby: expression -> untouched',
-   isFolded('SELECT user_id FROM users WHERE email LIKE ? ORDER BY (email = ?) DESC, email ASC LIMIT 10'), false);
+// (2026-07-28: expectation updated — the bare-= pass now folds the
+// `email = ?` PREDICATE inside the ORDER BY expression (users.email
+// FROM-narrows cleanly; verified live: executes + ranks identically).
+// translateOrderByCollation itself still leaves expressions/bare KEYS alone:
+// the second key `email ASC` stays raw (citext sorts ci natively on PG).
+eq('orderby: embedded = predicate folds via the bare pass (live-verified)',
+   isFolded('SELECT user_id FROM users WHERE email LIKE ? ORDER BY (email = ?) DESC, email ASC LIMIT 10'), true);
+eq('orderby: pure expression KEY itself never rewritten by the orderby pass',
+   /ORDER BY \(.*\) DESC, email ASC/.test(m.translate('SELECT user_id FROM users WHERE email LIKE ? ORDER BY (email = ?) DESC, email ASC LIMIT 10')), true);
 eq('orderby: PG enum (jobs.state) -> untouched (a fold is a hard type error)',
    isFolded('SELECT J.job_id FROM jobs J ORDER BY J.state'), false);
 // ---- guards pinned from the ADVERSARIAL SELF-REVIEW (both reproduced live
@@ -511,6 +521,44 @@ eq('orderby: LIMIT/OFFSET preserved verbatim after a folded key',
 eq('orderby: WHERE fold and ORDER BY fold coexist on the same column',
    (m.translate('SELECT T.tag FROM tags T WHERE T.tag LIKE ? ORDER BY T.tag LIMIT ?')
       .match(/translate\(lower\(T\.tag\)/g) || []).length, 2);
+
+console.log('== bare-= + IN-list collation fold (P6 =-surface, 2026-07-28) ==');
+var nfold = function (sql) { return (m.translate(sql).match(/translate\(lower\(/g) || []).length; };
+// FROM-narrowed bare = : the enumeration's real exposed shapes
+eq('bare=: sites dup-check folds (FROM narrows `name` to sites.name/gen)',
+   nfold("SELECT count(*) FROM sites WHERE name = 'x' AND project_id = 1 AND deleted_at is null"), 2);
+eq('bare=: tags create-lookup folds', nfold("SELECT tag_id FROM tags WHERE tag = 'bird'"), 2);
+eq('bare=: templates dup-check folds with the SV fold',
+   /translate\(lower\(name\),'áàâãéèêëíìîïóòôõúùûçñýÿ'/.test(
+     m.translate("SELECT 1 FROM templates WHERE `name`='X' AND `project_id`=1 LIMIT 1")), true);
+eq('bare=: same-class multi-table still folds (sites+projects both gen)',
+   nfold("SELECT 1 FROM sites S JOIN projects P ON S.project_id=P.project_id WHERE name = 'x'"), 2);
+// fail-safes: never guess
+eq('bare=: AMBIGUOUS across classes untouched (templates sv + projects gen)',
+   nfold("SELECT 1 FROM templates T JOIN projects P ON T.project_id=P.project_id WHERE name = 'x'"), 0);
+eq('bare=: enum column untouched (jobs.state)',
+   nfold("SELECT job_id FROM jobs WHERE state = 'completed'"), 0);
+eq('bare=: numeric column untouched', nfold("SELECT site_id FROM sites WHERE project_id = 5"), 0);
+eq('bare=: unknown table untouched', nfold("SELECT x FROM unknown_table WHERE name = 'x'"), 0);
+// THE STATEMENT GATE (load-bearing: the EXPORTS path translates without a
+// SELECT gate; a fold inside UPDATE..SET would corrupt a write)
+eq('bare= GATE: UPDATE SET untouched',
+   nfold("UPDATE playlists SET name = 'x', uri = NULL WHERE playlist_id = 5"), 0);
+eq('bare= GATE: INSERT untouched',
+   nfold("INSERT INTO tags (tag) VALUES ('x')"), 0);
+// IN lists
+eq('IN: qualified string LHS folds LHS + members',
+   nfold("SELECT r.recording_id FROM recordings r JOIN sites s ON s.site_id=r.site_id WHERE s.name IN ('A','B')"), 3);
+eq('IN: bare string LHS folds via FROM-narrowing',
+   nfold("SELECT tag_id FROM tags WHERE tag IN ('a','b')"), 3);
+eq('IN: NOT IN preserved',
+   /NOT IN \(/.test(m.translate("SELECT tag_id FROM tags WHERE tag NOT IN ('a')")), true);
+eq('IN: subquery RHS untouched',
+   nfold("SELECT tag_id FROM tags WHERE tag IN (SELECT tag FROM tags WHERE tag_id < 5)"), 0);
+eq('IN: numeric LHS untouched', nfold("SELECT site_id FROM sites WHERE site_id IN (1,2,3)"), 0);
+eq('IN: template-collapsed placeholder shape unchanged',
+   m.sqlTemplate("SELECT * FROM t WHERE id IN (1,2,3) AND name='x' AND n=5"),
+   'SELECT * FROM t WHERE id IN (?) AND name=? AND n=?');
 
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);


### PR DESCRIPTION
Closes the =-surface enumeration's exposed set (`runbooks/mysql2pg-p6-eq-surface-enumeration-2026-07-28.md` in rfcx-local): ~9 bare-`=` dup-check/lookup shapes + 2 `IN`-list filters that the qualified fold cannot see — at 6.4 they compare case-sensitively, so a dup-check misses a case-variant row → duplicate creation / **tag fragmentation** (1918 live case-variant tag groups measured). Fails open.

**Mechanism — FROM-narrowing:** a bare column folds only when the query's FROM/JOIN table set narrows it to **exactly one** collation class in the generated map, with no enum in scope. Ambiguous/unknown/enum → untouched. IN-lists fold LHS + literal members only; subquery RHS untouched.

**Statement gate (load-bearing):** the EXPORTS_DB_ENGINE path translates without a SELECT gate, and a bare `col = ?` inside `UPDATE … SET` is an assignment — the new passes run **only on SELECT/WITH**. Test-pinned.

**Verified:** selftest **173 → 190 ALL PASS**; live parity on the real translated shapes vs MariaDB originals **6/6 MATCH**, zero PG errors; citext fold proven harmless (and more MySQL-faithful); the embedded ORDER BY `(email = ?)` predicate folds and ranks identically live.

**Clock:** restarts the O5 clock (day-2 economics, operator GO 11:30 EDT).

⚠️ Post-merge same session: hand-roll `arbimon-export-consumer` + `arbimon-export-reconciler` (CD builds but never rolls them; container name `export-consumer`) + reconcile all pins.