### PR TITLE
shadow/6.4: connection-lifetime errors are SQLSTATE-aware (completes #1781)

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -177,6 +177,47 @@ function templateHash(sql) {
     return crypto.createHash('sha1').update(sqlTemplate(sql).toLowerCase()).digest('hex').slice(0, 16);
 }
 
+// ------------------------------------------- connection-lifetime SQLSTATEs
+// A server-side connection DEATH is not a dialect fault. #1781 established
+// the rule and guarded the shape it had measured: an Error with NO SQLSTATE
+// ("Connection terminated unexpectedly"). But an ADMINISTRATIVE termination
+// DOES carry a SQLSTATE, so it slipped past that guard and was counted as
+// `dialect_error` — the O5 gate's hard-zero headline metric.
+//
+// MEASURED (rfcx-local, 2026-07-29): the 04:04:06Z TL72->73 DCS-blip
+// failover produced exactly two `dialect_error` divergence records, both
+// pg_code **57P01** ("terminating connection due to administrator command"),
+// on two unrelated recordings templates. A third failover the same evening
+// (19:11:47Z TL74->75) produced ZERO — the client 'error' handler won that
+// race instead. **The mis-classification is therefore NON-DETERMINISTIC:
+// whether an infra blip corrupts the gate metric depends on a callback
+// race.** That is worse than a reliable bug, because a clean census cannot
+// be trusted to mean the guard held.
+//
+// The class (PG Appendix A, Class 57 - Operator Intervention):
+//   57P01 admin_shutdown          - terminate_backend / failover / restart
+//   57P02 crash_shutdown          - peer backend crashed, cluster restarting
+//   57P03 cannot_connect_now      - server starting up / shutting down
+//   08006 connection_failure      - connection broken mid-statement
+//   08003 connection_does_not_exist
+//   08000 connection_exception
+// 57014 (query_canceled) is deliberately NOT here: it is OUR statement_timeout
+// firing, already counted separately as pg_timeout (a perf signal).
+// 53300 (too_many_connections) is NOT here either: that is a real capacity
+// fault we WANT visible rather than silently absorbed as infra noise.
+var CONN_LIFETIME_SQLSTATES = {
+    '57P01': 1, '57P02': 1, '57P03': 1,
+    '08000': 1, '08003': 1, '08006': 1
+};
+
+function isConnLifetimeError(err) {
+    if (!err) { return false; }
+    // No SQLSTATE at all = the #1781 shape (connection died before the server
+    // could answer). Kept verbatim so that guard's behaviour is unchanged.
+    if (!err.code) { return true; }
+    return CONN_LIFETIME_SQLSTATES[String(err.code).toUpperCase()] === 1;
+}
+
 // ------------------------------------------------------ MySQL -> PG translator
 // First-pass dialect translation for the measured hot spots. Anything not
 // covered here surfaces as a `dialect_error` divergence = the Phase-6 queue.
@@ -1587,11 +1628,12 @@ function shadowAfterRead(finalSql, mariaRows, meta) {
                     // 2026-07-27). A server-side connection death (failover,
                     // pgbouncer restart, admin terminate) surfaces here as an
                     // Error with NO SQLSTATE `.code` — e.g. "Connection
-                    // terminated unexpectedly" / "server conn crashed?". The
-                    // client 'error' handler above catches these when it wins
-                    // the race, but the QUERY callback frequently fires first
-                    // (that ordering is exactly what #1781 established), so the
-                    // same fault also lands here.
+                    // terminated unexpectedly" / "server conn crashed?" — OR,
+                    // for an ADMINISTRATIVE termination, WITH one (57P01 &c;
+                    // see CONN_LIFETIME_SQLSTATES). The client 'error' handler
+                    // above catches these when it wins the race, but the QUERY
+                    // callback frequently fires first (that ordering is exactly
+                    // what #1781 established), so the same fault also lands here.
                     // Counting it as dialect_error corrupted the O5 gate's
                     // headline metric: MEASURED on 2026-07-27, the ~07:03Z
                     // TL68->69 organic failover pushed pod r4h9l's
@@ -1600,10 +1642,15 @@ function shadowAfterRead(finalSql, mariaRows, meta) {
                     // making a clean day look dirty and costing a triage cycle
                     // to reconcile counters against Loki. A dialect_error must
                     // mean "PG rejected or mis-executed our SQL", nothing else.
-                    if (!qerr.code) {
+                    // 2026-07-29: #1781's `!qerr.code` test was INCOMPLETE for
+                    // exactly that reason — the 04:04Z failover booked two
+                    // 57P01s as dialect_error (the 19:11Z one booked zero: the
+                    // race, not the fault, decides). Now SQLSTATE-aware.
+                    if (isConnLifetimeError(qerr)) {
                         _counters.pg_error++;
                         emitStat({ ev: 'query_conn_error',
                             err: String(qerr && qerr.message || qerr).slice(0, 200),
+                            pg_code: qerr && qerr.code,
                             hash: templateHash(text) });
                         return;
                     }
@@ -1806,12 +1853,19 @@ function pgReadQuery(finalSql, cb) {
                 try { client.query('ROLLBACK', function () { releaseOnce(); }); }
                 catch (e) { releaseOnce(); }
                 if (qerr) {
-                    // Connection-lifetime faults carry no SQLSTATE (see the
-                    // shadow path's matching guard) — never a dialect error.
-                    if (!qerr.code) {
+                    // Connection-lifetime faults are EITHER SQLSTATE-less (the
+                    // #1781 shape) or carry a Class-57/08 admin/connection code
+                    // (see isConnLifetimeError + the shadow path's matching
+                    // guard) — never a dialect error. This matters MORE here
+                    // than on the shadow path: at 6.4 this path serves real
+                    // users, so a mis-booked infra blip would both corrupt the
+                    // gate metric AND look like a translator defect while the
+                    // request silently falls back to MariaDB.
+                    if (isConnLifetimeError(qerr)) {
                         _counters.pg_error++;
                         emitStat({ ev: 'pg_route_conn_error',
-                            err: String(qerr && qerr.message || qerr).slice(0, 200) });
+                            err: String(qerr && qerr.message || qerr).slice(0, 200),
+                            pg_code: qerr && qerr.code });
                     } else if (qerr.code === '57014') {
                         _counters.pg_timeout++;
                         emitStat({ ev: 'pg_route_timeout', hash: templateHash(text) });
@@ -1851,6 +1905,8 @@ module.exports = {
     compareSnap: compareSnap,
     sqlTemplate: sqlTemplate,
     templateHash: templateHash,
+    isConnLifetimeError: isConnLifetimeError,
+    CONN_LIFETIME_SQLSTATES: CONN_LIFETIME_SQLSTATES,
     normalizeRows: normalizeRows,
     columnCaseMap: columnCaseMap,
     g6HalfEven: g6HalfEven,

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -560,5 +560,51 @@ eq('IN: template-collapsed placeholder shape unchanged',
    m.sqlTemplate("SELECT * FROM t WHERE id IN (1,2,3) AND name='x' AND n=5"),
    'SELECT * FROM t WHERE id IN (?) AND name=? AND n=?');
 
+// ---- connection-lifetime SQLSTATE classification (P6, 2026-07-29) --------
+// #1781 ruled that a connection DEATH must never book as dialect_error (the
+// O5 gate's hard-zero metric). Its guard tested `!err.code` only, so an
+// ADMINISTRATIVE termination — which DOES carry a SQLSTATE — slipped through.
+// MEASURED live: the 2026-07-29 04:04:06Z TL72->73 failover booked exactly
+// two 57P01s as dialect_error; the 19:11:47Z TL74->75 failover booked zero
+// (the client 'error' handler won that race). Non-deterministic by nature,
+// so these tests pin the CLASSIFIER rather than any one incident's outcome.
+console.log('== connection-lifetime SQLSTATE classification (P6 2026-07-29) ==');
+var cle = m.isConnLifetimeError;
+// the #1781 shape must keep behaving exactly as before
+eq('conn: no-SQLSTATE error is conn-lifetime (#1781 shape preserved)',
+   cle(new Error('Connection terminated unexpectedly')), true);
+eq('conn: null/undefined is not conn-lifetime', cle(null), false);
+// the measured live gap
+eq('conn: 57P01 admin_shutdown (THE measured 04:04Z failover case)',
+   cle({ code: '57P01', message: 'terminating connection due to administrator command' }), true);
+eq('conn: 57P02 crash_shutdown', cle({ code: '57P02' }), true);
+eq('conn: 57P03 cannot_connect_now', cle({ code: '57P03' }), true);
+eq('conn: 08006 connection_failure', cle({ code: '08006' }), true);
+eq('conn: 08003 connection_does_not_exist', cle({ code: '08003' }), true);
+eq('conn: 08000 connection_exception', cle({ code: '08000' }), true);
+eq('conn: lowercase SQLSTATE still matches', cle({ code: '57p01' }), true);
+// the boundaries that MUST stay visible — these are the whole point of the gate
+eq('conn: 57014 query_canceled is NOT conn-lifetime (our statement_timeout)',
+   cle({ code: '57014' }), false);
+eq('conn: 53300 too_many_connections is NOT absorbed (real capacity fault)',
+   cle({ code: '53300' }), false);
+eq('conn: 42P01 undefined_table is a REAL dialect error',
+   cle({ code: '42P01' }), false);
+eq('conn: 42P10 invalid_column_reference is a REAL dialect error',
+   cle({ code: '42P10' }), false);
+eq('conn: 22P02 invalid_text_representation is a REAL dialect error',
+   cle({ code: '22P02' }), false);
+eq('conn: 42883 undefined_function is a REAL dialect error',
+   cle({ code: '42883' }), false);
+eq('conn: 42601 syntax_error is a REAL dialect error',
+   cle({ code: '42601' }), false);
+eq('conn: 42804 datatype_mismatch is a REAL dialect error',
+   cle({ code: '42804' }), false);
+eq('conn: 23505 unique_violation is a REAL error (not infra)',
+   cle({ code: '23505' }), false);
+eq('conn: the table is exactly the 6 Class-57/08 codes',
+   Object.keys(m.CONN_LIFETIME_SQLSTATES).sort().join(','),
+   '08000,08003,08006,57P01,57P02,57P03');
+
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);


### PR DESCRIPTION
#1781 ruled that a server-side connection **death** must never book as `dialect_error` (the O5 gate's hard-zero metric). Its guard tested `!qerr.code` — correct for the shape it measured, but an **administrative** termination (Patroni failover, pgbouncer restart, `pg_terminate_backend`) **carries** SQLSTATE 57P01 and slipped past it.

**Measured live 2026-07-29:** the 04:04:06Z TL72to73 failover booked **two 57P01s as dialect_error**; the 19:11:47Z TL74to75 failover booked **zero** (the client error handler won that race). The mis-classification is **non-deterministic** — so a clean census could not be trusted to mean the guard held.

**Fix:** isConnLifetimeError() over the PG Class-57/08 codes, applied at **both** classification sites — including the DB_ENGINE=pg routing path 6.4 will serve users from, where a mis-booked blip would corrupt the metric *and* masquerade as a translator defect while falling back to MariaDB.

**Deliberately still visible:** 57014 (our statement_timeout, counted as pg_timeout), 53300 (real capacity fault), all 42xxx/22xxx/23xxx.

**Verified:** selftest 190 to **209 ALL PASS**; and **executed against the live engine pre-merge** per the #1780/#1785 rule — forced a real pg_terminate_backend inside a live arbimon pod: the error arrived **via the query callback with code=57P01** (patched predicate: conn-lifetime true; old guard: false, i.e. would have booked dialect_error), while a real 42P01 is correctly not absorbed.

Classification only — no translator/routing/SQL change.