### PR TITLE
shadow/6.4: strip the arbimon2. schema qualifier (first post-#1787 genuine dialect_error)

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -349,6 +349,25 @@ function translateBackticks(sql) {
     });
 }
 
+// --- schema-qualifier strip (P6, 2026-07-29) -----------------------------
+// Two legacy call sites qualify tables with the MySQL SCHEMA name:
+//   playlists.js:551  FROM arbimon2.playlist_recordings   (census d2f44837)
+//   projects.js:79    from arbimon2.projects p
+// On MariaDB that resolves (arbimon2 IS the schema); on PG the database is
+// `arbimon` with everything in `public`, so the qualified name is a hard
+// 42P01 (`relation "arbimon2.playlist_recordings" does not exist`) — the
+// FIRST genuine dialect_error caught by the post-#1787 unconditional gate
+// (2026-07-29 21:34Z, organic traffic). Strip the qualifier; the enumeration
+// found NO other schema ever referenced (information_schema/mysql/etc. never
+// appear in app SQL — verified by repo grep, 2 live sites total).
+// Runs AFTER protectLiterals (a literal like
+// 'arbimon2.s3.us-east-1.amazonaws.com' is already stashed and untouchable)
+// and AFTER translateBackticks (so a hypothetical `arbimon2`.`t` form,
+// already reduced to arbimon2.t, is caught too).
+function stripSchemaQualifier(sql) {
+    return sql.replace(/\barbimon2\s*\.\s*/gi, '');
+}
+
 // LIMIT offset, count  ->  LIMIT count OFFSET offset
 function translateLimitOffset(sql) {
     return sql.replace(/\blimit\s+(\d+)\s*,\s*(\d+)/gi, function (_, off, cnt) {
@@ -1198,6 +1217,7 @@ function translate(mysqlSql) {
     s = stripIndexHints(s);
     s = fixQuotedAliases(s, store);
     s = translateBackticks(s);
+    s = stripSchemaQualifier(s);
     s = translateLimitOffset(s);
     s = translateFunctions(s, store);
     s = translateCollation(s);

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -560,6 +560,30 @@ eq('IN: template-collapsed placeholder shape unchanged',
    m.sqlTemplate("SELECT * FROM t WHERE id IN (1,2,3) AND name='x' AND n=5"),
    'SELECT * FROM t WHERE id IN (?) AND name=? AND n=?');
 
+// ---- schema-qualifier strip (P6, 2026-07-29) ------------------------------
+// The first genuine dialect_error caught by the post-#1787 unconditional
+// gate: legacy qualifies two queries with the MySQL schema name `arbimon2.`,
+// which is a hard 42P01 on PG (database `arbimon`, schema `public`).
+console.log('== schema-qualifier strip (P6 2026-07-29) ==');
+eq('schema: the live d2f44837 shape (playlists.js:551)',
+   m.translate("SELECT DISTINCT(playlist_id) FROM arbimon2.playlist_recordings WHERE recording_id in (1,2)"),
+   'SELECT DISTINCT(playlist_id) FROM playlist_recordings WHERE recording_id in (1,2)');
+eq('schema: the projects.js:79 shape (aliased, lowercase from)',
+   /from projects p\b/.test(m.translate("select p.project_id from arbimon2.projects p join user_project_role upr on p.project_id = upr.project_id where upr.user_id = 5")),
+   true);
+eq('schema: qualifier inside a STRING LITERAL untouched',
+   m.translate("SELECT * FROM t WHERE uri = 'https://arbimon2.s3.us-east-1.amazonaws.com/x'"),
+   "SELECT * FROM t WHERE uri = 'https://arbimon2.s3.us-east-1.amazonaws.com/x'");
+eq('schema: backticked form also stripped',
+   m.translate('SELECT * FROM `arbimon2`.`playlist_recordings` LIMIT 1'),
+   'SELECT * FROM playlist_recordings LIMIT 1');
+eq('schema: an identifier merely CONTAINING arbimon2 untouched',
+   m.translate('SELECT arbimon2_backup_flag FROM t'),
+   'SELECT arbimon2_backup_flag FROM t');
+eq('schema: case-insensitive (ARBIMON2.)',
+   m.translate('SELECT * FROM ARBIMON2.projects LIMIT 1'),
+   'SELECT * FROM projects LIMIT 1');
+
 // ---- connection-lifetime SQLSTATE classification (P6, 2026-07-29) --------
 // #1781 ruled that a connection DEATH must never book as dialect_error (the
 // O5 gate's hard-zero metric). Its guard tested `!err.code` only, so an


### PR DESCRIPTION
Census hash d2f44837 (2026-07-29 21:34Z, organic traffic): `SELECT DISTINCT(playlist_id) FROM arbimon2.playlist_recordings ...` → 42P01 on PG. Two live call sites qualify with the MySQL schema name (playlists.js:551, projects.js:79); on PG the database is `arbimon`/schema `public`. **This is the first genuine dialect_error caught by the post-#1787 unconditional gate — the gate working as designed.**

Fix: `stripSchemaQualifier()` in the translator (after protectLiterals so `arbimon2.s3...` URLs in literals are untouchable; word-boundary anchored). Translator-level chosen over editing the two models: the translator owns dialect differences, and any future copy-paste of either shape stays covered.

selftest 209→**215 ALL PASS**. **Live-executed pre-merge:** unstripped shape still 42P01s (fault is real); both stripped shapes execute; cross-engine parity EXACT (29/29 rows, 0/0). Restarts the O5 clock — taken promptly per the operator's clock-economics rule.