### PR TITLE
shadow/6.4: 08P01 pgbouncer conn-death classification + classifications double-send crash guard

### DIFF
--- a/app/routes/data-api/project/classifications.js
+++ b/app/routes/data-api/project/classifications.js
@@ -152,6 +152,22 @@ router.post('/new', function(req, res, next) {
             next();
         },
     ], function(err, data){
+        // rfcx-local 2026-08-03: honor the waterfall's error. The #1631 rewrite
+        // dropped the err check, so an aborted waterfall (e.g. the duplicate-name
+        // path, which has ALREADY responded with {name:"repeated"} and bailed via
+        // next(new Error())) fell through to createClassificationJob with
+        // job_id === undefined — posting a garbage arbimon-rfm-classify-undefined-*
+        // k8s Job and double-sending the response. The second res.json() threw
+        // ERR_HTTP_HEADERS_SENT inside a q async tick (q.js:155 rethrow), which is
+        // OUTSIDE express's error handling → uncaughtException → the whole pod
+        // crashed (2 distinct crash events in 14d: main pod 2026-08-03 00:13Z,
+        // shadow canary 2026-07-20 18:40Z).
+        if (err) {
+            if (!response_already_sent) {
+                res.json({ err: 'Could not create classification job' });
+            }
+            return;
+        }
         return model.classifications.createClassificationJob({
             jobId: job_id
         }, function(err, data) {

--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -205,9 +205,21 @@ function templateHash(sql) {
 // firing, already counted separately as pg_timeout (a perf signal).
 // 53300 (too_many_connections) is NOT here either: that is a real capacity
 // fault we WANT visible rather than silently absorbed as infra noise.
+//
+// 08P01 protocol_violation (rfcx-local 2026-08-03, 3rd incompleteness of this
+// classifier after #1781/#1787): when a backend dies UNDER PGBOUNCER, the
+// pooler synthesizes an 08P01 error to the client with the message
+// "server conn crashed?" (both the SQLSTATE and the message are pgbouncer
+// binary strings; verified against the pooler log at the same second). The
+// TL78->79 failover at 06:47:33Z booked exactly 2 such records per pod as
+// dialect_error — a pooler-mediated connection death, not a dialect fault.
+// #1787 covered the DIRECT-connection death states (57P01/2/3, 08000/3/6)
+// but the shadow path rides pgbouncer, so the pooler's synthesized state is
+// the one it actually sees. A REAL client protocol bug would be chronic and
+// still visible as a pg_error step-change (query_conn_error keeps pg_code).
 var CONN_LIFETIME_SQLSTATES = {
     '57P01': 1, '57P02': 1, '57P03': 1,
-    '08000': 1, '08003': 1, '08006': 1
+    '08000': 1, '08003': 1, '08006': 1, '08P01': 1
 };
 
 function isConnLifetimeError(err) {

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -626,9 +626,18 @@ eq('conn: 42804 datatype_mismatch is a REAL dialect error',
    cle({ code: '42804' }), false);
 eq('conn: 23505 unique_violation is a REAL error (not infra)',
    cle({ code: '23505' }), false);
-eq('conn: the table is exactly the 6 Class-57/08 codes',
+// 08P01 protocol_violation (P6 2026-08-03, 3rd incompleteness): pgbouncer
+// SYNTHESIZES this state when a backend dies under the pooler ("server conn
+// crashed?" — both strings live in the pgbouncer binary). The shadow path
+// rides pgbouncer, so pooler-mediated deaths surface as 08P01, not 57P01.
+// MEASURED live: the 2026-08-03 06:47:33Z TL78->79 failover booked exactly
+// 2 records per pod as dialect_error via this state.
+eq('conn: 08P01 protocol_violation (pgbouncer-synthesized conn death, 06:47Z case)',
+   cle({ code: '08P01', message: 'server conn crashed?' }), true);
+eq('conn: lowercase 08p01 still matches', cle({ code: '08p01' }), true);
+eq('conn: the table is exactly the 7 Class-57/08 codes',
    Object.keys(m.CONN_LIFETIME_SQLSTATES).sort().join(','),
-   '08000,08003,08006,57P01,57P02,57P03');
+   '08000,08003,08006,08P01,57P01,57P02,57P03');
 
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);


### PR DESCRIPTION
## The bundle (one CD roll, per the O5 bundling guard)

### 1. 08P01 → CONN_LIFETIME_SQLSTATES (3rd classifier incompleteness: #1781 → #1787 → this)
The 2026-08-03 06:47:33Z TL78→79 failover booked **2 dialect_error records per pod**, all `pg_code: 08P01`, detail `server conn crashed?` — **proven pgbouncer-synthesized** (the message string AND the SQLSTATE both live in the pgbouncer binary; the pooler log shows the matching pooler error at the same second). A pooler-mediated backend death is a connection-lifetime event, not a dialect fault; #1787's table covered only the direct-connection states (57P01/2/3, 08000/3/6), but the shadow path rides pgbouncer.

Fail-direction: a REAL client protocol bug would be chronic and still visible as a `pg_error` step-change (`query_conn_error` preserves `pg_code`). 42xxx/22xxx/23xxx/57014/53300 stay visible — selftest pins the exact table membership.

**Live execution (pre-merge, on the main pod with the patched module):** classifier verified against live module exports; end-to-end `pg_terminate_backend` through pgbouncer:6432 arrived at the QUERY CALLBACK with a SQLSTATE and classified conn-lifetime; `42P01` verified still a real dialect error. (The pass-through shape carries 57P01; 08P01 is the shape pgbouncer synthesizes when it detects the crash itself, as measured live at 06:47:33Z.)

### 2. classifications.js POST /new: honor the waterfall error (weekly pod-crash class)
The #1631 rewrite dropped the `err` check in the final callback: the duplicate-name abort (already responded `{name:"repeated"}`, bailed via `next(new Error())`) fell through to `createClassificationJob({jobId: undefined})` → garbage `arbimon-rfm-classify-undefined-*` k8s Job + double `res.json()` → `ERR_HTTP_HEADERS_SENT` rethrown by q on a fresh async tick (outside express) → **uncaughtException → pod crash**. 2 distinct crash events in 14d (main pod 2026-08-03 00:13Z, shadow canary 2026-07-20 18:40Z).

### Verification
- selftest **217/217** (215 + two 08P01 cases; table-membership test updated to the 7 codes)
- Both `isConnLifetimeError` call sites (shadow ~1669 + 6.4 routing ~1884) share the single function — single-point fix, no two-site trap.

### O5 consequence
**Restarts the clock (9th T0)** — per the operator clock-economics rule (2026-07-29): the 06:47Z failover already corrupted the current census, so the days accrued were measured by a corrupted instrument. Operator GO 2026-08-03 03:44 EDT.