### PR TITLE
fix(clustering): perDate GROUP BY legal on PG — MIN(date_created), cardinality-neutral (P6 42803)

### DIFF
--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -121,9 +121,28 @@ let ClusteringJobs = {
         }
 
         if (options.perDate) {
+            // rfcx-local 2026-08-03 (P6 42803): C.audio_event_detection_job_id is
+            // NOT unique — one AED job can have many clustering runs (measured
+            // live: up to 88 C rows per job, avg fan-out 4.62) — so this join
+            // multiplies rows and the GROUP BY A.aed_id de-duplicates them.
+            // MariaDB (ONLY_FULL_GROUP_BY off) silently picked ONE
+            // date_created per aed (first-scanned, = MIN on every job tested);
+            // PostgreSQL rejects the bare column with 42803. MIN() keeps the
+            // query legal on BOTH engines, cardinality-neutral (verified live:
+            // 3 aeds -> 3 rows, vs 264 if the column joined the GROUP BY), and
+            // value-identical to MariaDB's historical pick — now deterministic
+            // instead of scan-order luck. The aed-branch columns join the
+            // GROUP BY for PG's strictness rule; they are 1:1 per aed (species/
+            // songtypes join on their PKs) so they add no rows.
             tables.push("JOIN job_params_audio_event_clustering C ON A.job_id = C.audio_event_detection_job_id");
-            select.push('C.`date_created`');
+            select.push('MIN(C.`date_created`) as `date_created`');
             groupby.push('A.aed_id');
+            if (options.aed) {
+                groupby.push('A.species_id', 'A.songtype_id', 'sgt.songtype', 'sp.scientific_name');
+            }
+            if (options.perSite) {
+                groupby.push('S.site_id', 'S.`name`');
+            }
         }
 
         if (options.rec_id) {

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -584,6 +584,17 @@ eq('schema: case-insensitive (ARBIMON2.)',
    m.translate('SELECT * FROM ARBIMON2.projects LIMIT 1'),
    'SELECT * FROM projects LIMIT 1');
 
+// ---- clustering perDate GROUP BY shape (P6 2026-08-03, 42803 hash 8ff48586) --
+// findRois(aed+perDate) selects MIN(C.`date_created`) with the aed-branch
+// columns in the GROUP BY. Pin that the translator carries the whole fixed
+// shape: MIN() aggregate untouched, backtick alias -> bare/quoted ident,
+// CONCAT -> || with text cast. (The FIX lives in clustering-jobs.js; this
+// guards the translated form the 6.4 routing path will execute.)
+console.log('== clustering perDate GROUP BY shape (P6 2026-08-03) ==');
+eq('clustering: MIN(backtick col) + alias translates',
+   m.translate('SELECT A.aed_id, MIN(C.`date_created`) as `date_created` FROM a A JOIN c C ON A.j = C.k GROUP BY A.aed_id, A.species_id'),
+   'SELECT A.aed_id, MIN(C.date_created) as date_created FROM a A JOIN c C ON A.j = C.k GROUP BY A.aed_id, A.species_id');
+
 // ---- connection-lifetime SQLSTATE classification (P6, 2026-07-29) --------
 // #1781 ruled that a connection DEATH must never book as dialect_error (the
 // O5 gate's hard-zero metric). Its guard tested `!err.code` only, so an


### PR DESCRIPTION
## The defect (first genuine dialect_error on the 64722ee clock)
2026-08-03 14:42:53Z, hash `8ff48586`, pg_code **42803**: `findRois()` with `aed`+`perDate` (the clustering UI's **Sort per Date** filter with selected ROIs) selects `sgt.songtype`/`sp.scientific_name`/`C.date_created` while grouping only by `A.aed_id`. MariaDB permits it (`ONLY_FULL_GROUP_BY` off); PG rejects it. 1 occurrence in 14d — a rarely-used filter combo, which is why six clock-weeks never saw it. At 6.4 it would be a user-facing 500.

## Why the #1769 precedent did NOT transfer
`C.audio_event_detection_job_id` is **not unique** — one AED job has up to **88** clustering runs (avg fan-out 4.62 across 10M joined rows), so `GROUP BY A.aed_id` is doing real de-duplication. The precedent fix (add the column to the GROUP BY) **explodes 3 aeds into 264 rows** (measured on MariaDB). An iterative re-review caught this before implementation.

## The fix
`MIN(C.date_created)` — proven live:
- **cardinality-neutral**: 3 aeds → 3 rows on both engines (NULL-species edge included)
- **value-identical** to MariaDB's historical implicit pick on every job tested (insertion order == date order) — and now **deterministic** (the 88 candidates span 3 weeks; MariaDB's pick was scan-order luck)
- aed-branch columns join the GROUP BY for PG strictness (1:1 PK joins, no row change); `perSite`+`perDate` combo guarded (the route permits it even though the UI radio-group doesn't)

## Verification
- **Pre-merge live execution** on the prod pod: the exact emitted SQL → the LIVE adapter's `translate()` → executed on PG via pgbouncer → 3 rows **byte-identical** to MariaDB (old and new shape)
- selftest **218/218** (+ a pin on the translated MIN/backtick-alias shape)
- Callers audited: legacy clustering UI (the trigger), visualizer + playlists (pass neither flag — unaffected), **exports worker** (shares `findRois()`, runs `EXPORTS_DB_ENGINE=pg` live-routed — passes `aed` without `perDate` so can't hit the bug, but gets the fix via the standard exports hand-roll)

## O5 consequence
Restarts the clock (**10th T0**). Operator GO 2026-08-03 14:55 EDT.