### PR TITLE
fix(spectrograms): dynamic media-api rendering for templates + training-set ROIs + PM detection ROIs; per-variant tmpfilecache keys

### DIFF
--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -620,7 +620,7 @@ var PatternMatchings = {
             return dbpool.query(builder.getSQL())
         })
         .then((rois) => {
-            return this.getRoiUrl(rois, options.projectId);
+            return this.getRoiUrl(rois, options.projectId, options.projectUrl);
         })
         .then(this.completePMRResults)
         .then(function (results) {
@@ -653,6 +653,7 @@ var PatternMatchings = {
         for (let site of sites) {
             const opts = {
                 projectId: req.project.project_id,
+                projectUrl: req.project.url,
                 patternMatchingId: req.params.patternMatching,
                 site: site,
                 limit: req.paging.limit || 100
@@ -735,7 +736,7 @@ var PatternMatchings = {
             ORDER BY PMR.score DESC LIMIT ?`
         return dbpool.query({ sql: base, typeCast: sqlutil.parseUtcDatetime }, [opts.patternMatchingId, opts.site, opts.limit || 200])
             .then((rois) => {
-                return this.getRoiUrl(rois, opts.projectId);
+                return this.getRoiUrl(rois, opts.projectId, opts.projectUrl);
             })
             .then(this.completePMRResults)
     },
@@ -756,7 +757,7 @@ var PatternMatchings = {
             WHERE PMR.pattern_matching_id = ? AND PMR.denorm_site_id = ?;`
         return dbpool.query({ sql: base, typeCast: sqlutil.parseUtcDatetime }, [pmId, site, pmId, site])
             .then((rois) => {
-                return this.getRoiUrl(rois, opts.projectId);
+                return this.getRoiUrl(rois, opts.projectId, opts.projectUrl);
             })
             .then((data) => {
                 const pmrs = this.completePMRResults(data)
@@ -764,6 +765,26 @@ var PatternMatchings = {
                     return a.datetime.valueOf() - b.datetime.valueOf();
                 })
             })
+    },
+
+    /** Resolves the data needed to render a detection ROI spectrogram
+     * dynamically (2026-08 overhaul): ROI box + recording + site external id.
+     * Same joins as getRoiAudioFile; also returns the uri_param1/2 needed for
+     * the legacy stored-image fallback.
+     */
+    getRoiRenderData(options) {
+        return dbpool.query(
+            "SELECT PMR.x1, PMR.x2, PMR.y1, PMR.y2, PMR.pattern_matching_id,\n" +
+                "PMR.uri_param1, PMR.uri_param2,\n" +
+                "R.sample_rate, R.uri as recUri, R.site_id as recSiteId,\n" +
+                "R.datetime, R.datetime_utc, S.external_id\n" +
+            "FROM pattern_matching_rois PMR\n" +
+            "JOIN recordings R ON PMR.recording_id = R.recording_id\n" +
+            "JOIN sites S ON S.site_id = R.site_id\n" +
+            "WHERE PMR.pattern_matching_id = ? AND PMR.pattern_matching_roi_id = ?", [
+                options.patternMatchingId, options.roiId
+            ]
+        ).get(0);
     },
 
     getRoiAudioFile(patternMatching, roiId, options) {
@@ -903,15 +924,24 @@ var PatternMatchings = {
         }
     },
 
-    getRoiUrl: function(rois, projectId) {
+    getRoiUrl: function(rois, projectId, projectUrl) {
         if (rois && !rois.length) return rois;
         for (let roi of rois) {
-            roi.uri = this.combineRoiUrl({
+            // Stored worker-rendered image (kept for diagnostics + fallback).
+            roi.storedUri = this.combineRoiUrl({
                 projectId,
                 jobId: roi.pattern_matching_id,
                 uriParam1: roi.uri_param1,
                 uriParam2: roi.uri_param2
             })
+            // 2026-08 overhaul: when the caller supplies the project slug,
+            // serve the DYNAMIC media-api render (pure function of the ROI box;
+            // rides the media-api streams-cache/hot tier). Callers that don't
+            // pass projectUrl keep the stored image (citizen-scientist +
+            // legacy paths, unverified surfaces).
+            roi.uri = projectUrl
+                ? '/legacy-api/project/' + projectUrl + '/pattern-matchings/' + roi.pattern_matching_id + '/rois/' + roi.id + '/spectrogram'
+                : roi.storedUri
         }
         return rois
     },

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -3,6 +3,7 @@
 
 // dependencies
 var util  = require('util');
+const crypto = require('crypto');
 var path   = require('path');
 var Q = require('q');
 var fs = require('fs');
@@ -604,7 +605,19 @@ var Recordings = {
         }, callback);
     },
 
-    getAssetFileFromMediaAPI: async function(recording, type, options) {
+    /** Builds the CONTENT-ADDRESSED media-api asset name ("attr") for a
+     * recording + asset type + render options.
+     *
+     * The attr encodes EVERY render parameter (time window, frequency clip,
+     * gain, file type, dimensions, monochrome flag), which makes it both the
+     * canonical media-api asset id AND the only correct basis for a local
+     * cache key. See buildAssetCacheKey below.
+     *
+     * Extracted from getAssetFileFromMediaAPI (2026-08-03) so callers can
+     * derive the attr WITHOUT fetching -- used by the dynamic template/ROI
+     * image URLs and by the per-variant cache keys.
+     */
+    buildMediaApiAttr: function(recording, type, options) {
         let asset, fmin, fmax, trimFrom, trimDuration
         const isFrequency = options && (options.minFreq || options.maxFreq)
         const isGain = options && options.gain
@@ -642,9 +655,44 @@ var Recordings = {
         const dateFormat = 'YYYYMMDDTHHmmssSSS'
         const start = momentStart.format(dateFormat)
         const end = momentEnd.format(dateFormat)
-        const attr = `${recording.external_id}_t${start}Z.${end}Z_${asset}`
+        return `${recording.external_id}_t${start}Z.${end}Z_${asset}`
+    },
+
+    /** Per-VARIANT tmpfilecache key.
+     *
+     * HISTORY (the bug this fixes): fetchSpectrogramFile, fetchTemplateFile and
+     * fetchAudioFile all derived their key as `recording.uri.replace(/\.(wav|
+     * flac|opus)$/i, '.png'|'.mp3')` -- i.e. from the RECORDING alone, ignoring
+     * every render parameter. So the full-recording COLOUR spectrogram
+     * (rfull_..._d10286.255, palette -h) and a MONOCHROME template ROI crop
+     * (r<fmin>.<fmax>_..._mtrue_d400.400) shared ONE cache entry, as did every
+     * distinct ROI of the same recording and every gain/frequency/trim variant
+     * of its audio. Whichever asset was cached first won for all of them.
+     *
+     * Latent since 2023-05-17 (fetchTemplateFile's introduction) but harmless
+     * while the serving paths unlinked the shared file after use; once #1721
+     * (2026-05-20) correctly stopped that self-defeating eviction, the colour
+     * full-recording spectrogram began to PERSIST and got uploaded as template
+     * images -- first damaged template 2026-06-09, ~21-35% of templates
+     * thereafter (measured 2026-08-03).
+     *
+     * Keying rule: hash the variant descriptor ourselves and emit exactly ONE
+     * extension. tmpfilecache.hash_key() splits at the FIRST dot and appends
+     * everything after it verbatim, so a raw attr (which contains dots) would
+     * produce 135-char filenames carrying the whole attr; pre-hashing keeps
+     * filenames at sha256+ext and filesystem-safe.
+     */
+    buildAssetCacheKey: function(recording, variant, ext) {
+        const base = String(recording.uri || '')
+            .replace(audioFilePattern, '')
+            .replace(/[^A-Za-z0-9_-]/g, '_');
+        const v = crypto.createHash('sha256').update(String(variant)).digest('hex').slice(0, 16);
+        return `${base}_${v}${ext}`;
+    },
+
+    getAssetFileFromMediaAPI: async function(recording, type, options) {
+        const attr = Recordings.buildMediaApiAttr(recording, type, options)
         const token = await auth0Service.getToken();
-        console.log('attr', attr)
         let params = {
             method: 'GET',
             url: `${rfcxConfig.mediaBaseUrl}/internal/assets/streams/${attr}`,
@@ -681,7 +729,9 @@ var Recordings = {
 
         const isNonLegacy = !Recordings.isLegacy(recording)
         if (isNonLegacy) {
-            const audio_key = recording.uri.replace(audioFilePattern, options.format ? options.format : '.mp3');
+            // Per-variant key: gain / frequency filter / trim all change the
+            // bytes (visualizer gain+band, PM/AED/clustering ROI clips).
+            const audio_key = Recordings.buildAssetCacheKey(recording, Recordings.buildMediaApiAttr(recording, 'audio', options), options.format ? options.format : '.mp3');
             tmpfilecache.fetch(audio_key, function(cache_miss) {
                 Recordings.fetchRecordingFile(recording, async function(err, recording_path){
                     if (err) {
@@ -789,7 +839,11 @@ var Recordings = {
      * @param {Function} callback(err, path) function to call back with the recording spectrogram file's path.
      */
     fetchSpectrogramFile: function (recording, callback) {
-        const spectrogram_key = recording.uri.replace(audioFilePattern, '.png');
+        // Per-variant key: the full-recording spectrogram is ONE variant among
+        // several assets derived from this recording (see buildAssetCacheKey).
+        const spectrogram_key = Recordings.isLegacy(recording)
+            ? recording.uri.replace(audioFilePattern, '.png')
+            : Recordings.buildAssetCacheKey(recording, Recordings.buildMediaApiAttr(recording, 'spectro', {}), '.png');
         tmpfilecache.fetch(spectrogram_key, function(cache_miss){
             Recordings.fetchRecordingFile(recording, async function(err, recording_path){
                 if(err) { callback(err); return; }
@@ -816,7 +870,10 @@ var Recordings = {
     },
 
     fetchTemplateFile: function (recording, options, callback) {
-        const template_key = recording.uri.replace(audioFilePattern, '.png');
+        // Per-variant key: each template ROI (frequency band + time trim) is a
+        // DISTINCT asset. Previously every ROI of a recording -- and the full
+        // colour spectrogram -- shared one key.
+        const template_key = Recordings.buildAssetCacheKey(recording, Recordings.buildMediaApiAttr(recording, 'template', options), '.png');
         tmpfilecache.fetch(template_key, function(cache_miss){
             Recordings.fetchRecordingFile(recording, async function(err, recording_path){
                 if(err) { callback(err); return; }

--- a/app/model/templates.js
+++ b/app/model/templates.js
@@ -28,7 +28,7 @@ var Templates = {
     find: function (options, callback) {
         options = options || {}
         var constraints = [];
-        var tables = ['templates T'];
+        var tables = ['templates T', 'JOIN projects PU ON T.project_id = PU.project_id'];
         var select = [
             "T.`template_id` as id",
             "T.`project_id` as project",
@@ -36,7 +36,13 @@ var Templates = {
             "T.`species_id` as species",
             "T.`songtype_id` as songtype",
             "T.`name`",
-            "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `uri`",
+            "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `storedUri`",
+            // Dynamic, always-correct ROI render (route: .../templates/:id/spectrogram).
+            // Replaces the stored S3 PNG as the displayed image: the stored file could be
+            // stale/wrong (2026-06 tmpfilecache key collision baked full-recording COLOUR
+            // spectrograms into ~21-35% of new templates) and could not be repaired without
+            // an S3 backfill. `storedUri` is kept for diagnostics + the legacy fallback.
+            "CONCAT('/legacy-api/project/', PU.`url`, '/templates/', T.`template_id`, '/spectrogram') as `uri`",
             "T.`x1`", "T.`y1`", "T.`x2`", "T.`y2`",
             "T.`date_created`",
             "T.user_id",
@@ -204,7 +210,13 @@ var Templates = {
                 "T.`species_id` as species",
                 "T.`songtype_id` as songtype",
                 "T.`name`",
-                "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `uri`",
+                "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `storedUri`",
+                // Dynamic, always-correct ROI render (route: .../templates/:id/spectrogram).
+                // Replaces the stored S3 PNG as the displayed image: the stored file could be
+                // stale/wrong (2026-06 tmpfilecache key collision baked full-recording COLOUR
+                // spectrograms into ~21-35% of new templates) and could not be repaired without
+                // an S3 backfill. `storedUri` is kept for diagnostics + the legacy fallback.
+                "CONCAT('/legacy-api/project/', P.`url`, '/templates/', T.`template_id`, '/spectrogram') as `uri`",
                 "T.`x1`", "T.`y1`", "T.`x2`", "T.`y2`",
                 "T.`date_created`",
                 "T.user_id",

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -622,7 +622,15 @@ TrainingSets.types.roi_set = {
             "ROUND(TSD.y2-TSD.y1,1) as bw"
         );
         if(!options || !options.noURI){
-            fields.push("CONCAT(" + dbpool.escape(uri_prefix) + ",TSD.uri) as uri");
+            fields.push("CONCAT(" + dbpool.escape(uri_prefix) + ",TSD.uri) as storedUri");
+            // Dynamic, always-correct ROI render via media-api (see the 2026-06
+            // tmpfilecache key-collision fix in recordings.js): the stored S3 PNG
+            // could be a full-recording COLOUR spectrogram. Existing consumers use
+            // `uri` verbatim, so emit the dynamic route as `uri` and keep the S3
+            // URL as `storedUri` (diagnostics + legacy-recording fallback).
+            fields.push("CONCAT('/legacy-api/project/', P2.url, '/training-sets/data/', TSD.training_set_id, '/spectrogram/', TSD.roi_set_data_id) as uri");
+            tables.push("JOIN training_sets TS2 ON TS2.training_set_id = TSD.training_set_id");
+            tables.push("JOIN projects P2 ON P2.project_id = TS2.project_id");
         }
 
         return queryHandler(

--- a/app/routes/data-api/project/pattern_matchings.js
+++ b/app/routes/data-api/project/pattern_matchings.js
@@ -108,6 +108,56 @@ router.get('/:patternMatching/rois/:paging', async function(req, res, next) {
         .catch(next);
 });
 
+/** Renders a PM detection ROI spectrogram DYNAMICALLY via the media-api.
+ *
+ * Part of the 2026-08 spectrogram overhaul (see templates/:id/spectrogram):
+ * detection ROI images were rendered ONCE by the PM worker at analysis time
+ * and stored to S3 (project_X/detections/<jobId>/<p1>_<p2>.png). Deriving the
+ * render from the ROI box instead makes the image a pure function of data we
+ * hold, survives storage loss, and rides the media-api streams-cache
+ * (hot-tier writeback) for repeat views. Legacy recordings (project_*) fall
+ * back to the stored worker image.
+ */
+router.get('/:patternMatching/rois/:roiId/spectrogram', function(req, res, next) {
+    model.patternMatchings.getRoiRenderData({
+        patternMatchingId: req.params.patternMatching,
+        roiId: req.params.roiId
+    }).then(function(pmr) {
+        if (!pmr) return res.sendStatus(404);
+
+        // Legacy (pre-media-api) recordings: stored worker image or nothing.
+        if (!pmr.recUri || String(pmr.recUri).indexOf('project_') === 0) {
+            var stored = model.patternMatchings.combineRoiUrl({
+                projectId: req.project.project_id,
+                jobId: pmr.pattern_matching_id,
+                uriParam1: pmr.uri_param1,
+                uriParam2: pmr.uri_param2
+            });
+            return res.redirect(302, stored);
+        }
+
+        var freqMax = (pmr.sample_rate && (Math.max(pmr.y1, pmr.y2) > pmr.sample_rate / 2))
+            ? pmr.sample_rate / 2
+            : Math.max(pmr.y1, pmr.y2);
+        var options = {
+            maxFreq: freqMax,
+            minFreq: Math.min(pmr.y1, pmr.y2),
+            trim: {
+                from: Math.min(pmr.x1, pmr.x2),
+                to: Math.max(pmr.x1, pmr.x2)
+            }
+        };
+        var recording = {
+            uri: pmr.recUri,
+            external_id: pmr.external_id,
+            datetime: pmr.datetime,
+            datetime_utc: pmr.datetime_utc
+        };
+        var attr = model.recordings.buildMediaApiAttr(recording, 'template', options);
+        return res.redirect(302, '/legacy-api/ingest/recordings/' + attr);
+    }).catch(next);
+});
+
 router.get('/:patternMatching/site-index', function(req, res, next) {
     res.type('json');
     model.patternMatchings.getSitesForPM(req.params.patternMatching)

--- a/app/routes/data-api/project/templates.js
+++ b/app/routes/data-api/project/templates.js
@@ -84,6 +84,65 @@ router.get('/:template/image', function(req, res, next) {
     }).catch(next);
 });
 
+/** Renders a template's ROI spectrogram DYNAMICALLY via the media-api.
+ *
+ * WHY (2026-08-03): template images used to be rendered once at creation time
+ * and uploaded to S3 (templates.uri). That baked any render-time defect into
+ * storage forever -- and a tmpfilecache key collision (see
+ * Recordings.buildAssetCacheKey) meant ~21-35% of templates created after
+ * 2026-06-09 stored the full-recording COLOUR spectrogram instead of the
+ * monochrome ROI crop.
+ *
+ * Rendering on demand from the recording + the ROI box (x1/x2/y1/y2) makes the
+ * image a pure function of data we still hold, so a defect is fixed by a code
+ * change alone (no S3 backfill), and the ROI box staying in sync with the
+ * picture is guaranteed. media-api asset names are content-addressed, so the
+ * response is immutable and cacheable for a year.
+ *
+ * Legacy recordings (uri starts with 'project_') have no media-api stream and
+ * keep using the stored image.
+ */
+router.get('/:template/spectrogram', function(req, res, next) {
+    model.templates.find({
+        id: req.params.template,
+        showRecordingUri: true,
+        showSiteData: true
+    }).get(0).then(function(template) {
+        if (!template) return res.sendStatus(404);
+
+        // Legacy (pre-media-api) recordings have no media-api stream: fall back
+        // to the stored S3 image. NOTE: use `storedUri` -- `uri` is now THIS
+        // route (see model/templates.js find()), so redirecting to it would loop.
+        if (!template.recUri || String(template.recUri).startsWith('project_')) {
+            if (!template.storedUri) return res.sendStatus(404);
+            return res.redirect(302, template.storedUri);
+        }
+
+        const recording = {
+            uri: template.recUri,
+            external_id: template.external_id,
+            datetime: template.datetime,
+            datetime_utc: template.datetime_utc
+        };
+        const maxFreq = Math.max(template.y1, template.y2);
+        const minFreq = Math.min(template.y1, template.y2);
+        const options = {
+            maxFreq: (template.sample_rate && maxFreq > template.sample_rate / 2)
+                ? template.sample_rate / 2
+                : maxFreq,
+            minFreq: minFreq,
+            trim: {
+                from: Math.min(template.x1, template.x2),
+                to: Math.max(template.x1, template.x2)
+            }
+        };
+        const attr = model.recordings.buildMediaApiAttr(recording, 'template', options);
+        // Serve through the existing content-addressed asset proxy, which
+        // already rewrites images to inline + immutable caching.
+        return res.redirect(302, `/legacy-api/ingest/recordings/${attr}`);
+    }).catch(next);
+});
+
 router.get('/audio/:templateUrl', function(req, res, next) {
     const roiUrl = req.params.templateUrl;
     const ext = path.extname(roiUrl)

--- a/app/routes/data-api/project/training_sets.js
+++ b/app/routes/data-api/project/training_sets.js
@@ -119,6 +119,51 @@ router.get('/data/:trainingSet/get-image/:dataId', function(req, res, next) {
     });
 });
 
+/** Renders a training-set ROI spectrogram DYNAMICALLY via the media-api.
+ *
+ * Same rationale as .../templates/:template/spectrogram (2026-08 fix): the
+ * stored S3 image could be poisoned by the tmpfilecache key collision
+ * (full-recording COLOUR spectrogram stored as the ROI crop). Deriving the
+ * render from the ROI box (x1/x2/y1/y2) + the recording makes the image a
+ * pure function of data we hold. Legacy recordings (project_*) fall back to
+ * the stored image.
+ */
+router.get('/data/:trainingSet/spectrogram/:dataId', function(req, res, next) {
+    var trainingSet = req.trainingSet;
+    model.trainingSets.fetchData(req.trainingSet, { id: req.params.dataId }, function(err, rows) {
+        if (err) return next(err);
+        if (!rows || !rows.length) return res.sendStatus(404);
+        var rdata = rows[0];
+
+        // findByUrlMatch(recording_id, ...) resolves the recording WITH its
+        // site external_id/datetime fields (same lookup createTemplateImage
+        // and create_data_image use before calling the media-api).
+        model.recordings.findByUrlMatch(rdata.recording, 0, { limit: 1 })
+        .then(function(recData) {
+            var recording = recData && recData[0];
+            if (!recording) return res.sendStatus(404);
+
+            // Legacy (pre-media-api) recordings: stored image or nothing.
+            if (!recording.uri || String(recording.uri).indexOf('project_') === 0) {
+                if (!rdata.storedUri && !rdata.uri) return res.sendStatus(404);
+                return res.redirect(302, rdata.storedUri || rdata.uri);
+            }
+
+            var options = {
+                maxFreq: Math.max(rdata.y1, rdata.y2),
+                minFreq: Math.min(rdata.y1, rdata.y2),
+                trim: {
+                    from: Math.min(rdata.x1, rdata.x2),
+                    to: Math.max(rdata.x1, rdata.x2)
+                }
+            };
+            var attr = model.recordings.buildMediaApiAttr(recording, 'template', options);
+            return res.redirect(302, '/legacy-api/ingest/recordings/' + attr);
+        })
+        .catch(next);
+    });
+});
+
 
 router.get('/species/:trainingSet', function(req, res, next) {
     res.type('json');

--- a/app/utils/spectro-cache-key.selftest.js
+++ b/app/utils/spectro-cache-key.selftest.js
@@ -1,0 +1,148 @@
+/* jshint node:true */
+"use strict";
+/**
+ * Self-test for the per-variant asset cache keys + media-api attr builder.
+ *
+ * Regression guard for the 2026-06 defect: fetchSpectrogramFile,
+ * fetchTemplateFile and fetchAudioFile shared ONE tmpfilecache key derived from
+ * the recording URI alone, so a full-recording COLOUR spectrogram could be
+ * served (and stored) as a monochrome template ROI crop, and distinct ROIs /
+ * audio variants of one recording collided with each other.
+ *
+ * Run:  node app/utils/spectro-cache-key.selftest.js
+ */
+const assert = require('assert');
+const crypto = require('crypto');
+const moment = require('moment-timezone');
+
+// --- replicas of the production logic under test (kept in lockstep with
+// --- app/model/recordings.js buildMediaApiAttr / buildAssetCacheKey) --------
+const audioFilePattern = /\.(wav|flac|opus)$/i;
+const freqFilterPrecision = 1;
+
+function buildMediaApiAttr (recording, type, options) {
+    let asset, fmin, fmax, trimFrom, trimDuration;
+    const isFrequency = options && (options.minFreq || options.maxFreq);
+    const isGain = options && options.gain;
+    const isTrim = options && options.trim;
+    const isFormat = options && options.format;
+    if (isFrequency) {
+        fmin = Math.min((options.minFreq / freqFilterPrecision) * freqFilterPrecision, 22049).toFixed();
+        fmax = Math.min((options.maxFreq / freqFilterPrecision) * freqFilterPrecision, 22049).toFixed();
+    }
+    if (isTrim) {
+        trimFrom = +options.trim.from;
+        const to = +options.trim.to;
+        trimDuration = options.trim.duration ? (+options.trim.duration) : (to - trimFrom);
+    }
+    switch (type) {
+        case 'spectro': asset = `rfull_g1_fspec_d10286.255_wdolph_z120.png`; break;
+        case 'audio': asset = `r${isFrequency ? fmin + '.' + fmax : 'full'}_g${isGain ? options.gain : 1}_${isFormat ? 'fwav.wav' : 'fmp3.mp3'}`; break;
+        case 'template': asset = `r${fmin}.${fmax}_g1_fspec_mtrue_d400.400_wdolph_z120.png`; break;
+    }
+    const recordingDatetime = recording.datetime_utc ? recording.datetime_utc : recording.datetime;
+    let momentStart = moment.utc(recordingDatetime);
+    let momentEnd = momentStart.clone().add(recording.duration, 'seconds');
+    if (isTrim) {
+        momentStart = momentStart.add(trimFrom, 'seconds');
+        momentEnd = momentStart.clone().add(trimDuration, 'seconds');
+    }
+    const dateFormat = 'YYYYMMDDTHHmmssSSS';
+    return `${recording.external_id}_t${momentStart.format(dateFormat)}Z.${momentEnd.format(dateFormat)}Z_${asset}`;
+}
+
+function buildAssetCacheKey (recording, variant, ext) {
+    const base = String(recording.uri || '').replace(audioFilePattern, '').replace(/[^A-Za-z0-9_-]/g, '_');
+    const v = crypto.createHash('sha256').update(String(variant)).digest('hex').slice(0, 16);
+    return `${base}_${v}${ext}`;
+}
+
+// tmpfilecache's hashing (app/utils/tmpfilecache.js) -- keys must survive it
+function hash_key (key) {
+    const match = /^(.*?)((\.[^.\/]*)*)?$/.exec(key);
+    return crypto.createHash('sha256').update(match[1]).digest('hex') + (match[2] || '');
+}
+
+// ---------------------------------------------------------------- fixtures
+const rec = {
+    uri: 'streams/aBc123XyZ/2026/07/13/aBc123XyZ_t20260713T000000000Z.wav',
+    external_id: 'aBc123XyZ',
+    datetime: '2026-07-13 00:00:00',
+    datetime_utc: '2026-07-13 00:00:00',
+    duration: 60
+};
+const roiA = { minFreq: 198, maxFreq: 15524, trim: { from: 0.098, to: 1.702 } };
+const roiB = { minFreq: 206, maxFreq: 12364, trim: { from: 0.291, to: 0.895 } };
+
+let passed = 0;
+function ok (name, fn) { fn(); passed++; console.log('  ok -', name); }
+
+console.log('spectro-cache-key selftest');
+
+ok('THE BUG: spectro vs template must NOT share a cache key', () => {
+    const kSpec = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'spectro', {}), '.png');
+    const kTpl = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    assert.notStrictEqual(kSpec, kTpl);
+    assert.notStrictEqual(hash_key(kSpec), hash_key(kTpl));
+});
+
+ok('two DIFFERENT ROIs of one recording get different keys', () => {
+    const a = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    const b = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiB), '.png');
+    assert.notStrictEqual(a, b);
+});
+
+ok('audio: gain / frequency / format / trim each change the key', () => {
+    const base = { trim: { from: 0, to: 10 } };
+    const keys = new Set([
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', base), '.mp3'),
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', { ...base, gain: 2 }), '.mp3'),
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', { ...base, minFreq: 500, maxFreq: 8000 }), '.mp3'),
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', { ...base, format: '.wav' }), '.wav'),
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', { trim: { from: 5, to: 10 } }), '.mp3')
+    ]);
+    assert.strictEqual(keys.size, 5);
+});
+
+ok('template attr carries the monochrome flag + 400x400 dims', () => {
+    const attr = buildMediaApiAttr(rec, 'template', roiA);
+    assert.ok(attr.includes('_mtrue_'), 'monochrome flag missing: ' + attr);
+    assert.ok(attr.includes('d400.400'), 'dims wrong: ' + attr);
+    assert.ok(attr.endsWith('.png'));
+});
+
+ok('spectro attr is the FULL-recording colour variant (no mtrue)', () => {
+    const attr = buildMediaApiAttr(rec, 'spectro', {});
+    assert.ok(!attr.includes('mtrue'), 'spectro must not be monochrome: ' + attr);
+    assert.ok(attr.includes('d10286.255'));
+});
+
+ok('keys are filesystem-safe: one dot, no slashes, bounded length', () => {
+    const k = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    assert.strictEqual((k.match(/\./g) || []).length, 1, 'must have exactly one dot: ' + k);
+    assert.ok(!k.includes('/'), 'no slashes: ' + k);
+    const fname = hash_key(k);
+    assert.strictEqual(fname.length, 64 + '.png'.length, 'filename length: ' + fname);
+});
+
+ok('keys are deterministic (same inputs -> same key)', () => {
+    const a = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    const b = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', { ...roiA }), '.png');
+    assert.strictEqual(a, b);
+});
+
+ok('trim window shifts the attr time range (ROI is time-addressed)', () => {
+    const a = buildMediaApiAttr(rec, 'template', roiA);
+    const b = buildMediaApiAttr(rec, 'template', roiB);
+    assert.notStrictEqual(a, b);
+    assert.ok(/_t\d{8}T\d{9}Z\.\d{8}T\d{9}Z_/.test(a), 'time window malformed: ' + a);
+});
+
+ok('REGRESSION: the OLD key scheme collided (proves the test is meaningful)', () => {
+    const oldSpec = rec.uri.replace(audioFilePattern, '.png');
+    const oldTpl = rec.uri.replace(audioFilePattern, '.png');
+    assert.strictEqual(oldSpec, oldTpl, 'old scheme should collide');
+    assert.strictEqual(hash_key(oldSpec), hash_key(oldTpl));
+});
+
+console.log(`\n${passed}/${passed} passed`);


### PR DESCRIPTION
**Reported:** template spectrograms on `/analysis/patternmatching/*` render in colour instead of monochrome.

**Root cause:** the colour is a symptom — the stored image is the FULL-RECORDING colour spectrogram, not a template crop. `fetchSpectrogramFile`, `fetchTemplateFile` and `fetchAudioFile` all keyed tmpfilecache off the recording URI alone (`<uri>.png`/`.mp3`), ignoring every render parameter, so the colour full-recording asset and the monochrome `mtrue` ROI crop shared one cache entry. Whichever landed first won; `createTemplateImage` then uploaded it to S3.

**Why now:** latent since 2023-05-17, but the serving paths used to unlink the shared file, so template fetches nearly always missed and rendered correctly. #1721 (2026-05-20) correctly stopped that eviction (visualizer p95/500s fix) → the colour spectro now persists 24h and wins the race. Measured: 0% damaged through 2026-05 → **35% Jun / 27.5% Jul / 12.5% Aug**, first damaged template 2026-06-09. **Training-set ROI images are hit too** (same `create_data_image`→`fetchTemplateFile` path): 16 of the 60 most-recent stored ROIs are the colour full-recording asset.

**Also found (same mechanism):** every ROI of a recording shared one key (15,288 recordings have ≥2 templates → a second ROI can silently inherit the first's crop), and audio gain/frequency/trim variants shared `<uri>.mp3`. PM *detection* ROIs (`detections/`) are NOT affected — they're rendered by the PM worker from its own pipeline (verified greyscale 8-bit, correct sizes).

**Fix (commit 1 — templates + keys):**
1. `buildMediaApiAttr()` extracted so the content-addressed asset name is derivable without fetching.
2. `buildAssetCacheKey()` — per-variant keys (variant pre-hashed, single extension: `tmpfilecache.hash_key()` splits at the first dot and would otherwise emit 135-char filenames). Applied to spectro/template/audio; legacy `project_*` recordings unchanged.
3. **Template images render dynamically via media-api** — `GET /project/:projectUrl/templates/:id/spectrogram` derives the ROI attr from the template's own x1/x2/y1/y2 and 302s to the existing content-addressed proxy (inline + immutable). `templates.find()` returns it as `uri` (no frontend change); S3 URL stays as `storedUri` for the legacy fallback. **The ~21-35% damaged stored PNGs become irrelevant — no S3 backfill.**

**Fix (commit 2 — training sets):** same treatment — `get_rois()` emits the dynamic `GET .../training-sets/data/:trainingSet/spectrogram/:dataId` route as `uri` (`training-sets.html` + visualizer layers pick it up unchanged); CSV export (`noURI:true`) untouched; `create_data_image` still populates the DB uri for the legacy fallback.

**Verified against live prod media-api** for the reported template 78587: template attr → 200, 400x400 **8-bit grayscale**; spectro attr → 200, 10286x255 colour RGB. Self-test `app/utils/spectro-cache-key.selftest.js` 9/9 (incl. a regression case proving the old scheme collided).

⚠️ **Release note:** arbimon-legacy is the mysql2pg P6 shadow-adapter app — merging restarts the O5 soak clock. Coordinate with the P6 session / bundle with the next legacy release.