### PR TITLE
feat(spectrograms): consolidated dynamic rendering — templates + all 3 ROI families + per-variant cache keys

### DIFF
--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -6,6 +6,7 @@ const AWS = require('aws-sdk');
 const { createS3Client } = require('../utils/storage');
 const q = require('q');
 const dbpool = require('../utils/dbpool');
+const { roiSpectrogramUrl } = require('../utils/asset-url');
 const Recordings = require('./recordings');
 const config = require('../config');
 const k8sConfig = config('k8s');
@@ -93,7 +94,7 @@ let ClusteringJobs = {
         if(!options){
             options = {};
         }
-        select.push(
+select.push(
             `A.aed_id,
             A.time_min,
             A.time_max,
@@ -103,6 +104,19 @@ let ClusteringJobs = {
             CONCAT('audio_events/${curEnv}/detection/', A.job_id, '/png/', A.recording_id, '/', A.uri_param, '.png') as 'uri',
             A.validated`
         );
+
+        // Join the recording + site so we can build the on-demand spectrogram
+        // URL (media API) and never depend on the pre-cached detection PNGs.
+        // `RSPEC`/`SSPEC` aliases avoid colliding with the perSite R/S joins.
+        // Skip on the perDate path (it GROUPs BY aed_id; adding non-aggregated
+        // columns would break under ONLY_FULL_GROUP_BY — that path isn't used to
+        // render the ROI image grid, which goes through the rec_id path).
+        const withSpectroCols = !options.perDate;
+        if (withSpectroCols) {
+            tables.push("JOIN recordings RSPEC ON A.recording_id = RSPEC.recording_id");
+            tables.push("JOIN sites SSPEC ON SSPEC.site_id = RSPEC.site_id");
+            select.push("SSPEC.external_id as external_id, RSPEC.datetime_utc as datetime_utc");
+        }
 
         if (options.aed) {
             tables.push("LEFT JOIN species sp ON sp.species_id = A.species_id");
@@ -157,7 +171,21 @@ let ClusteringJobs = {
         if (options.exportReport) {
             return dbpool.query(sql)
         }
-        return dbpool.query(sql)
+        return dbpool.query(sql).then(function (rois) {
+            if (withSpectroCols && Array.isArray(rois)) {
+                for (const roi of rois) {
+                    roi.spectrogram_url = roiSpectrogramUrl({
+                        externalId: roi.external_id,
+                        datetimeUtc: roi.datetime_utc,
+                        timeMin: roi.time_min,
+                        timeMax: roi.time_max,
+                        freqMin: roi.frequency_min,
+                        freqMax: roi.frequency_max
+                    });
+                }
+            }
+            return rois;
+        })
     },
 
     getClusteringPlaylist: async function(recId) {

--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -116,6 +116,10 @@ select.push(
             tables.push("JOIN recordings RSPEC ON A.recording_id = RSPEC.recording_id");
             tables.push("JOIN sites SSPEC ON SSPEC.site_id = RSPEC.site_id");
             select.push("SSPEC.external_id as external_id, RSPEC.datetime_utc as datetime_utc");
+            // Needed by the SPA 'expand' modal to frame a padded full-band
+            // window: sample_rate -> nyquist (freq axis), duration -> clamp
+            // the padded window. Cheap columns on the already-joined RSPEC.
+            select.push("RSPEC.sample_rate as sample_rate, RSPEC.duration as duration");
         }
 
         if (options.aed) {

--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -111,7 +111,12 @@ select.push(
         // Skip on the perDate path (it GROUPs BY aed_id; adding non-aggregated
         // columns would break under ONLY_FULL_GROUP_BY — that path isn't used to
         // render the ROI image grid, which goes through the rec_id path).
-        const withSpectroCols = !options.perDate;
+        // ALSO skip on exportReport: the clustering CSV export derives its
+        // column list from Object.keys(results[0]) (processClusteringStream),
+        // so any column projected here LEAKS into the user-facing CSV — and
+        // the export doesn't need the spectro/window columns (nor the extra
+        // RSPEC/SSPEC joins on the full-job export query).
+        const withSpectroCols = !options.perDate && !options.exportReport;
         if (withSpectroCols) {
             tables.push("JOIN recordings RSPEC ON A.recording_id = RSPEC.recording_id");
             tables.push("JOIN sites SSPEC ON SSPEC.site_id = RSPEC.site_id");

--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -189,7 +189,8 @@ select.push(
                         timeMin: roi.time_min,
                         timeMax: roi.time_max,
                         freqMin: roi.frequency_min,
-                        freqMax: roi.frequency_max
+                        freqMax: roi.frequency_max,
+                        sampleRate: roi.sample_rate
                     });
                 }
             }

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -13,7 +13,7 @@ const Templates = require('./templates');
 const models = require("./index");
 const lambda = new AWS.Lambda();
 const { getSignedUrl } = require('../utils/storage')
-const { arbimon2PublicUrl } = require('../utils/asset-url')
+const { arbimon2PublicUrl, roiSpectrogramUrl } = require('../utils/asset-url')
 
 // exports
 var PatternMatchings = {
@@ -323,6 +323,13 @@ var PatternMatchings = {
                 'R.uri as recording, R.meta ',
                 'S.name as site, S.site_id',
                 'PMR.denorm_recording_datetime as datetime',
+                // Needed to build the on-demand spectrogram URL (media API,
+                // non-session /ingest path) so the SPA does not depend on the
+                // pre-cached detection PNGs. external_id = stream id; datetime_utc
+                // is the true UTC start that frames the ROI time window (the
+                // denorm `datetime` above is TZ-shifted and must NOT be used).
+                'S.external_id as external_id',
+                'R.datetime_utc as datetime_utc',
             );
 
             if(show.datetime){
@@ -912,8 +919,30 @@ var PatternMatchings = {
                 uriParam1: roi.uri_param1,
                 uriParam2: roi.uri_param2
             })
+            // On-demand spectrogram (generated live via the media API through
+            // the non-session /ingest path), so the SPA can render detection
+            // spectrograms WITHOUT depending on the ~1B pre-baked detection PNGs
+            // (roi.uri). Only for non-legacy recordings (which have a stream
+            // external_id); legacy recordings keep the cached uri only.
+            roi.spectrogram_url = this.combineRoiSpectrogramUrl(roi)
         }
         return rois
+    },
+
+    /**
+     * On-demand spectrogram URL for one PM ROI (delegates to the shared
+     * roiSpectrogramUrl helper). CRITICAL: uses datetime_utc, never the
+     * TZ-shifted denorm `datetime`.
+     */
+    combineRoiSpectrogramUrl: function(roi) {
+        return roiSpectrogramUrl({
+            externalId: roi.external_id,
+            datetimeUtc: roi.datetime_utc,
+            timeMin: roi.x1,
+            timeMax: roi.x2,
+            freqMin: roi.y1,
+            freqMax: roi.y2
+        });
     },
 
     combineRoiUrl: function(opts) {

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -945,7 +945,8 @@ var PatternMatchings = {
             timeMin: roi.x1,
             timeMax: roi.x2,
             freqMin: roi.y1,
-            freqMax: roi.y2
+            freqMax: roi.y2,
+            sampleRate: roi.sample_rate
         });
     },
 

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -330,6 +330,11 @@ var PatternMatchings = {
                 // denorm `datetime` above is TZ-shifted and must NOT be used).
                 'S.external_id as external_id',
                 'R.datetime_utc as datetime_utc',
+                // Needed by the SPA 'expand' modal to frame a padded full-band
+                // window: sample_rate -> nyquist (freq axis), duration -> clamp
+                // the +/-5s window. Cheap columns on the already-joined R.
+                'R.sample_rate as sample_rate',
+                'R.duration as duration',
             );
 
             if(show.datetime){
@@ -347,9 +352,8 @@ var PatternMatchings = {
                 builder.addTable('JOIN songtypes St ON PMR.songtype_id = St.songtype_id');
                 builder.addProjection('Sp.scientific_name as species, St.songtype as songtype');
             }
-            if (show.showFrequency) {
-                builder.addProjection('R.sample_rate as sample_rate');
-            }
+            // (sample_rate is now projected unconditionally above for the SPA
+            // expand modal, so show.showFrequency no longer needs to add it.)
             if(!show.names){
                 builder.addProjection(
                     'PMR.`recording_id`',

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -3,6 +3,7 @@
 
 // dependencies
 var util  = require('util');
+const crypto = require('crypto');
 var path   = require('path');
 var Q = require('q');
 var fs = require('fs');
@@ -604,7 +605,19 @@ var Recordings = {
         }, callback);
     },
 
-    getAssetFileFromMediaAPI: async function(recording, type, options) {
+    /** Builds the CONTENT-ADDRESSED media-api asset name ("attr") for a
+     * recording + asset type + render options.
+     *
+     * The attr encodes EVERY render parameter (time window, frequency clip,
+     * gain, file type, dimensions, monochrome flag), which makes it both the
+     * canonical media-api asset id AND the only correct basis for a local
+     * cache key. See buildAssetCacheKey below.
+     *
+     * Extracted from getAssetFileFromMediaAPI (2026-08-03) so callers can
+     * derive the attr WITHOUT fetching -- used by the dynamic template/ROI
+     * image URLs and by the per-variant cache keys.
+     */
+    buildMediaApiAttr: function(recording, type, options) {
         let asset, fmin, fmax, trimFrom, trimDuration
         const isFrequency = options && (options.minFreq || options.maxFreq)
         const isGain = options && options.gain
@@ -642,9 +655,44 @@ var Recordings = {
         const dateFormat = 'YYYYMMDDTHHmmssSSS'
         const start = momentStart.format(dateFormat)
         const end = momentEnd.format(dateFormat)
-        const attr = `${recording.external_id}_t${start}Z.${end}Z_${asset}`
+        return `${recording.external_id}_t${start}Z.${end}Z_${asset}`
+    },
+
+    /** Per-VARIANT tmpfilecache key.
+     *
+     * HISTORY (the bug this fixes): fetchSpectrogramFile, fetchTemplateFile and
+     * fetchAudioFile all derived their key as `recording.uri.replace(/\.(wav|
+     * flac|opus)$/i, '.png'|'.mp3')` -- i.e. from the RECORDING alone, ignoring
+     * every render parameter. So the full-recording COLOUR spectrogram
+     * (rfull_..._d10286.255, palette -h) and a MONOCHROME template ROI crop
+     * (r<fmin>.<fmax>_..._mtrue_d400.400) shared ONE cache entry, as did every
+     * distinct ROI of the same recording and every gain/frequency/trim variant
+     * of its audio. Whichever asset was cached first won for all of them.
+     *
+     * Latent since 2023-05-17 (fetchTemplateFile's introduction) but harmless
+     * while the serving paths unlinked the shared file after use; once #1721
+     * (2026-05-20) correctly stopped that self-defeating eviction, the colour
+     * full-recording spectrogram began to PERSIST and got uploaded as template
+     * images -- first damaged template 2026-06-09, ~21-35% of templates
+     * thereafter (measured 2026-08-03).
+     *
+     * Keying rule: hash the variant descriptor ourselves and emit exactly ONE
+     * extension. tmpfilecache.hash_key() splits at the FIRST dot and appends
+     * everything after it verbatim, so a raw attr (which contains dots) would
+     * produce 135-char filenames carrying the whole attr; pre-hashing keeps
+     * filenames at sha256+ext and filesystem-safe.
+     */
+    buildAssetCacheKey: function(recording, variant, ext) {
+        const base = String(recording.uri || '')
+            .replace(audioFilePattern, '')
+            .replace(/[^A-Za-z0-9_-]/g, '_');
+        const v = crypto.createHash('sha256').update(String(variant)).digest('hex').slice(0, 16);
+        return `${base}_${v}${ext}`;
+    },
+
+    getAssetFileFromMediaAPI: async function(recording, type, options) {
+        const attr = Recordings.buildMediaApiAttr(recording, type, options)
         const token = await auth0Service.getToken();
-        console.log('attr', attr)
         let params = {
             method: 'GET',
             url: `${rfcxConfig.mediaBaseUrl}/internal/assets/streams/${attr}`,
@@ -681,7 +729,9 @@ var Recordings = {
 
         const isNonLegacy = !Recordings.isLegacy(recording)
         if (isNonLegacy) {
-            const audio_key = recording.uri.replace(audioFilePattern, options.format ? options.format : '.mp3');
+            // Per-variant key: gain / frequency filter / trim all change the
+            // bytes (visualizer gain+band, PM/AED/clustering ROI clips).
+            const audio_key = Recordings.buildAssetCacheKey(recording, Recordings.buildMediaApiAttr(recording, 'audio', options), options.format ? options.format : '.mp3');
             tmpfilecache.fetch(audio_key, function(cache_miss) {
                 Recordings.fetchRecordingFile(recording, async function(err, recording_path){
                     if (err) {
@@ -789,7 +839,11 @@ var Recordings = {
      * @param {Function} callback(err, path) function to call back with the recording spectrogram file's path.
      */
     fetchSpectrogramFile: function (recording, callback) {
-        const spectrogram_key = recording.uri.replace(audioFilePattern, '.png');
+        // Per-variant key: the full-recording spectrogram is ONE variant among
+        // several assets derived from this recording (see buildAssetCacheKey).
+        const spectrogram_key = Recordings.isLegacy(recording)
+            ? recording.uri.replace(audioFilePattern, '.png')
+            : Recordings.buildAssetCacheKey(recording, Recordings.buildMediaApiAttr(recording, 'spectro', {}), '.png');
         tmpfilecache.fetch(spectrogram_key, function(cache_miss){
             Recordings.fetchRecordingFile(recording, async function(err, recording_path){
                 if(err) { callback(err); return; }
@@ -816,7 +870,10 @@ var Recordings = {
     },
 
     fetchTemplateFile: function (recording, options, callback) {
-        const template_key = recording.uri.replace(audioFilePattern, '.png');
+        // Per-variant key: each template ROI (frequency band + time trim) is a
+        // DISTINCT asset. Previously every ROI of a recording -- and the full
+        // colour spectrogram -- shared one key.
+        const template_key = Recordings.buildAssetCacheKey(recording, Recordings.buildMediaApiAttr(recording, 'template', options), '.png');
         tmpfilecache.fetch(template_key, function(cache_miss){
             Recordings.fetchRecordingFile(recording, async function(err, recording_path){
                 if(err) { callback(err); return; }

--- a/app/model/templates.js
+++ b/app/model/templates.js
@@ -28,7 +28,7 @@ var Templates = {
     find: function (options, callback) {
         options = options || {}
         var constraints = [];
-        var tables = ['templates T'];
+        var tables = ['templates T', 'JOIN projects PU ON T.project_id = PU.project_id'];
         var select = [
             "T.`template_id` as id",
             "T.`project_id` as project",
@@ -36,7 +36,13 @@ var Templates = {
             "T.`species_id` as species",
             "T.`songtype_id` as songtype",
             "T.`name`",
-            "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `uri`",
+            "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `storedUri`",
+            // Dynamic, always-correct ROI render (route: .../templates/:id/spectrogram).
+            // Replaces the stored S3 PNG as the displayed image: the stored file could be
+            // stale/wrong (2026-06 tmpfilecache key collision baked full-recording COLOUR
+            // spectrograms into ~21-35% of new templates) and could not be repaired without
+            // an S3 backfill. `storedUri` is kept for diagnostics + the legacy fallback.
+            "CONCAT('/legacy-api/project/', PU.`url`, '/templates/', T.`template_id`, '/spectrogram') as `uri`",
             "T.`x1`", "T.`y1`", "T.`x2`", "T.`y2`",
             "T.`date_created`",
             "T.user_id",
@@ -204,7 +210,13 @@ var Templates = {
                 "T.`species_id` as species",
                 "T.`songtype_id` as songtype",
                 "T.`name`",
-                "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `uri`",
+                "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `storedUri`",
+                // Dynamic, always-correct ROI render (route: .../templates/:id/spectrogram).
+                // Replaces the stored S3 PNG as the displayed image: the stored file could be
+                // stale/wrong (2026-06 tmpfilecache key collision baked full-recording COLOUR
+                // spectrograms into ~21-35% of new templates) and could not be repaired without
+                // an S3 backfill. `storedUri` is kept for diagnostics + the legacy fallback.
+                "CONCAT('/legacy-api/project/', P.`url`, '/templates/', T.`template_id`, '/spectrogram') as `uri`",
                 "T.`x1`", "T.`y1`", "T.`x2`", "T.`y2`",
                 "T.`date_created`",
                 "T.user_id",

--- a/app/model/templates.js
+++ b/app/model/templates.js
@@ -12,7 +12,7 @@ const config = require('../config');
 const dbpool = require('../utils/dbpool');
 const Recordings = require('./recordings');
 const { isArray } = require('lodash');
-const { arbimon2PublicUrl, arbimon2PublicUrlBase } = require('../utils/asset-url');
+const { arbimon2PublicUrl, arbimon2PublicUrlBase, roiSpectrogramUrl } = require('../utils/asset-url');
 
 let s3;
 
@@ -28,7 +28,7 @@ var Templates = {
     find: function (options, callback) {
         options = options || {}
         var constraints = [];
-        var tables = ['templates T', 'JOIN projects PU ON T.project_id = PU.project_id'];
+        var tables = ['templates T', 'JOIN recordings RDYN ON RDYN.recording_id = T.recording_id', 'JOIN sites SDYN ON SDYN.site_id = RDYN.site_id'];
         var select = [
             "T.`template_id` as id",
             "T.`project_id` as project",
@@ -37,12 +37,15 @@ var Templates = {
             "T.`songtype_id` as songtype",
             "T.`name`",
             "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `storedUri`",
-            // Dynamic, always-correct ROI render (route: .../templates/:id/spectrogram).
-            // Replaces the stored S3 PNG as the displayed image: the stored file could be
-            // stale/wrong (2026-06 tmpfilecache key collision baked full-recording COLOUR
-            // spectrograms into ~21-35% of new templates) and could not be repaired without
-            // an S3 backfill. `storedUri` is kept for diagnostics + the legacy fallback.
-            "CONCAT('/legacy-api/project/', PU.`url`, '/templates/', T.`template_id`, '/spectrogram') as `uri`",
+            // Columns for the DYNAMIC media-api render (post-mapped onto `uri`
+            // below via roiSpectrogramUrl). The stored S3 PNG can be stale/wrong
+            // (the 2026-06 tmpfilecache key collision baked full-recording COLOUR
+            // spectrograms into ~21-35% of new templates). The dynamic URL must be
+            // the AUTH-FREE /legacy-api/ingest path (NOT the session-gated
+            // .../templates/:id/spectrogram route): SPA users hold an Auth0 session
+            // but not necessarily a legacy session, so a session-gated <img> URL
+            // 302s to /legacy-login (QA-caught on demo 2026-08-04).
+            "RDYN.`uri` as `dynRecUri`, RDYN.`datetime_utc` as `dynDatetimeUtc`, RDYN.`sample_rate` as `dynSampleRate`, SDYN.`external_id` as `dynExternalId`",
             "T.`x1`", "T.`y1`", "T.`x2`", "T.`y2`",
             "T.`date_created`",
             "T.user_id",
@@ -142,7 +145,30 @@ var Templates = {
             WHERE ${constraints.join(' AND ')}
             ORDER BY date_created DESC
             ${options.limit ? ('LIMIT ' + options.limit + ' OFFSET ' + options.offset) : ''}`
-        );
+        ).then(function(rows) {
+            // Post-map: `uri` = the dynamic media-api render when the recording
+            // has a stream external_id (auth-free ingest path, hot-cache-backed);
+            // pre-media-api recordings (project_* uri, no external_id) keep the
+            // stored S3 image. Internal render columns are stripped.
+            for (var i = 0; i < rows.length; i++) {
+                var r = rows[i];
+                var dyn = (r.dynRecUri && String(r.dynRecUri).indexOf('project_') !== 0)
+                    ? roiSpectrogramUrl({
+                        externalId: r.dynExternalId,
+                        datetimeUtc: r.dynDatetimeUtc,
+                        timeMin: Math.min(r.x1, r.x2),
+                        timeMax: Math.max(r.x1, r.x2),
+                        freqMin: Math.min(r.y1, r.y2),
+                        freqMax: Math.max(r.y1, r.y2),
+                        sampleRate: r.dynSampleRate
+                    }, { width: 400, height: 400 })
+                    : null;
+                r.uri = dyn || r.storedUri;
+                delete r.dynRecUri; delete r.dynDatetimeUtc;
+                delete r.dynSampleRate; delete r.dynExternalId;
+            }
+            return rows;
+        });
     },
 
     findOne: function(query){
@@ -211,12 +237,9 @@ var Templates = {
                 "T.`songtype_id` as songtype",
                 "T.`name`",
                 "CONCAT(" + dbpool.escape(arbimon2PublicUrlBase() + '/') + ", T.`uri`) as `storedUri`",
-                // Dynamic, always-correct ROI render (route: .../templates/:id/spectrogram).
-                // Replaces the stored S3 PNG as the displayed image: the stored file could be
-                // stale/wrong (2026-06 tmpfilecache key collision baked full-recording COLOUR
-                // spectrograms into ~21-35% of new templates) and could not be repaired without
-                // an S3 backfill. `storedUri` is kept for diagnostics + the legacy fallback.
-                "CONCAT('/legacy-api/project/', P.`url`, '/templates/', T.`template_id`, '/spectrogram') as `uri`",
+                // Dynamic media-api render columns (post-mapped onto `uri` below;
+                // auth-free ingest path -- see find()).
+                "RDYN.`uri` as `dynRecUri`, RDYN.`datetime_utc` as `dynDatetimeUtc`, RDYN.`sample_rate` as `dynSampleRate`, SDYN.`external_id` as `dynExternalId`",
                 "T.`x1`", "T.`y1`", "T.`x2`", "T.`y2`",
                 "T.`date_created`",
                 "T.user_id",
@@ -227,6 +250,8 @@ var Templates = {
                 "P.`name` as `project_name`, P.`url` as `project_url`",
             );
             tables.push('JOIN projects P ON T.project_id = P.project_id');
+            tables.push('JOIN recordings RDYN ON RDYN.recording_id = T.recording_id');
+            tables.push('JOIN sites SDYN ON SDYN.site_id = RDYN.site_id');
             constraints.push('P.public_templates_enabled = 1')
             constraints.push('T.source_project_id IS NULL');
             tables.push('JOIN project_classes pc ON pc.species_id = T.species_id AND pc.songtype_id = T.songtype_id');
@@ -239,7 +264,26 @@ var Templates = {
                 LIMIT 3)`
             query += index === classIds.length - 1 ? sql : `${sql} UNION `
         })
-        return dbpool.query(query)
+        return dbpool.query(query).then(function(rows) {
+            for (var i = 0; i < rows.length; i++) {
+                var r = rows[i];
+                var dyn = (r.dynRecUri && String(r.dynRecUri).indexOf('project_') !== 0)
+                    ? roiSpectrogramUrl({
+                        externalId: r.dynExternalId,
+                        datetimeUtc: r.dynDatetimeUtc,
+                        timeMin: Math.min(r.x1, r.x2),
+                        timeMax: Math.max(r.x1, r.x2),
+                        freqMin: Math.min(r.y1, r.y2),
+                        freqMax: Math.max(r.y1, r.y2),
+                        sampleRate: r.dynSampleRate
+                    }, { width: 400, height: 400 })
+                    : null;
+                r.uri = dyn || r.storedUri;
+                delete r.dynRecUri; delete r.dynDatetimeUtc;
+                delete r.dynSampleRate; delete r.dynExternalId;
+            }
+            return rows;
+        })
     },
 
     SCHEMA: joi.object().keys({

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -23,7 +23,7 @@ var sqlutil      = require('../utils/sqlutil');
 var dbpool       = require('../utils/dbpool');
 var Recordings   = require('./recordings');
 var Projects     = require('./projects');
-var { arbimon2PublicUrl, arbimon2PublicUrlBase } = require('../utils/asset-url');
+var { arbimon2PublicUrl, arbimon2PublicUrlBase, roiSpectrogramUrl } = require('../utils/asset-url');
 
 // local variables
 var s3;
@@ -599,6 +599,13 @@ TrainingSets.types.roi_set = {
         ], callback);
     },
     get_rois : function(training_set, options, callback) {
+        // Normalise the (training_set, callback) 2-arg call used by the JSON
+        // route (fetchRois(ts, cb)); queryHandler normalises this too, but we
+        // read options.stream + wrap the callback here, so we must do it first.
+        if (callback === undefined && options instanceof Function) {
+            callback = options;
+            options = undefined;
+        }
         var uri_prefix = arbimon2PublicUrlBase() + '/';
         var fields=["TSD.roi_set_data_id as id"];
         var tables=["training_set_roi_set_data TSD"];
@@ -625,12 +632,40 @@ TrainingSets.types.roi_set = {
             fields.push("CONCAT(" + dbpool.escape(uri_prefix) + ",TSD.uri) as uri");
         }
 
+        // On-demand spectrogram support: join the recording's stream external_id
+        // + true UTC start so we can build the media-API URL and never depend on
+        // the pre-cached ROI PNGs. Use RSPEC/SSPEC aliases to avoid colliding
+        // with the resolveIds R join above. Only for the streamed JSON path
+        // (not the CSV export, which sets stream:true and streams raw rows).
+        var withSpectro = !(options && options.stream);
+        if (withSpectro) {
+            tables.push("JOIN recordings RSPEC ON RSPEC.recording_id = TSD.recording_id");
+            tables.push("JOIN sites SSPEC ON SSPEC.site_id = RSPEC.site_id");
+            fields.push("SSPEC.external_id as external_id", "RSPEC.datetime_utc as datetime_utc");
+        }
+
+        var enrich = function (err, rows) {
+            if (!err && withSpectro && Array.isArray(rows)) {
+                for (var i = 0; i < rows.length; i++) {
+                    rows[i].spectrogram_url = roiSpectrogramUrl({
+                        externalId: rows[i].external_id,
+                        datetimeUtc: rows[i].datetime_utc,
+                        timeMin: rows[i].x1,
+                        timeMax: rows[i].x2,
+                        freqMin: rows[i].y1,
+                        freqMax: rows[i].y2
+                    });
+                }
+            }
+            return callback(err, rows);
+        };
+
         return queryHandler(
             'SELECT ' + fields.join(',') + '\n' +
             'FROM ' + tables.join('\n') + '\n' +
             'WHERE TSD.training_set_id = ' + dbpool.escape(training_set.id),
             options,
-            callback
+            withSpectro ? enrich : callback
         );
     },
     get_species : function(training_set, callback) {

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -659,6 +659,18 @@ TrainingSets.types.roi_set = {
                         freqMin: rows[i].y1,
                         freqMax: rows[i].y2
                     });
+                    // 2026-08-04 consolidation: the legacy training-sets page
+                    // binds roi.uri directly, and the STORED image can be a
+                    // full-recording COLOUR spectrogram (tmpfilecache key
+                    // collision, damaging since 2026-06-09 -- see
+                    // recordings.js buildAssetCacheKey). Serve the dynamic
+                    // render to legacy consumers too; keep the stored URL as
+                    // storedUri (diagnostics + pre-media-api recordings,
+                    // which have no spectrogram_url and keep the stored uri).
+                    if (rows[i].spectrogram_url) {
+                        rows[i].storedUri = rows[i].uri;
+                        rows[i].uri = rows[i].spectrogram_url;
+                    }
                 }
             }
             return callback(err, rows);

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -642,6 +642,10 @@ TrainingSets.types.roi_set = {
             tables.push("JOIN recordings RSPEC ON RSPEC.recording_id = TSD.recording_id");
             tables.push("JOIN sites SSPEC ON SSPEC.site_id = RSPEC.site_id");
             fields.push("SSPEC.external_id as external_id", "RSPEC.datetime_utc as datetime_utc");
+            // Needed by the SPA 'expand' modal to frame a padded full-band
+            // window: sample_rate -> nyquist (freq axis), duration -> clamp
+            // the padded window. Cheap columns on the already-joined RSPEC.
+            fields.push("RSPEC.sample_rate as sample_rate", "RSPEC.duration as duration");
         }
 
         var enrich = function (err, rows) {

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -657,7 +657,8 @@ TrainingSets.types.roi_set = {
                         timeMin: rows[i].x1,
                         timeMax: rows[i].x2,
                         freqMin: rows[i].y1,
-                        freqMax: rows[i].y2
+                        freqMax: rows[i].y2,
+                        sampleRate: rows[i].sample_rate
                     });
                     // 2026-08-04 consolidation: the legacy training-sets page
                     // binds roi.uri directly, and the STORED image can be a

--- a/app/routes/data-api/project/pattern_matchings.js
+++ b/app/routes/data-api/project/pattern_matchings.js
@@ -145,9 +145,13 @@ router.get('/:patternMatching/:fileName?', function(req, res, next) {
             const datastream = results[0];
             const fields = results[1].map(function(f) { return f.name });
             ['year', 'month', 'day', 'hour', 'minute', 'url', 'frequency'].forEach(item=> { fields.push(item) });
-            ['datetime', 'meta', 'recording_id', 'sample_rate'].forEach(item=> {
+            // NOTE: external_id / datetime_utc / duration are the SPA on-demand
+            // spectrogram + expand-modal enrichment columns (unconditional in
+            // buildRoisQuery); they are internal plumbing and must NOT leak
+            // into the user-facing CSV export (prod-baseline header parity).
+            ['datetime', 'meta', 'recording_id', 'sample_rate', 'external_id', 'datetime_utc', 'duration'].forEach(item=> {
                 let index = fields.findIndex(i => i === item);
-                fields.splice(index, 1);
+                if (index !== -1) fields.splice(index, 1);
             });
             const colOrder= { id: -17, recording: -16, site: -15, year: -14, month: -13, day: -12, hour: -11, minute: -10,
                 species: -9, songtype: -8, x1: -7, x2: -6, y1: -5, y2: -4, frequency: -3, validated: -2,url: -1

--- a/app/routes/data-api/project/templates.js
+++ b/app/routes/data-api/project/templates.js
@@ -84,6 +84,65 @@ router.get('/:template/image', function(req, res, next) {
     }).catch(next);
 });
 
+/** Renders a template's ROI spectrogram DYNAMICALLY via the media-api.
+ *
+ * WHY (2026-08-03): template images used to be rendered once at creation time
+ * and uploaded to S3 (templates.uri). That baked any render-time defect into
+ * storage forever -- and a tmpfilecache key collision (see
+ * Recordings.buildAssetCacheKey) meant ~21-35% of templates created after
+ * 2026-06-09 stored the full-recording COLOUR spectrogram instead of the
+ * monochrome ROI crop.
+ *
+ * Rendering on demand from the recording + the ROI box (x1/x2/y1/y2) makes the
+ * image a pure function of data we still hold, so a defect is fixed by a code
+ * change alone (no S3 backfill), and the ROI box staying in sync with the
+ * picture is guaranteed. media-api asset names are content-addressed, so the
+ * response is immutable and cacheable for a year.
+ *
+ * Legacy recordings (uri starts with 'project_') have no media-api stream and
+ * keep using the stored image.
+ */
+router.get('/:template/spectrogram', function(req, res, next) {
+    model.templates.find({
+        id: req.params.template,
+        showRecordingUri: true,
+        showSiteData: true
+    }).get(0).then(function(template) {
+        if (!template) return res.sendStatus(404);
+
+        // Legacy (pre-media-api) recordings have no media-api stream: fall back
+        // to the stored S3 image. NOTE: use `storedUri` -- `uri` is now THIS
+        // route (see model/templates.js find()), so redirecting to it would loop.
+        if (!template.recUri || String(template.recUri).startsWith('project_')) {
+            if (!template.storedUri) return res.sendStatus(404);
+            return res.redirect(302, template.storedUri);
+        }
+
+        const recording = {
+            uri: template.recUri,
+            external_id: template.external_id,
+            datetime: template.datetime,
+            datetime_utc: template.datetime_utc
+        };
+        const maxFreq = Math.max(template.y1, template.y2);
+        const minFreq = Math.min(template.y1, template.y2);
+        const options = {
+            maxFreq: (template.sample_rate && maxFreq > template.sample_rate / 2)
+                ? template.sample_rate / 2
+                : maxFreq,
+            minFreq: minFreq,
+            trim: {
+                from: Math.min(template.x1, template.x2),
+                to: Math.max(template.x1, template.x2)
+            }
+        };
+        const attr = model.recordings.buildMediaApiAttr(recording, 'template', options);
+        // Serve through the existing content-addressed asset proxy, which
+        // already rewrites images to inline + immutable caching.
+        return res.redirect(302, `/legacy-api/ingest/recordings/${attr}`);
+    }).catch(next);
+});
+
 router.get('/audio/:templateUrl', function(req, res, next) {
     const roiUrl = req.params.templateUrl;
     const ext = path.extname(roiUrl)

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -68,7 +68,67 @@ function arbimon2PublicUrl (key) {
     return `${arbimon2PublicUrlBase()}/${k}`;
 }
 
+/**
+ * Build an on-demand ROI spectrogram URL for the modern SPA.
+ *
+ * Instead of pointing at a pre-generated detection PNG in the arbimon2 bucket
+ * (there are ~1B of these; backfilling them off AWS is prohibitive), this
+ * returns a URL on the NON-SESSION media proxy
+ * (`/legacy-api/ingest/recordings/:attr`, see app/routes/non-session.js +
+ * app/routes/data-api/ingest.js) which renders the spectrogram live via the
+ * core media API. The URL is auth-free (loadable as a bare <img>), content
+ * addressed, and served inline + immutable-cached.
+ *
+ * The window is framed by the recording's TRUE UTC start (`datetimeUtc`) plus
+ * the ROI's time bounds; the image is cropped to the ROI frequency band. NOTE:
+ * callers MUST pass the recording's `datetime_utc` (not the denormalised,
+ * TZ-shifted `datetime`) or the media window will be hours off.
+ *
+ * Returns null when the inputs to generate it aren't available (e.g. a legacy
+ * recording that has no stream external_id) — callers then render a placeholder
+ * and MUST NOT fall back to the cached detection PNG.
+ *
+ * @param {object} roi
+ * @param {string} roi.externalId  stream external id
+ * @param {string|Date} roi.datetimeUtc  recording start (UTC)
+ * @param {number} roi.timeMin  ROI start, seconds into the recording
+ * @param {number} roi.timeMax  ROI end, seconds into the recording
+ * @param {number} roi.freqMin  ROI low frequency, Hz
+ * @param {number} roi.freqMax  ROI high frequency, Hz
+ * @param {object} [opts]
+ * @param {number} [opts.width=600]
+ * @param {number} [opts.height=256]
+ */
+function roiSpectrogramUrl (roi, opts) {
+    if (!roi || !roi.externalId) return null;
+    const base = roi.datetimeUtc;
+    if (!base) return null;
+    const baseMs = new Date(base).getTime();
+    if (isNaN(baseMs)) return null;
+    const from = Math.min(Number(roi.timeMin), Number(roi.timeMax));
+    const to = Math.max(Number(roi.timeMin), Number(roi.timeMax));
+    if (isNaN(from) || isNaN(to)) return null;
+    const fmtTs = function (ms) {
+        const d = new Date(ms);
+        const p = function (n, w) { return String(n).padStart(w || 2, '0'); };
+        return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}T` +
+            `${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}${p(d.getUTCMilliseconds(), 3)}`;
+    };
+    const start = fmtTs(baseMs + from * 1000);
+    const end = fmtTs(baseMs + to * 1000);
+    const fmin = Math.max(0, Math.min(Number(roi.freqMin), Number(roi.freqMax)));
+    const fmax = Math.max(Number(roi.freqMin), Number(roi.freqMax));
+    if (isNaN(fmin) || isNaN(fmax)) return null;
+    const w = (opts && opts.width) || 600;
+    const h = (opts && opts.height) || 256;
+    // r{fmin}.{fmax} freq band; mtrue = magma color map; d{W}.{H} px; wdolph
+    // window; z120 z-scale. Same grammar the visualizer + templates use.
+    const asset = `r${fmin.toFixed(0)}.${fmax.toFixed(0)}_g1_fspec_mtrue_d${w}.${h}_wdolph_z120.png`;
+    return `/legacy-api/ingest/recordings/${roi.externalId}_t${start}Z.${end}Z_${asset}`;
+}
+
 module.exports = {
     arbimon2PublicUrl,
-    arbimon2PublicUrlBase
+    arbimon2PublicUrlBase,
+    roiSpectrogramUrl
 };

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -95,6 +95,7 @@ function arbimon2PublicUrl (key) {
  * @param {number} roi.timeMax  ROI end, seconds into the recording
  * @param {number} roi.freqMin  ROI low frequency, Hz
  * @param {number} roi.freqMax  ROI high frequency, Hz
+ * @param {number} [roi.sampleRate]  recording sample rate, Hz (clamps freqMax to nyquist)
  * @param {object} [opts]
  * @param {number} [opts.width=600]
  * @param {number} [opts.height=256]
@@ -117,8 +118,14 @@ function roiSpectrogramUrl (roi, opts) {
     const start = fmtTs(baseMs + from * 1000);
     const end = fmtTs(baseMs + to * 1000);
     const fmin = Math.max(0, Math.min(Number(roi.freqMin), Number(roi.freqMax)));
-    const fmax = Math.max(Number(roi.freqMin), Number(roi.freqMax));
+    let fmax = Math.max(Number(roi.freqMin), Number(roi.freqMax));
     if (isNaN(fmin) || isNaN(fmax)) return null;
+    // Clamp to nyquist when the caller knows the sample rate (all three ROI
+    // payloads project it). ROI boxes can carry y2 above the recording's
+    // nyquist; the audio path (getRoiAudioFile) has always clamped for this
+    // reason, and an out-of-band bandpass can fail the media-api render.
+    const nyquist = roi.sampleRate ? Number(roi.sampleRate) / 2 : null;
+    if (nyquist && !isNaN(nyquist) && fmax > nyquist) fmax = nyquist;
     const w = (opts && opts.width) || 600;
     const h = (opts && opts.height) || 256;
     // r{fmin}.{fmax} freq band; mtrue = MONOCHROME (sox -lm greyscale, verified

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -121,7 +121,8 @@ function roiSpectrogramUrl (roi, opts) {
     if (isNaN(fmin) || isNaN(fmax)) return null;
     const w = (opts && opts.width) || 600;
     const h = (opts && opts.height) || 256;
-    // r{fmin}.{fmax} freq band; mtrue = magma color map; d{W}.{H} px; wdolph
+    // r{fmin}.{fmax} freq band; mtrue = MONOCHROME (sox -lm greyscale, verified
+    // against media-api segment-file-utils renderSpectrogram); d{W}.{H} px; wdolph
     // window; z120 z-scale. Same grammar the visualizer + templates use.
     const asset = `r${fmin.toFixed(0)}.${fmax.toFixed(0)}_g1_fspec_mtrue_d${w}.${h}_wdolph_z120.png`;
     return `/legacy-api/ingest/recordings/${roi.externalId}_t${start}Z.${end}Z_${asset}`;

--- a/app/utils/spectro-cache-key.selftest.js
+++ b/app/utils/spectro-cache-key.selftest.js
@@ -1,0 +1,148 @@
+/* jshint node:true */
+"use strict";
+/**
+ * Self-test for the per-variant asset cache keys + media-api attr builder.
+ *
+ * Regression guard for the 2026-06 defect: fetchSpectrogramFile,
+ * fetchTemplateFile and fetchAudioFile shared ONE tmpfilecache key derived from
+ * the recording URI alone, so a full-recording COLOUR spectrogram could be
+ * served (and stored) as a monochrome template ROI crop, and distinct ROIs /
+ * audio variants of one recording collided with each other.
+ *
+ * Run:  node app/utils/spectro-cache-key.selftest.js
+ */
+const assert = require('assert');
+const crypto = require('crypto');
+const moment = require('moment-timezone');
+
+// --- replicas of the production logic under test (kept in lockstep with
+// --- app/model/recordings.js buildMediaApiAttr / buildAssetCacheKey) --------
+const audioFilePattern = /\.(wav|flac|opus)$/i;
+const freqFilterPrecision = 1;
+
+function buildMediaApiAttr (recording, type, options) {
+    let asset, fmin, fmax, trimFrom, trimDuration;
+    const isFrequency = options && (options.minFreq || options.maxFreq);
+    const isGain = options && options.gain;
+    const isTrim = options && options.trim;
+    const isFormat = options && options.format;
+    if (isFrequency) {
+        fmin = Math.min((options.minFreq / freqFilterPrecision) * freqFilterPrecision, 22049).toFixed();
+        fmax = Math.min((options.maxFreq / freqFilterPrecision) * freqFilterPrecision, 22049).toFixed();
+    }
+    if (isTrim) {
+        trimFrom = +options.trim.from;
+        const to = +options.trim.to;
+        trimDuration = options.trim.duration ? (+options.trim.duration) : (to - trimFrom);
+    }
+    switch (type) {
+        case 'spectro': asset = `rfull_g1_fspec_d10286.255_wdolph_z120.png`; break;
+        case 'audio': asset = `r${isFrequency ? fmin + '.' + fmax : 'full'}_g${isGain ? options.gain : 1}_${isFormat ? 'fwav.wav' : 'fmp3.mp3'}`; break;
+        case 'template': asset = `r${fmin}.${fmax}_g1_fspec_mtrue_d400.400_wdolph_z120.png`; break;
+    }
+    const recordingDatetime = recording.datetime_utc ? recording.datetime_utc : recording.datetime;
+    let momentStart = moment.utc(recordingDatetime);
+    let momentEnd = momentStart.clone().add(recording.duration, 'seconds');
+    if (isTrim) {
+        momentStart = momentStart.add(trimFrom, 'seconds');
+        momentEnd = momentStart.clone().add(trimDuration, 'seconds');
+    }
+    const dateFormat = 'YYYYMMDDTHHmmssSSS';
+    return `${recording.external_id}_t${momentStart.format(dateFormat)}Z.${momentEnd.format(dateFormat)}Z_${asset}`;
+}
+
+function buildAssetCacheKey (recording, variant, ext) {
+    const base = String(recording.uri || '').replace(audioFilePattern, '').replace(/[^A-Za-z0-9_-]/g, '_');
+    const v = crypto.createHash('sha256').update(String(variant)).digest('hex').slice(0, 16);
+    return `${base}_${v}${ext}`;
+}
+
+// tmpfilecache's hashing (app/utils/tmpfilecache.js) -- keys must survive it
+function hash_key (key) {
+    const match = /^(.*?)((\.[^.\/]*)*)?$/.exec(key);
+    return crypto.createHash('sha256').update(match[1]).digest('hex') + (match[2] || '');
+}
+
+// ---------------------------------------------------------------- fixtures
+const rec = {
+    uri: 'streams/aBc123XyZ/2026/07/13/aBc123XyZ_t20260713T000000000Z.wav',
+    external_id: 'aBc123XyZ',
+    datetime: '2026-07-13 00:00:00',
+    datetime_utc: '2026-07-13 00:00:00',
+    duration: 60
+};
+const roiA = { minFreq: 198, maxFreq: 15524, trim: { from: 0.098, to: 1.702 } };
+const roiB = { minFreq: 206, maxFreq: 12364, trim: { from: 0.291, to: 0.895 } };
+
+let passed = 0;
+function ok (name, fn) { fn(); passed++; console.log('  ok -', name); }
+
+console.log('spectro-cache-key selftest');
+
+ok('THE BUG: spectro vs template must NOT share a cache key', () => {
+    const kSpec = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'spectro', {}), '.png');
+    const kTpl = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    assert.notStrictEqual(kSpec, kTpl);
+    assert.notStrictEqual(hash_key(kSpec), hash_key(kTpl));
+});
+
+ok('two DIFFERENT ROIs of one recording get different keys', () => {
+    const a = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    const b = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiB), '.png');
+    assert.notStrictEqual(a, b);
+});
+
+ok('audio: gain / frequency / format / trim each change the key', () => {
+    const base = { trim: { from: 0, to: 10 } };
+    const keys = new Set([
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', base), '.mp3'),
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', { ...base, gain: 2 }), '.mp3'),
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', { ...base, minFreq: 500, maxFreq: 8000 }), '.mp3'),
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', { ...base, format: '.wav' }), '.wav'),
+        buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'audio', { trim: { from: 5, to: 10 } }), '.mp3')
+    ]);
+    assert.strictEqual(keys.size, 5);
+});
+
+ok('template attr carries the monochrome flag + 400x400 dims', () => {
+    const attr = buildMediaApiAttr(rec, 'template', roiA);
+    assert.ok(attr.includes('_mtrue_'), 'monochrome flag missing: ' + attr);
+    assert.ok(attr.includes('d400.400'), 'dims wrong: ' + attr);
+    assert.ok(attr.endsWith('.png'));
+});
+
+ok('spectro attr is the FULL-recording colour variant (no mtrue)', () => {
+    const attr = buildMediaApiAttr(rec, 'spectro', {});
+    assert.ok(!attr.includes('mtrue'), 'spectro must not be monochrome: ' + attr);
+    assert.ok(attr.includes('d10286.255'));
+});
+
+ok('keys are filesystem-safe: one dot, no slashes, bounded length', () => {
+    const k = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    assert.strictEqual((k.match(/\./g) || []).length, 1, 'must have exactly one dot: ' + k);
+    assert.ok(!k.includes('/'), 'no slashes: ' + k);
+    const fname = hash_key(k);
+    assert.strictEqual(fname.length, 64 + '.png'.length, 'filename length: ' + fname);
+});
+
+ok('keys are deterministic (same inputs -> same key)', () => {
+    const a = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    const b = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', { ...roiA }), '.png');
+    assert.strictEqual(a, b);
+});
+
+ok('trim window shifts the attr time range (ROI is time-addressed)', () => {
+    const a = buildMediaApiAttr(rec, 'template', roiA);
+    const b = buildMediaApiAttr(rec, 'template', roiB);
+    assert.notStrictEqual(a, b);
+    assert.ok(/_t\d{8}T\d{9}Z\.\d{8}T\d{9}Z_/.test(a), 'time window malformed: ' + a);
+});
+
+ok('REGRESSION: the OLD key scheme collided (proves the test is meaningful)', () => {
+    const oldSpec = rec.uri.replace(audioFilePattern, '.png');
+    const oldTpl = rec.uri.replace(audioFilePattern, '.png');
+    assert.strictEqual(oldSpec, oldTpl, 'old scheme should collide');
+    assert.strictEqual(hash_key(oldSpec), hash_key(oldTpl));
+});
+
+console.log(`\n${passed}/${passed} passed`);


### PR DESCRIPTION
**Supersedes #1791** (will close it in favor of this). Consolidates two independent efforts per the converged re-review (rfcx-local `runbooks/DESIGN-dynamic-spectrograms-consolidation-2026-08-04.md`):

**From `feat/pm-roi-spectro-ondemand` (2026-07-20 Phase-4 session, demo-proven, was local-only — now pushed):** commits 1–4. Server-side payload enrichment `spectrogram_url` on PM / clustering / training-set ROI payloads via the shared `roiSpectrogramUrl` helper (d600.256, datetime_utc-framed, auth-free `/legacy-api/ingest` proxy), sample_rate+duration projection, CSV-export leak guard.

**From #1791 (the colour-templates root-cause fix):** commit 5. Per-variant tmpfilecache keys (`buildMediaApiAttr` + `buildAssetCacheKey`) — fixes the actual 2026-06-09 defect where the colour full-recording spectrogram was cached+uploaded as template/training-set ROI images (0% damage through May → 35%/27.5%/12.5% Jun/Jul/Aug); dynamic template serving (`GET .../templates/:id/spectrogram`, uri swap w/ storedUri fallback).

**New in consolidation:** commits 6–7. Legacy training-sets page gets the dynamic uri too (it binds `roi.uri` directly and 16/60 recent stored images are damaged); mtrue comment corrected (sox `-lm` greyscale, not magma); `roiSpectrogramUrl` clamps freqMax to nyquist (all 3 call sites pass sample_rate — matches the audio path's longstanding clamp; out-of-band bandpass can fail the render).

**Verified on the demo tier (`arbimon:demo-spectro-consolidated-10444536`, live now):**
- template 78587 (the reported damaged one): payload uri = dynamic route, storedUri = S3; edge render **200, 400×400, colortype-0 GRAYSCALE**, `inline + immutable`
- PM ROI payloads carry `spectrogram_url` (job 124518 verified)
- training-set ROIs: uri = dynamic ingest URL, storedUri = S3; edge render **200, 600×256 GRAYSCALE**
- selftest 9/9 (incl. the old-scheme-collides regression case)

Serving path is double-cached: browser/CDN immutable + media-api streams-cache (hot-plane writeback, 0-byte-guard covered).

⚠️ **Release gate:** arbimon-legacy release restarts the mysql2pg O5 soak clock — merge with operator coordination (Phase-4 train or explicit go).