### PR TITLE
shadow: canonicalize datetimes at whole-second precision (the b0cc625e class)

### DIFF
--- a/app/utils/dbpool-pg.js
+++ b/app/utils/dbpool-pg.js
@@ -1315,7 +1315,26 @@ function canonValue(v, epsilon) {
         if (Buffer.compare(Buffer.from(asStr, 'utf8'), v) === 0) { return 'str:' + asStr; }
         return 'bytes:' + v.toString('hex');
     }
-    if (v instanceof Date) { return 'dt:' + v.toISOString(); }
+    if (v instanceof Date) {
+        // WHOLE-SECOND canonicalization (2026-08-04, the b0cc625e class).
+        // Temporal parity is defined at whole-second precision CLUSTER-WIDE:
+        // every datetime column in the arbimon2 reference schema is fsp 0
+        // (information_schema datetime_precision > 0 count = 0, verified
+        // live 2026-08-04), the forward-sync fingerprint already truncates
+        // (delta_sync.py::_fp_norm s[:19]), and the reverse-sync write path
+        // measurably FLOORS PG micros into MariaDB DATETIME (all 556
+        // post-flip rows with micros >= .5s: Maria == PG floor, never
+        // floor+1). Post-flip PG-owned writes carry real sub-second
+        // precision (jobs.last_update 501/564, soundscapes.date_created
+        // 33/80) that is UNREPRESENTABLE on the MariaDB side by schema —
+        // comparing it manufactures permanent divergence on identical
+        // stored facts (same class as the g6HalfEven float4 fold above).
+        // slice(0,19) truncates the ISO string at seconds ('YYYY-MM-DDTHH:
+        // MM:SS'), matching _fp_norm's convention exactly. A real drift of
+        // >= 1s still differs. NOTE: V8 Date already truncated pg micros
+        // to ms at parse time (OID-1114 parser), so this folds ms -> s.
+        return 'dt:' + v.toISOString().slice(0, 19) + 'Z';
+    }
     if (typeof v === 'object') {
         // arrays (pg text[]), json — canonicalize deterministically
         try { return 'json:' + JSON.stringify(v); } catch (e) { return 'str:' + String(v); }

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -650,5 +650,31 @@ eq('conn: the table is exactly the 7 Class-57/08 codes',
    Object.keys(m.CONN_LIFETIME_SQLSTATES).sort().join(','),
    '08000,08003,08006,08P01,57P01,57P02,57P03');
 
+console.log('== datetime whole-second canonicalization (P6 2026-08-04) ==');
+// Post-flip PG-owned writes carry micros (jobs.last_update 501/564,
+// soundscapes.date_created 33/80 measured live 2026-08-04); the arbimon2
+// reference schema is fsp 0 EVERYWHERE (datetime_precision > 0 count = 0)
+// and both sync legs truncate (_fp_norm s[:19]; reverse write-path floors —
+// all 556 post-flip rows with micros >= .5s: Maria == PG floor). Temporal
+// parity is therefore defined at whole-second precision; comparing finer
+// manufactures permanent divergence on identical stored facts (the
+// b0cc625e models.details class, model 6352 jobs.last_update .181324).
+function dtPair(a, b) { return m.compare('SELECT a FROM t ORDER BY a',
+    [{ a: a }], [{ a: b }], 1e-9); }
+eq('dt: pg-micros vs maria whole-second equal (the live 6352 pair)',
+   dtPair(new Date('2026-08-03T01:59:01.000Z'), new Date('2026-08-03T01:59:01.181Z')), null);
+eq('dt: identical whole-second dates equal',
+   dtPair(new Date('2026-08-04T15:26:33Z'), new Date('2026-08-04T15:26:33Z')), null);
+eq('dt: >=1s drift still fires (the 168389 skip-no-op class stays visible)',
+   dtPair(new Date('2026-07-31T05:30:08Z'), new Date('2026-07-31T05:38:10.922Z')) !== null, true);
+eq('dt: exactly-1s drift still fires (boundary)',
+   dtPair(new Date('2026-08-04T15:26:33Z'), new Date('2026-08-04T15:26:34Z')) !== null, true);
+eq('dt: sub-second at the SECOND boundary does not round up (floor semantics)',
+   dtPair(new Date('2026-08-04T15:26:33.999Z'), new Date('2026-08-04T15:26:33.000Z')), null);
+eq('dt: date-only columns unaffected (midnight both sides)',
+   dtPair(new Date('2014-10-02T00:00:00Z'), new Date('2014-10-02T00:00:00Z')), null);
+eq('dt: non-Date values untouched by the fold (string passthrough)',
+   dtPair('2026-08-03 01:59:01', '2026-08-03 01:59:01'), null);
+
 console.log('\n' + (fails ? ('FAILED ' + fails + '/' + n) : ('ALL ' + n + ' PASS')));
 process.exit(fails ? 1 : 0);


### PR DESCRIPTION
## What

`canonValue` Date branch: `toISOString()` → `toISOString().slice(0,19)+'Z'` (whole-second truncation). +7 selftest cases (218→225).

## Why

Day-1 census on the 5697ffd clock booked `b0cc625e` (models.details): all columns byte-identical both engines EXCEPT `jobs.last_update` — PG carries post-flip worker micros (`01:59:01.181324`), MariaDB stores `01:59:01`. The sub-second part is unrepresentable in arbimon2 BY SCHEMA (fsp 0 on every datetime column, measured: `datetime_precision > 0` count = 0).

Whole-second parity is already cluster convention: `delta_sync._fp_norm` `s[:19]`, and the reverse-sync write path provably FLOORS (all 556 post-flip rows with micros ≥ .5s: Maria == PG floor, never floor+1). Same design as the #1784 g6HalfEven float4 fold: canonicalize at the reference engine's representable precision.

Class width (live sweep): jobs.last_update 501/564, soundscapes.date_created 33/80; recordings/PMR/date_created columns 0 (whole-second write paths).

## Verified

- selftest ALL 225 PASS
- **Live-executed pre-merge on the main pod** (5th occurrence of the rule): actual models.details(6352) template via mysql + pgbouncer — OLD comparator books result_mismatch, NEW returns null, perturbed threshold STILL books, 8-min drift STILL books (the 168389 skip-no-op residual stays visible). ALL 4 CLAIMS PROVEN.

## Notes

- Restarts the O5 clock (12th T0) — day-1 economics, operator GO 2026-08-04 14:31 EDT after a 6-pass converged re-review.
- Known residual documented, not hidden: job 168389 8-min whole-second drift (reverse-sync skip-no-op leg, by design; ≥1s so it books honestly).
- rfcx-local follow-up PR: replay.py same convention + census REMINDER + docs.