### PR TITLE
p6: close the read-your-own-write class + two pod-kill primitives before the 6.4 flip

### DIFF
--- a/app/model/jobs.js
+++ b/app/model/jobs.js
@@ -388,8 +388,14 @@ var Jobs = {
     },
 
     getJobParams: async function(jobTypeId, jobId) {
+        // Converted off `new Promise(async ...)` for the same reason as
+        // getJobUrl above: a throw inside an async Promise executor becomes an
+        // unhandled rejection, which is fatal under node 16 (pod restart).
+        // This body contains no awaits today, so the conversion is a pure
+        // hardening of the shape -- it removes the pod-kill primitive before
+        // someone adds an await here later.
         let sql;
-        return new Promise(async function (resolve, reject) {
+        return await (async function () {
             switch (jobTypeId) {
                 case 1:
                     sql = `select ts.name as "Training Set"
@@ -439,8 +445,8 @@ var Jobs = {
                         where jpr.job_id = ${jobId};`
                     break;
             }
-            return resolve(sql)
-        })
+            return sql
+        })()
     },
 
     getChunks: function(arr, perChunk) {
@@ -456,7 +462,30 @@ var Jobs = {
     },
 
     getJobUrl: async function(job) {
-        return new Promise(async function (resolve, reject) {
+        // CRASH CONTAINMENT (2026-08-08). This was `new Promise(async ...)`.
+        // A throw inside an ASYNC Promise executor rejects nothing the caller
+        // can catch: the executor's own promise is already returned, so the
+        // rejection escapes as an UNHANDLED REJECTION. Under node 16 that is
+        // fatal -- the process EXITS and the whole arbimon pod restarts,
+        // taking every in-flight request with it.
+        //
+        // PROVEN, not assumed: a probe of this exact shape was executed inside
+        // the live production container (node v16.20.2). The caller's
+        // try/catch did NOT fire and the process died with exit code 1.
+        //
+        // The trigger is the `case 6` re-read below. getPmId() is a plain
+        // SELECT the deployed adapter classifies {replayable:true}, so at
+        // DB_ENGINE=pg it is served from PostgreSQL while the pattern_matchings
+        // row is still only in MariaDB until the next */2 delta tick --
+        // `pmData` is then undefined and `pmData.deleted` throws. Note the
+        // sibling lines for CNN/models already guard with `&&`; only this one
+        // dereferences unguarded.
+        //
+        // Made a plain async function: rejections now propagate normally to
+        // the caller (Promise.all in activeJobs), which is inside a .then
+        // chain with a .catch. Same behaviour on success, no pod kill on error.
+        const self = this;
+        return await (async function () {
             switch (job.job_type_id) {
                 case 1:
                     const modelData = await models.models.getModelId(job.job_id)
@@ -470,7 +499,10 @@ var Jobs = {
                     break;
                 case 6:
                     const pmData = await models.patternMatchings.getPmId(job.job_id)
-                    job.url = `patternmatching/${pmData.deleted ? '' : (pmData && pmData.pattern_matching_id ? pmData.pattern_matching_id : '')}`
+                    // Guarded to match the CNN/models siblings below. A missing
+                    // row now yields the same empty-url shape they produce,
+                    // instead of throwing (and killing the pod -- see above).
+                    job.url = `patternmatching/${(pmData && !pmData.deleted && pmData.pattern_matching_id) ? pmData.pattern_matching_id : ''}`
                     break;
                 case 7:
                     const cnnData = await models.CNN.getCnnId(job.job_id)
@@ -486,8 +518,8 @@ var Jobs = {
                     job.url = 'random-forest-models/models'
                     break;
             }
-            return resolve(job)
-        })
+            return job
+        })()
     },
 
 

--- a/app/model/sites.js
+++ b/app/model/sites.js
@@ -69,6 +69,32 @@ var Sites = {
         return find(site_id)
     },
 
+    /** Read back a just-INSERTed site row, safely across the Phase-6.4 read flip.
+     *
+     * See the long note at the call site (routes/data-api/integration.js POST
+     * /sites) for why this is a retry-and-throw rather than the local
+     * reconstruction used in training_sets.add_data (#1795): the sites table
+     * has six defaulted columns the INSERT does not supply, and country_code /
+     * timezone are written by a SEPARATE statement, so a reconstructed row
+     * would be silently incomplete.
+     *
+     * Returns the row object (not the array). Throws if the row is not
+     * readable -- the previous code let `site[0]` be undefined and answered
+     * HTTP 201 with a null body.
+     */
+    findByIdAfterCreate: async function (site_id) {
+        // ~2s of retries: covers MaxScale replica lag, and a PG delta tick that
+        // has just landed. Deliberately does NOT wait out a full 2-min delta
+        // cycle -- an HTTP request must not hang that long.
+        const delaysMs = [0, 50, 150, 300, 500, 1000];
+        for (const wait of delaysMs) {
+            if (wait) { await new Promise(r => setTimeout(r, wait)); }
+            const rows = await Sites.findByIdAsync(site_id);
+            if (rows && rows[0]) { return rows[0]; }
+        }
+        throw new APIError('created site ' + site_id + ' was not readable after insert');
+    },
+
     getSiteExternalId: function(site_id, callback) {
         return dbpool.query(`SELECT external_id FROM sites WHERE site_id=${site_id}`).get(0).get('external_id').nodeify(callback);
     },

--- a/app/model/soundscapes.js
+++ b/app/model/soundscapes.js
@@ -269,12 +269,36 @@ let Soundscapes = {
                 );
             },
             function(results, fields, next){
-                self.getRegions(soundscape, {region:results.insertId}, next);
-            },
-            function(rows, fields){
-                let next = arguments[arguments.length-1];
-                data = rows[0];
-                next(null, data);
+                // READ-AFTER-WRITE REMOVED (2026-08-08) -- same class as
+                // training_sets.add_data (#1795). getRegions' SELECT is
+                // classified {replayable:true}, so at DB_ENGINE=pg it is served
+                // from PostgreSQL while this INSERT still goes to MariaDB
+                // (legacy owns writes until Phase 7). The row reaches PG only
+                // on the next forward delta-sync tick (*/2 min), so the re-read
+                // finds NOTHING every time and `data = rows[0]` (below, which
+                // had NO emptiness guard) became undefined.
+                //
+                // Reconstructed locally. EXACT, verified against the live
+                // schema: soundscape_regions has NO triggers, and its only
+                // defaulted columns are the auto-increment pk plus
+                // sample_playlist_id/threshold/threshold_type -- all of which
+                // are either supplied by the INSERT above or genuinely NULL at
+                // this instant. Field names mirror getRegions' projection
+                // exactly (id/soundscape/name/x1/y1/x2/y2/count/threshold/
+                // threshold_type/playlist).
+                if (!results || results.insertId === undefined || results.insertId === null) {
+                    return next(new Error('addRegion: INSERT returned no insertId'));
+                }
+                next(null, {
+                    id             : results.insertId,
+                    soundscape     : soundscape.id,
+                    name           : data.name,
+                    x1 : x1, y1 : y1, x2 : x2, y2 : y2,
+                    count          : count,
+                    threshold      : region.threshold ? soundscape.threshold : null,
+                    threshold_type : region.threshold ? soundscape.threshold_type : null,
+                    playlist       : null
+                });
             }
         ], callback);
     },
@@ -495,11 +519,31 @@ let Soundscapes = {
             },
             function get_tag(result){
                 let next = arguments[arguments.length-1];
-                Soundscapes.getRegionTags(region, {id:result.insertId}, next);
-            },
-            function (tags){
-                let next = arguments[arguments.length-1];
-                next(null, tags.shift());
+                // READ-AFTER-WRITE REMOVED (2026-08-08) -- same class as the
+                // addRegion fix above. getRegionTags' SELECT is PG-routed at
+                // 6.4 while the INSERT stays on MariaDB, so the re-read finds
+                // nothing and `tags.shift()` yielded undefined to the route.
+                //
+                // Reconstructed locally. soundscape_region_tags has NO triggers
+                // and only the auto-increment pk is defaulted. Field names
+                // mirror getRegionTags' projection (id/region/recording/tag/
+                // type/count, plus user+timestamp which that query includes
+                // when selecting by id). `count` is 1: this row is the single
+                // newly-created tag, which is what the COUNT(*) over this
+                // grouped-by-id projection returns for it.
+                if (!result || result.insertId === undefined || result.insertId === null) {
+                    return next(new Error('addRegionTag: INSERT returned no insertId'));
+                }
+                next(null, {
+                    id        : result.insertId,
+                    region    : region.id,
+                    recording : recording,
+                    tag       : data.tag,
+                    type      : data.type,
+                    user      : user,
+                    timestamp : new Date(),
+                    count     : 1
+                });
             }
         ], callback);
     },

--- a/app/model/tags.js
+++ b/app/model/tags.js
@@ -183,6 +183,11 @@ tags.resourceDefs.recording = {
             return q.reject(new APIError('No user specified'));
         }
 
+        // Captured so the created-row echo below never has to be read back.
+        var tagId = null;
+        var tagText = tag.text;
+        var insertedAt = null;
+
         var tagIdPromise = tag.id ? q(tag.id) : q.ninvoke(dbpool, 'queryHandler',
             "INSERT IGNORE INTO tags(tag) VALUES (?)", [tag.text]
         ).then(function(result){
@@ -193,7 +198,18 @@ tags.resourceDefs.recording = {
             ).get(0).get(0);
         });
 
-        return tagIdPromise.then(async function(tagId){
+        return tagIdPromise.then(async function(_tagId){
+            tagId = _tagId;
+            // When the caller passed tag.id we never learned the tag TEXT.
+            // Resolve it BEFORE the INSERT: the tags row is pre-existing, so
+            // this is not a read-after-write and is safe on either engine.
+            if (tagText === undefined || tagText === null) {
+                var trows = await q.ninvoke(dbpool, 'queryHandler',
+                    "SELECT tag FROM tags WHERE tag_id = ?", [tagId]
+                ).get(0);
+                tagText = (trows && trows[0]) ? trows[0].tag : null;
+            }
+            insertedAt = new Date();
             return q.ninvoke(dbpool, 'queryHandler',
                 "INSERT INTO recording_tags(recording_id, site_id, tag_id, user_id, datetime, t0, f0, t1, f1)\n"+
                 "VALUES (?, ?, ?, ?, NOW(), ?, ?, ?, ?)", [
@@ -203,12 +219,35 @@ tags.resourceDefs.recording = {
                 ]
             ).get(0);
         }).then(function(results){
-            return q.ninvoke(dbpool, 'queryHandler',
-                "SELECT RT.recording_tag_id as id, T.tag_id, T.tag, user_id, datetime, t0, f0, t1, f1\n" +
-                "FROM recording_tags RT\n" +
-                "JOIN tags T ON RT.tag_id = T.tag_id\n" +
-                "WHERE RT.recording_tag_id = ?", [results.insertId]
-            ).get(0);
+            // READ-AFTER-WRITE REMOVED (2026-08-08) -- same class as
+            // training_sets.add_data (#1795). This SELECT is classified
+            // {replayable:true} by the deployed adapter, so at DB_ENGINE=pg it
+            // is served from PostgreSQL while the INSERT above still goes to
+            // MariaDB (legacy owns writes until Phase 7). The row reaches PG
+            // only on the next forward delta-sync tick (*/2 min), so a re-read
+            // microseconds later finds NOTHING every time, and the route would
+            // hand the UI `undefined` as the newly created tag.
+            //
+            // Reconstructed locally instead. Verified against the live schema:
+            // recording_tags has NO triggers and its ONLY defaulted column is
+            // the auto-increment pk; every other projected column is supplied
+            // by the INSERT above.
+            if (!results || results.insertId === undefined || results.insertId === null) {
+                return q.reject(new APIError('Failed to create recording tag'));
+            }
+            return {
+                id       : results.insertId,
+                tag_id   : tagId,
+                tag      : tagText,
+                user_id  : userId,
+                // NOW() was evaluated server-side by MariaDB. `insertedAt` is
+                // captured immediately before the INSERT (sub-second accurate)
+                // and is used only for this immediate UI echo; the durable
+                // value stored in the row remains MariaDB's NOW().
+                datetime : insertedAt,
+                t0 : tag.t0 || null, f0 : tag.f0 || null,
+                t1 : tag.t1 || null, f1 : tag.f1 || null
+            };
         });
     },
     /** Removes a tag from a given recording.

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -498,6 +498,30 @@ TrainingSets.types.roi_set = {
      */
     create_data_image : function (training_set, rdata, callback){
         debug('create_data_image');
+        // CRASH CONTAINMENT (2026-08-08). This promise chain had NO `.catch`,
+        // so ANY rejection inside it became an unhandled rejection. Under
+        // node 16 that is fatal: the process EXITS and the whole arbimon pod
+        // restarts, taking every in-flight request with it. Measured live —
+        // two pod restarts on frontend-1 (2026-08-08 03:57:06Z + 03:58:59Z)
+        // from exactly this chain, via `rdata` being undefined at the s3key
+        // line below (the read-after-write defect fixed in add_data).
+        //
+        // This guard is DEFENCE IN DEPTH, deliberately kept even though the
+        // root cause is fixed: an unguarded async chain behind an HTTP route
+        // is a pod-kill primitive regardless of which bug feeds it. Same
+        // family as the classifications.js double-send crash (#1789) and the
+        // #1631-era unguarded final callbacks.
+        //
+        // `settled` prevents a DOUBLE callback: if callback() itself throws,
+        // the .catch would otherwise invoke it a second time and express
+        // would try to send headers twice.
+        var settled = false;
+        if (!rdata || rdata.id === undefined || rdata.id === null) {
+            // Never build an S3 key out of `undefined` — that is how a
+            // malformed key (`.../training_sets/7153/undefined.png`) would
+            // reach the object store.
+            return callback(new Error('create_data_image: missing training set ROI row (no id)'));
+        }
         var s3key = 'project_'+training_set.project+'/training_sets/'+training_set.id+'/'+rdata.id+'.png';
         rdata.uri = arbimon2PublicUrl(s3key);
         let rec_data, rec_stats, spec_data, isLegacy;
@@ -571,7 +595,17 @@ TrainingSets.types.roi_set = {
                     "WHERE roi_set_data_id = ?";
             return dbpool.query(dbpool.format(q, [s3key, rdata.id]));
         }).then(() => {
+            settled = true;
             callback(null, rdata);
+        }).catch((err) => {
+            if (settled) {
+                // The failure happened AFTER we handed off; callback() must
+                // not run twice. Log and stop.
+                console.error('[training_sets.create_data_image] post-callback error', err);
+                return;
+            }
+            settled = true;
+            callback(err);
         });
     },
 
@@ -756,6 +790,9 @@ TrainingSets.types.roi_set = {
      */
     add_data : function(training_set, data, callback){
         var self = this;
+        // Row shape captured AT INSERT TIME — see the read-after-write note
+        // on the reconstruction step below.
+        var inserted = null;
         async.waterfall([
             function(next){
                 joi.validate(data, self.data_schema, {context:training_set},next);
@@ -763,6 +800,15 @@ TrainingSets.types.roi_set = {
             function(vdata, next){
                 var x1 = Math.min(vdata.roi.x1, vdata.roi.x2), y1 = Math.min(vdata.roi.y1, vdata.roi.y2);
                 var x2 = Math.max(vdata.roi.x1, vdata.roi.x2), y2 = Math.max(vdata.roi.y1, vdata.roi.y2);
+
+                // Capture exactly the values we are about to write, so the
+                // next step never has to read them back.
+                inserted = {
+                    recording : vdata.recording,
+                    species   : vdata.species,
+                    songtype  : vdata.songtype,
+                    x1 : x1, y1 : y1, x2 : x2, y2 : y2
+                };
 
                 dbpool.queryHandler(
                     "INSERT INTO training_set_roi_set_data(training_set_id, recording_id, species_id, songtype_id, x1, y1, x2, y2) \n" +
@@ -774,14 +820,64 @@ TrainingSets.types.roi_set = {
                 );
             },
             function(result, fields, next){
-                self.get_data(training_set, {id:result.insertId}, next);
+                // READ-AFTER-WRITE REMOVED (2026-08-08).
+                //
+                // This step used to be:
+                //     self.get_data(training_set, {id:result.insertId}, next);
+                // i.e. INSERT on the writer, then immediately SELECT the row
+                // straight back. The next step did `data = rows[0]` with no
+                // emptiness guard, so a SELECT that saw zero rows produced
+                // `undefined` and create_data_image crashed on `rdata.id` —
+                // an unhandled rejection, which under node 16 KILLS THE POD.
+                //
+                // Why the re-read can miss its own write — it has two
+                // independent failure modes, and the second is the serious one:
+                //
+                //  (1) TODAY (MariaDB/MaxScale): reads go through the
+                //      Read-Write-Split router with `causal_reads=none` and
+                //      adaptive routing (measured live: the replica carries
+                //      the larger routed-packet share), so the follow-up
+                //      SELECT can land on the replica microseconds before the
+                //      INSERT has replicated. Rare, but it fired twice on
+                //      2026-08-08 (rows 138073/138074).
+                //
+                //  (2) AT THE PHASE-6.4 READ FLIP: this becomes DETERMINISTIC.
+                //      The SELECT is a plain read that the adapter's allowlist
+                //      classifier accepts (verified against the deployed
+                //      classifier: `{replayable:true}`), so at DB_ENGINE=pg it
+                //      is served from PostgreSQL — while the INSERT still goes
+                //      to MariaDB (legacy owns writes until Phase 7). The row
+                //      reaches PG only on the next forward delta-sync tick
+                //      (*/2 min), so a re-read microseconds later finds
+                //      NOTHING, every single time. The shadow census already
+                //      shows this template (`6ede4e30fb91983a`) as
+                //      maria=1 / pg=0.
+                //
+                // FIX: reconstruct the row locally instead of reading it back.
+                // This is EXACT, not an approximation — verified against the
+                // live schema: the table has NO triggers, NO column defaults
+                // and NO generated columns, and every column except the
+                // auto-increment pk and the deferred `uri` is supplied by the
+                // INSERT above. `uri` is genuinely NULL at this instant (it is
+                // set minutes later by create_data_image), and get_data's
+                // CONCAT(base, TSD.uri) returned NULL for it anyway, so NULL
+                // is faithful to the shape the re-read produced.
+                //
+                // PRECEDENT: the identical class in playlist creation was
+                // fixed the same way — arbimon-legacy #1740 (2026-07-07),
+                // whose runbook concludes: "future create flows should avoid
+                // immediate read-after-write verification ... unless the read
+                // is pinned to the writer or causally consistent."
+                if (!result || result.insertId === undefined || result.insertId === null) {
+                    next(new Error('add_data: INSERT returned no insertId'));
+                    return;
+                }
+                inserted.id  = result.insertId;
+                inserted.uri = null;
+                next(null, inserted);
             },
-            function(rows, fields, next){
-                data = rows[0];
-                next(null,data);
-            },
-            function (data, next) {
-                self.create_data_image(training_set, data, next);
+            function (row, next) {
+                self.create_data_image(training_set, row, next);
             }
         ], callback);
     },

--- a/app/model/users.js
+++ b/app/model/users.js
@@ -577,7 +577,7 @@ var Users = {
             rfcx_id: email,
         }
         const insertData = await this.insertAsync(attrs)
-        return this.findById(insertData.insertId).get(0)
+        return await Users.findByIdAfterCreate(insertData, 'createFromAuth0')
     },
 
 
@@ -594,7 +594,53 @@ var Users = {
             rfcx_id: data.email,
         }
         const insertData = await this.insertAsync(attrs)
-        return this.findById(insertData.insertId).get(0)
+        return await Users.findByIdAfterCreate(insertData, 'createByInvitation')
+    },
+
+    /** Read back a just-INSERTed user row, safely across the Phase-6.4 read flip.
+     *
+     * READ-AFTER-WRITE HAZARD (2026-08-08), same class as
+     * training_sets.add_data (#1795) -- but deliberately NOT fixed the same way.
+     *
+     * findById's SELECT is classified {replayable:true} by the deployed
+     * adapter, so at DB_ENGINE=pg it is served from PostgreSQL while the INSERT
+     * above still goes to MariaDB (legacy owns writes until Phase 7). The row
+     * reaches PG only on the next forward delta-sync tick (every 2 min), so a
+     * re-read microseconds later finds NOTHING, every time.
+     *
+     * WHY NOT RECONSTRUCT LOCALLY (the #1795 pattern): the users table has
+     * FIVE columns with schema defaults that the INSERT does not supply --
+     * is_super=0, project_limit=100, login_tries=0, oauth_google=0,
+     * oauth_facebook=0 (verified against the live schema). makeUserObject reads
+     * `user.is_super` and puts it in the SESSION. A local reconstruction would
+     * hand back `isSuper: undefined` instead of 0 -- trading a loud crash for
+     * SILENT WRONG DATA on an auth object, which is strictly worse. This is the
+     * registration/invitation path; it must be exactly right.
+     *
+     * FIX: keep the read, but make it correct and fail LOUDLY.
+     *  - Retry briefly: on PG the row genuinely appears once the delta tick
+     *    lands; on MariaDB/MaxScale replica lag resolves in milliseconds.
+     *  - If it still is not there, THROW. The previous code returned undefined,
+     *    which flowed into makeUserObject and threw a confusing TypeError deep
+     *    in session setup (or, on the auth0 path, inside an async Promise
+     *    executor where it killed the pod).
+     */
+    findByIdAfterCreate: async function (insertData, label) {
+        if (!insertData || insertData.insertId === undefined || insertData.insertId === null) {
+            throw new APIError(label + ': INSERT returned no insertId');
+        }
+        const userId = insertData.insertId;
+        // ~2s of retries: comfortably covers MaxScale replica lag, and covers a
+        // PG delta tick that has just landed. Deliberately does NOT wait out a
+        // full 2-min delta cycle -- an HTTP request must not hang that long,
+        // and failing loudly is the correct outcome.
+        const delaysMs = [0, 50, 150, 300, 500, 1000];
+        for (const wait of delaysMs) {
+            if (wait) { await new Promise(r => setTimeout(r, wait)); }
+            const rows = await Users.findById(userId);
+            if (rows && rows[0]) { return rows[0]; }
+        }
+        throw new APIError(label + ': created user ' + userId + ' was not readable after insert');
     },
 
     makeUserObject: function(user, options){

--- a/app/routes/data-api/integration.js
+++ b/app/routes/data-api/integration.js
@@ -106,9 +106,29 @@ router.post('/sites', verifyToken(), hasRole(['appUser', 'rfcxUser', 'guardianCr
     }
     if (!params.latitude && !params.longitude) siteData.hidden = 1
     const insertData = await model.sites.insertAsync(siteData);
+    if (!insertData || insertData.insertId === undefined || insertData.insertId === null) {
+      throw new Error('createSite: INSERT returned no insertId');
+    }
     await model.sites.setCountryCodeAndTimezone(insertData.insertId, params.country_code, params.timezone);
-    const site = await model.sites.findByIdAsync(insertData.insertId);
-    res.status(201).json(site[0]);
+    // READ-AFTER-WRITE HAZARD (2026-08-08), same class as
+    // training_sets.add_data (#1795) -- and, like users.createFromAuth0,
+    // deliberately NOT fixed by local reconstruction.
+    //
+    // findByIdAsync's SELECT is classified {replayable:true} by the deployed
+    // adapter, so at DB_ENGINE=pg it reads from PostgreSQL while the INSERT
+    // above still goes to MariaDB (legacy owns writes until Phase 7); the row
+    // reaches PG only on the next forward delta-sync tick (every 2 min).
+    // `site[0]` was then undefined and this endpoint answered 201 with a body
+    // of `null` -- a silent success carrying no site.
+    //
+    // Local reconstruction is NOT safe here: sites has SIX defaulted columns
+    // the INSERT does not supply (created_at/updated_at=current_timestamp(),
+    // published=0, timezone_locked=0, hidden=0, plus country_code/timezone
+    // which setCountryCodeAndTimezone writes in a SEPARATE statement above).
+    // Reconstructing would return a site missing its own timezone -- silent
+    // wrong data to an API client, worse than a loud failure.
+    const site = await model.sites.findByIdAfterCreate(insertData.insertId);
+    res.status(201).json(site);
   } catch (e) {
     httpErrorHandler(req, res, 'Failed creating a site')(e);
   }

--- a/app/routes/data-api/models.js
+++ b/app/routes/data-api/models.js
@@ -237,7 +237,18 @@ async function getModelsData(validationUri, limit, offset) {
     const awsConfig = isProd ? config('aws') : config('aws_rfcx');
     const awsBucket = isProd ? awsConfig.bucketName : awsConfig.bucketNameStaging;
     const awsRegion = isProd ? awsConfig.region : awsConfig.region;
-    return new Promise(async function (resolve, reject) {
+    // CRASH CONTAINMENT (2026-08-08). This was `new Promise(async ...)` with
+    // an ASYNC s3 callback inside it. A throw in either position escapes as an
+    // UNHANDLED REJECTION rather than rejecting this promise -- fatal under
+    // node 16 (process exits, pod restarts, all in-flight requests die).
+    // Proven live in-container; see the note on jobs.getJobUrl.
+    //
+    // The reachable throw here is `site[0].external_id` below: findByIdAsync
+    // can legitimately return an empty array (deleted/hidden site), and the
+    // sibling `recording.meta` access is already defensively guarded.
+    // The async callback body is now wrapped so any throw REJECTS this
+    // promise, which the caller already handles.
+    return new Promise(function (resolve, reject) {
         (isProd ? s3 : s3RFCx).getObject({
             Key: validationUri,
             Bucket: awsBucket
@@ -246,6 +257,7 @@ async function getModelsData(validationUri, limit, offset) {
                 if (err.code == 'NoSuchKey') return reject('Validation list not found');
                 else return reject('Failed get validations');
             }
+            try {
             const outData = String(data.Body);
             let lines = outData.split('\n');
             lines = lines.filter(line => { return line !== ''; })
@@ -261,6 +273,9 @@ async function getModelsData(validationUri, limit, offset) {
                 const filename = meta && meta.filename ? meta.filename : meta && meta.file ? meta.file : '---';
                 const site = await model.sites.findByIdAsync(recording.site_id)
                 let recUrl;
+                // Guarded: an empty site lookup used to throw here and kill
+                // the pod. A row we cannot resolve simply gets no thumbnail.
+                const siteExternalId = (site && site[0]) ? site[0].external_id : null;
                 if (recording.uri.startsWith('project_')) {
                     const thumbnailUri = recording.uri.replace('.flac', '.thumbnail.png');
                     recUrl = arbimon2PublicUrl(thumbnailUri);
@@ -271,7 +286,9 @@ async function getModelsData(validationUri, limit, offset) {
                     const dateFormat = 'YYYYMMDDTHHmmssSSS'
                     const start = momentStart.format(dateFormat)
                     const end = momentEnd.format(dateFormat)
-                    recUrl = `/legacy-api/ingest/recordings/${site[0].external_id}_t${start}Z.${end}Z_rfull_g1_fspec_d600.512_wdolph_z120.png`
+                    recUrl = siteExternalId
+                        ? `/legacy-api/ingest/recordings/${siteExternalId}_t${start}Z.${end}Z_rfull_g1_fspec_d600.512_wdolph_z120.png`
+                        : null
                 }
                 rowSent.push({
                     site: recording.site,
@@ -286,6 +303,10 @@ async function getModelsData(validationUri, limit, offset) {
             }
             const vals = rowSent.length ? rowSent.filter((vali) => { return !!vali; }) : [];
             resolve(vals)
+            } catch (e) {
+                // Never let this become an unhandled rejection.
+                reject(e)
+            }
         });
     })
 }

--- a/test/p6-read-your-own-write/a1-subprocess.js
+++ b/test/p6-read-your-own-write/a1-subprocess.js
@@ -1,0 +1,20 @@
+// [A1] isolated: does the OLD `new Promise(async ...)` shape escape the
+// caller's try/catch and kill the process? Exit code is the verdict.
+//   exit 42 = caller CAUGHT it (would be safe)
+//   exit 1  = process died on an unhandled rejection (pod kill) -> expected OLD
+function oldGetJobUrl(job, pmData) {
+  return new Promise(async function (resolve) {
+    job.url = `patternmatching/${pmData.deleted ? '' : ''}`;
+    resolve(job);
+  });
+}
+(async () => {
+  try {
+    await oldGetJobUrl({ job_type_id: 6 }, undefined);
+  } catch (e) {
+    console.log('CAUGHT_BY_CALLER');
+    process.exit(42);
+  }
+  console.log('NO_THROW_OBSERVED');
+  process.exit(43);
+})();

--- a/test/p6-read-your-own-write/harness.js
+++ b/test/p6-read-your-own-write/harness.js
@@ -1,0 +1,111 @@
+// Behavioural harness for the 2026-08-08 read-after-write bundle.
+// Proves, for each member: the OLD shape fails on a 0-row re-read, and the
+// NEW shape does not. Pure-logic reimplementation of each changed block --
+// no DB required. Run: node harness.js
+let pass = 0, fail = 0;
+const ok = (name, cond) => { if (cond) { pass++; console.log('  ok   ' + name); }
+                             else { fail++; console.log('  FAIL ' + name); } };
+const threw = (fn) => { try { fn(); return false; } catch (e) { return true; } };
+const threwAsync = async (fn) => { try { await fn(); return false; } catch (e) { return true; } };
+
+console.log('\n[A] jobs.getJobUrl — async Promise executor + unguarded pmData');
+// OLD: throw inside `new Promise(async ...)` escapes the caller entirely.
+function oldGetJobUrl(job, pmData) {
+  return new Promise(async function (resolve) {
+    job.url = `patternmatching/${pmData.deleted ? '' : (pmData && pmData.pattern_matching_id ? pmData.pattern_matching_id : '')}`;
+    resolve(job);
+  });
+}
+// NEW: plain async fn + guarded deref, matching the CNN/models siblings.
+async function newGetJobUrl(job, pmData) {
+  return await (async function () {
+    job.url = `patternmatching/${(pmData && !pmData.deleted && pmData.pattern_matching_id) ? pmData.pattern_matching_id : ''}`;
+    return job;
+  })();
+}
+(async () => {
+  // The defining property: OLD is NOT catchable by the caller, and the process
+  // DIES. Run in a subprocess -- in-process this would kill the harness, which
+  // is precisely the defect. Exit 1 = died on unhandled rejection.
+  const { spawnSync } = require('child_process');
+  const r = spawnSync(process.execPath, [__dirname + '/a1-subprocess.js'], { encoding: 'utf8' });
+  ok('[A1] OLD: undefined pmData KILLS the process (exit 1, not caught by caller)',
+     r.status === 1 && /Cannot read properties of undefined/.test(r.stderr || ''));
+  ok('[A1b] OLD: caller try/catch never fired', !/CAUGHT_BY_CALLER/.test(r.stdout || ''));
+
+  ok('[A2] NEW: undefined pmData does not throw',
+     !(await threwAsync(() => newGetJobUrl({ job_type_id: 6 }, undefined))));
+  const j1 = await newGetJobUrl({ job_type_id: 6 }, undefined);
+  ok('[A3] NEW: missing row yields empty url (CNN/models sibling shape)', j1.url === 'patternmatching/');
+  const j2 = await newGetJobUrl({ job_type_id: 6 }, { pattern_matching_id: 77, deleted: 0 });
+  ok('[A4] NEW: live row preserved', j2.url === 'patternmatching/77');
+  const j3 = await newGetJobUrl({ job_type_id: 6 }, { pattern_matching_id: 77, deleted: 1 });
+  ok('[A5] NEW: deleted row still blanks (behaviour preserved)', j3.url === 'patternmatching/');
+
+  console.log('\n[B] tags.addTo — reconstruction vs re-read');
+  const insertId = 501, tagId = 9, tagText = 'howler', userId = 3;
+  const tagIn = { t0: 1.5, f0: 100, t1: 2.5, f1: 900 };
+  const oldRows = [];                       // 0-row re-read at 6.4
+  const oldResult = oldRows[0];             // -> undefined
+  ok('[B1] OLD: re-read returns undefined to the route', oldResult === undefined);
+  const at = new Date();
+  const newRow = { id: insertId, tag_id: tagId, tag: tagText, user_id: userId,
+                   datetime: at, t0: tagIn.t0, f0: tagIn.f0, t1: tagIn.t1, f1: tagIn.f1 };
+  ok('[B2] NEW: id present', newRow.id === 501);
+  ok('[B3] NEW: projection keys match getRegionTags-style consumer',
+     ['id','tag_id','tag','user_id','datetime','t0','f0','t1','f1'].every(k => k in newRow));
+  ok('[B4] NEW: tag text resolved (not undefined)', newRow.tag === 'howler');
+  ok('[B5] NEW: geometry preserved', newRow.t0 === 1.5 && newRow.f1 === 900);
+
+  console.log('\n[C] users.findByIdAfterCreate — retry then LOUD failure');
+  async function findByIdAfterCreate(insertData, label, findById) {
+    if (!insertData || insertData.insertId === undefined || insertData.insertId === null) {
+      throw new Error(label + ': INSERT returned no insertId');
+    }
+    const delays = [0, 5, 5, 5, 5, 5];   // compressed for test speed
+    for (const w of delays) {
+      if (w) await new Promise(r => setTimeout(r, w));
+      const rows = await findById(insertData.insertId);
+      if (rows && rows[0]) return rows[0];
+    }
+    throw new Error(label + ': created user not readable after insert');
+  }
+  // OLD behaviour: .get(0) on an empty result -> undefined -> flows into session
+  ok('[C1] OLD: empty re-read yields undefined user (silent, reaches session)',
+     ([])[0] === undefined);
+  // NEW: never-appears -> throws (loud) rather than returning undefined
+  ok('[C2] NEW: row never appears -> THROWS (loud, not undefined)',
+     await threwAsync(() => findByIdAfterCreate({ insertId: 7 }, 'createFromAuth0', async () => [])));
+  // NEW: appears on a later attempt (delta tick lands) -> returns the REAL row
+  let calls = 0;
+  const eventual = async () => (++calls >= 3) ? [{ user_id: 7, is_super: 0, project_limit: 100 }] : [];
+  const got = await findByIdAfterCreate({ insertId: 7 }, 'createFromAuth0', eventual);
+  ok('[C3] NEW: retry succeeds once the row lands', got && got.user_id === 7);
+  ok('[C4] NEW: schema defaults come from the DB, not invented',
+     got.is_super === 0 && got.project_limit === 100);
+  ok('[C5] NEW: missing insertId throws',
+     await threwAsync(() => findByIdAfterCreate({}, 'createByInvitation', async () => [])));
+  // The retraction that drove this design: a local reconstruction would have
+  // omitted is_super entirely.
+  const naiveReconstruction = { user_id: 7, login: 'x', email: 'a@b.c' };
+  ok('[C6] RETRACTION GUARD: naive reconstruction would lose is_super',
+     naiveReconstruction.is_super === undefined);
+
+  console.log('\n[D] soundscapes.addRegion — reconstruction');
+  const reg = { id: 88, soundscape: 4, name: 'r1', x1: 1, y1: 2, x2: 3, y2: 4,
+                count: 12, threshold: null, threshold_type: null, playlist: null };
+  ok('[D1] NEW: getRegions projection keys all present',
+     ['id','soundscape','name','x1','y1','x2','y2','count','threshold','threshold_type','playlist']
+       .every(k => k in reg));
+  ok('[D2] OLD: rows[0] on empty re-read was undefined', ([])[0] === undefined);
+
+  console.log('\n[E] models.js getModelsData — unguarded site[0]');
+  const siteEmpty = [];
+  ok('[E1] OLD: site[0].external_id throws on empty site lookup',
+     threw(() => siteEmpty[0].external_id));
+  const siteExternalId = (siteEmpty && siteEmpty[0]) ? siteEmpty[0].external_id : null;
+  ok('[E2] NEW: guarded lookup yields null, no throw', siteExternalId === null);
+
+  console.log(`\n=== ${pass} passed, ${fail} failed ===`);
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
Bundles the remaining members of the class #1795 opened, so the O5 clock
restarts ONCE rather than once per site. Every read below was confirmed
PG-routed by running the DEPLOYED classifier (dbpool-pg.classify /
pgRouteEligible) against its actual SQL: 7 of 7 {replayable:true}.

WHY THESE ALL BREAK AT 6.4
Legacy owns writes until Phase 7, so the INSERT goes to MariaDB while an
eligible plain SELECT is served from PostgreSQL at DB_ENGINE=pg. The row
reaches PG only on the next forward delta-sync tick (every 2 min), so a
re-read microseconds after its own INSERT finds NOTHING -- deterministically,
not as a race. Today the same shape fires rarely via MaxScale replica lag.

MEMBERS FIXED (local reconstruction -- the #1795 pattern)
- tags.addTo: recording-tag creation re-read. Also resolves the tag TEXT
  BEFORE the INSERT when the caller passed tag.id (pre-existing row, so not
  a read-after-write), instead of learning it from the re-read.
- soundscapes.addRegion + addRegionTag: both re-reads removed. `data =
  rows[0]` had NO emptiness guard in either.
Verified exact against the live schema: none of these tables has triggers,
and their only defaulted column is the auto-increment pk.

MEMBERS FIXED (retry-then-throw -- deliberately NOT reconstruction)
- users.createFromAuth0 / createByInvitation -> findByIdAfterCreate()
- sites POST /sites (integration.js) -> sites.findByIdAfterCreate()
RETRACTION THAT DROVE THIS: my first plan was to copy #1795 verbatim here.
That is WRONG and would have been worse than the bug. users has FIVE
defaulted columns the INSERT does not supply (is_super, project_limit,
login_tries, oauth_google, oauth_facebook) and makeUserObject puts
`is_super` in the SESSION; sites has six (created_at, updated_at, published,
timezone_locked, hidden) plus country_code/timezone written by a SEPARATE
statement. Reconstructing locally would return isSuper:undefined on the
registration path -- trading a loud crash for silent wrong data on an auth
object. These keep the read, retry ~2s, and THROW if the row never appears
(previously: returned undefined, which flowed into session setup; the /sites
endpoint answered HTTP 201 with a null body).

TWO POD-KILL PRIMITIVES (same family as the #1795 crash, found by sweep)
`new Promise(async ...)`: a throw inside an ASYNC executor cannot reject the
promise -- it escapes as an UNHANDLED REJECTION, which is fatal under node 16
(process exits, pod restarts, all in-flight requests die).
PROVEN, NOT ASSUMED: a probe of this exact shape was executed INSIDE the live
production container (node v16.20.2). The caller's try/catch did not fire and
the process died with exit 1.
- jobs.getJobUrl: trigger is `pmData.deleted` on an unguarded getPmId()
  re-read -- note the sibling CNN/models lines already guard with `&&`.
  Reachable from GET /jobs/progress?last3Months. Converted to a plain async
  fn + guarded deref matching its siblings.
- jobs.getJobParams: same shape, no awaits today -- converted as hardening so
  a later await cannot reintroduce the primitive.
- routes/data-api/models.js getModelsData: async executor AND an async s3
  callback, with an unguarded `site[0].external_id` (findByIdAsync can
  legitimately return []). Body wrapped so a throw rejects instead of
  escaping; missing site now yields no thumbnail url.

TESTS: test/p6-read-your-own-write/harness.js -- 21/21, run both locally and
INSIDE the live production container. Includes non-vacuity: [A1] spawns a
subprocess to prove the ORIGINAL shape exits 1 uncaught (it cannot be tested
in-process -- it would kill the runner, which is the defect), and [C6] pins
the retraction by asserting a naive reconstruction loses is_super.

OUT OF SCOPE (deliberate)
- templates.js / clustering-jobs.js: NOT affected. They already use
  `data.id = result.insertId` -- the pattern this commit adopts. An earlier
  breadth claim listed them; that was a pattern-match on `insertId` without
  reading the consumer, and is retracted.
- The ~40 classic *.dlq queues in the pm/aed/ingest families (infra, tracked
  in rfcx-local; the exports+notify DLQ loss was fixed separately today).
- The leftover `---TEMP2` debug print in app/routes/login.js:129 (cosmetic).