### PR TITLE
p6: close the models-delete pod-kill + install the process-level crash net

### DIFF
--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -575,9 +575,15 @@ var PatternMatchings = {
     },
 
     unvalidateRois: async function (patternMatchingId, userId, projectId) {
+        // 2026-08-09: the validateRois chain below was FLOATING (started with
+        // .then, never returned, no .catch) -- a rejection inside it (e.g. a
+        // recordings.validate DB error) was unhandled. Returning the chain
+        // makes the caller's own error handling own it (the one live caller,
+        // pattern_matchings.js /remove, awaits this inside a .catch(next)
+        // chain). Behaviour on success is unchanged.
         const rois = await PatternMatchings.getPresentRois(patternMatchingId)
         const ids = rois.map(roi => { return roi.id })
-        PatternMatchings.validateRois(patternMatchingId, ids, null)
+        return PatternMatchings.validateRois(patternMatchingId, ids, null)
             .then(async function(validatedRois) {
                 for (let roi of rois) {
                     const previousValidation = roi.validated;

--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -935,7 +935,18 @@ var Projects = {
         joi.validate(userProjectRole, schema, async function(err, upr){
             if(err) return callback(err);
 
-            const [user] = await Projects.findByEmailAsync(userProjectRole.user_email)
+            // Guarded 2026-08-09: this async callback is invoked by joi's
+            // node-style API -- nothing awaits it, so a throw (unknown email ->
+            // [user] = [] -> user.user_id) or a rejecting DB read escapes as an
+            // unhandled rejection = pod kill under node 16. Contain the tail
+            // and route every failure through callback(err).
+            let user;
+            try {
+                [user] = await Projects.findByEmailAsync(userProjectRole.user_email)
+            } catch (e) {
+                return callback(e);
+            }
+            if (!user) return callback(new Error('changeUserRole: no user found for email'));
             var user_id = user.user_id;
             var project_id = dbpool.escape(upr.project_id);
             var role_id = dbpool.escape(upr.role_id);

--- a/app/routes/data-api/models.js
+++ b/app/routes/data-api/models.js
@@ -123,7 +123,13 @@ router.post('/project/:projectUrl/models/new', function(req, res, next) {
 router.get('/project/:projectUrl/models/:mid', function(req, res, next) {
     res.type('json');
     model.models.getModelById(req.params.mid, async function(err, modelData) {
-        const [data] = modelData;
+        // Guarded 2026-08-09: err was ignored and `[data]` destructured
+        // unchecked -- an empty result (bad id today; at DB_ENGINE=pg any
+        // just-created model not yet on the */2 delta tick) threw on
+        // `data.uri` inside an un-awaited async callback = pod kill.
+        if (err) return next(err);
+        const [data] = modelData || [];
+        if (!data) return res.status(404).json({ error: 'model not found' });
         const isSharedModel = !data.uri.startsWith(`project_${data.project_id}`)
         let opts = {
             isSharedModel
@@ -209,8 +215,32 @@ router.get('/project/:projectUrl/models/:mid/delete', function(req, res, next) {
         model.models.delete(model_id, async function(err, row) {
             if(err) return next(err);
             res.json('Model deleted');
-            const jobData = await model.models.getModelJobId(model_id)
-            await model.jobs.hideAsync(jobData.job_id)
+            // CRASH CONTAINMENT (2026-08-09). This tail runs AFTER res.json in an
+            // async callback that nothing awaits, so any throw here is an
+            // unhandled rejection -> fatal under node 16 -> POD RESTART. That
+            // happened 3x on 2026-08-08 22:04-22:06Z: each training job writes
+            // TWO model rows and job_params_training links only ONE, so deleting
+            // the unlinked twin makes getModelJobId() return undefined and the
+            // bare `jobData.job_id` deref killed the pod (51 such live models).
+            // TWO layers, both required (proven in-container 2026-08-09):
+            //  1. the guard: skip hide() when no jpt row links this model. This
+            //     is semantically CORRECT, not a fallback -- the row that IS
+            //     linked may belong to a still-alive twin model (6394/6395
+            //     from job 168730), so resolving the job any other way (e.g.
+            //     from the uri) would hide a LIVE model's job.
+            //  2. the try/catch: a guard alone still dies when the READ itself
+            //     rejects (DB error; at 6.4, any PG-side failure). Nothing
+            //     awaits this callback, so the tail must contain its own errors.
+            try {
+                const jobData = await model.models.getModelJobId(model_id)
+                if (jobData && jobData.job_id) {
+                    await model.jobs.hideAsync(jobData.job_id)
+                } else {
+                    console.log(`models/${model_id}/delete: no training-job row; nothing to hide`)
+                }
+            } catch(e) {
+                console.error(`models/${model_id}/delete: post-delete job-hide failed (model already deleted, response already sent):`, e && e.message)
+            }
         });
     });
 });
@@ -219,7 +249,10 @@ router.get('/project/:projectUrl/models/:modelId/validation-list', async functio
     res.type('json');
     if (!req.params.modelId) return res.json({ error: 'missing values' });
     return model.projects.modelValidationUri(req.params.modelId, async function (err, row) {
-        if (!row.length) {
+        // Guarded 2026-08-09: `row.length` itself threw when row was
+        // undefined (err path / empty result) -- check err and shape first.
+        if (err) return next(err);
+        if (!row || !row.length) {
             return res.sendStatus(404);
         }
         let validationUri = row[0].uri;
@@ -340,7 +373,10 @@ router.get('/project/:projectUrl/models/:modelId/training-vector/:recId', functi
         return res.status(400).json({ error: 'missing parameters'});
     }
     model.models.getModelById(req.params.modelId, async function(err, modelData) {
-        const [data] = modelData;
+        // Guarded 2026-08-09: same shape as the /models/:mid route above.
+        if (err) return next(err);
+        const [data] = modelData || [];
+        if (!data) return res.status(404).json({ error: 'model not found' });
         const isSharedModel = !data.uri.startsWith(`project_${data.project_id}`);
         let sourceModelId;
         if (isSharedModel) {

--- a/bin/www
+++ b/bin/www
@@ -1,4 +1,48 @@
 #!/usr/bin/env node
+
+// ---------------------------------------------------------------------------
+// PROCESS-LEVEL CRASH NET (2026-08-09, mysql2pg P6).
+//
+// Installed FIRST, before any app code loads. Under node >= 15 an unhandled
+// promise rejection is FATAL: the process exits and the whole pod restarts,
+// dropping every in-flight request. This app is full of legacy async
+// callbacks handed to node-style APIs that nothing awaits (the pod-kill
+// primitive) -- four distinct crash classes have killed prod pods this way
+// (#1631-era finals, #1789 classifications double-send [uncaughtException],
+// #1795 training_sets re-read, and the 2026-08-08 models-delete tail).
+//
+// THIS IS A NET, NOT A MUFFLER. Every catch below logs LOUDLY with a stable,
+// greppable marker + the stack, so masked defects remain visible (Loki alert
+// on UNHANDLED_ERROR_NET) and MUST still be fixed at their site. The known
+// sites are fixed in this same change; the net exists for the site nobody
+// has enumerated yet.
+//
+// Deliberate behaviour choices:
+//  - unhandledRejection: log + survive. These arise from post-response tails;
+//    the HTTP response is almost always already sent, so there is nothing to
+//    fail toward. Surviving preserves the other ~100 in-flight requests.
+//  - uncaughtException: log + survive ONLY for ERR_HTTP_HEADERS_SENT (the
+//    known q-tick double-send class, harmless duplicate response); anything
+//    else re-raises after logging -- a truly unknown synchronous corruption
+//    should still fail-stop rather than run in an undefined state.
+// ---------------------------------------------------------------------------
+process.on('unhandledRejection', function (reason) {
+    try {
+        var msg = (reason && reason.stack) || String(reason);
+        console.error('UNHANDLED_ERROR_NET {"kind":"unhandledRejection"}', msg);
+    } catch (e) { /* the net must never throw */ }
+});
+process.on('uncaughtException', function (err) {
+    try {
+        var isHeadersSent = err && (err.code === 'ERR_HTTP_HEADERS_SENT' ||
+            /Cannot set headers after they are sent/.test(err.message || ''));
+        console.error('UNHANDLED_ERROR_NET {"kind":"uncaughtException","survivable":' + !!isHeadersSent + '}',
+            (err && err.stack) || String(err));
+        if (isHeadersSent) { return; }
+    } catch (e) { /* fall through to exit */ }
+    process.exit(1);
+});
+
 var debug = require('debug')('arbimon2');
 var app = require('../app');
 var redirectHttp = require('../app/utils/redirect-http');

--- a/test/p6-pod-kill-net/harness.js
+++ b/test/p6-pod-kill-net/harness.js
@@ -1,0 +1,146 @@
+// Behavioural harness for the 2026-08-09 pod-kill bundle (models-delete tail,
+// getModelById guards, changeUserRole tail, unvalidateRois float, bin/www net).
+// Pure-logic + subprocess proofs -- no DB required. Run: node harness.js
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+let pass = 0, fail = 0;
+const ok = (name, cond) => { if (cond) { pass++; console.log('  ok   ' + name); }
+                             else { fail++; console.log('  FAIL ' + name); } };
+
+const runSub = (code) => {
+  const f = path.join(os.tmpdir(), 'p6net-' + Math.random().toString(36).slice(2) + '.js');
+  fs.writeFileSync(f, code);
+  const r = spawnSync(process.execPath, [f], { encoding: 'utf8', timeout: 5000 });
+  fs.unlinkSync(f);
+  return r;
+};
+
+(async () => {
+  console.log('\n[A] models-delete tail -- guard + contained try/catch (both layers required)');
+
+  // The FIXED tail, extracted logic-identical from models.js.
+  async function fixedTail(getModelJobId, hideAsync, model_id, log) {
+    try {
+      const jobData = await getModelJobId(model_id);
+      if (jobData && jobData.job_id) { await hideAsync(jobData.job_id); return 'hide'; }
+      log.push('skip'); return 'skip';
+    } catch (e) { log.push('contained:' + e.message); return 'contained'; }
+  }
+  const log = [];
+  let hid = null;
+  ok('[A1] linked model still hides the right job',
+     (await fixedTail(async () => ({ job_id: 168732 }), async (id) => { hid = id; }, 6397, log)) === 'hide' && hid === 168732);
+  ok('[A2] unlinked model (twin row) skips without throwing',
+     (await fixedTail(async () => undefined, async () => {}, 6394, log)) === 'skip');
+  ok('[A3] job_id NULL row skips (never hide(null))',
+     (await fixedTail(async () => ({ job_id: null }), async () => {}, 1, log)) === 'skip');
+  ok('[A4] rejecting read is CONTAINED (guard alone would die here)',
+     (await fixedTail(async () => { throw new Error('ECONNRESET'); }, async () => {}, 1, log)) === 'contained');
+  ok('[A5] skip + containment are logged, not silent', log.length === 3);
+
+  // Subprocess: the OLD shape kills the process on the unlinked-model input.
+  const rOld = runSub(`
+    function fakeDelete(cb){ cb(null, [{}]); }
+    fakeDelete(async function(err,row){
+      const jobData = await (async()=>undefined)();
+      await jobData.job_id;
+    });
+    setTimeout(()=>console.log('SURVIVED'),50);`);
+  ok('[A6] OLD shape: process DIES (exit 1) on the same input -- the 08-08 crash',
+     rOld.status === 1 && /Cannot read properties of undefined/.test(rOld.stderr || ''));
+
+  // Subprocess: the FIXED shape survives BOTH failure modes with no net installed.
+  const rNew = runSub(`
+    function fakeDelete(cb){ cb(null, [{}]); }
+    async function tail(getJob){ try { const j = await getJob(); if (j && j.job_id) {} else {} } catch(e){} }
+    fakeDelete(async function(err,row){ await tail(async()=>undefined); await tail(async()=>{throw new Error('db')}); console.log('TAILS_DONE'); });
+    setTimeout(()=>console.log('SURVIVED'),50);`);
+  ok('[A7] FIXED shape: survives empty read AND rejecting read without any net',
+     rNew.status === 0 && /TAILS_DONE/.test(rNew.stdout) && /SURVIVED/.test(rNew.stdout));
+
+  console.log('\n[B] getModelById routes -- err + empty-result guards');
+  function guardedHead(err, modelData) {           // logic of the fixed prologue
+    if (err) return { next: err };
+    const [data] = modelData || [];
+    if (!data) return { status: 404 };
+    return { data };
+  }
+  ok('[B1] err routes to next()', !!guardedHead(new Error('x'), null).next);
+  ok('[B2] empty result -> 404, no throw', guardedHead(null, []).status === 404);
+  ok('[B3] undefined result -> 404, no throw', guardedHead(null, undefined).status === 404);
+  ok('[B4] real row passes through', guardedHead(null, [{ uri: 'u' }]).data.uri === 'u');
+  ok('[B5] validation-list guard: undefined row -> 404 path (no .length deref)',
+     (function (row) { if (!row || !row.length) return 404; return 200; })(undefined) === 404);
+
+  console.log('\n[C] changeUserRole tail -- unknown email fails via callback, not via crash');
+  function makeChangeUserRole(findByEmailAsync) {
+    return (upr, cb) => {
+      (async function (err) {
+        if (err) return cb(err);
+        let user;
+        try { [user] = await findByEmailAsync(upr.user_email); }
+        catch (e) { return cb(e); }
+        if (!user) return cb(new Error('changeUserRole: no user found for email'));
+        cb(null, 'updated:' + user.user_id);
+      })(null);
+    };
+  }
+  await new Promise((res) => makeChangeUserRole(async () => [{ user_id: 7 }])({ user_email: 'a@b' }, (e, r) => {
+    ok('[C1] known email: update proceeds', !e && r === 'updated:7'); res();
+  }));
+  await new Promise((res) => makeChangeUserRole(async () => [])({ user_email: 'x@y' }, (e) => {
+    ok('[C2] unknown email: callback(err), no throw', e && /no user found/.test(e.message)); res();
+  }));
+  await new Promise((res) => makeChangeUserRole(async () => { throw new Error('db down'); })({ user_email: 'x@y' }, (e) => {
+    ok('[C3] rejecting read: callback(err), no escape', e && e.message === 'db down'); res();
+  }));
+
+  console.log('\n[D] unvalidateRois -- the chain is returned (caller owns rejections)');
+  async function fixedUnvalidate(getRois, validate) {
+    const rois = await getRois();
+    return Promise.resolve().then(async function () {
+      for (const r of rois) { await validate(r); }
+    });
+  }
+  let caught = false;
+  await fixedUnvalidate(async () => [{ id: 1 }], async () => { throw new Error('boom'); }).catch(() => { caught = true; });
+  ok('[D1] a rejection inside the chain reaches the caller\'s .catch', caught);
+
+  console.log('\n[E] bin/www net -- subprocess proofs of both handlers');
+  const netSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'bin', 'www'), 'utf8');
+  const netBlock = netSrc.slice(0, netSrc.indexOf("var debug"));
+  ok('[E0] net block present in bin/www and installed before any require',
+     /unhandledRejection/.test(netBlock) && /uncaughtException/.test(netBlock));
+
+  const rNet1 = runSub(netBlock + `
+    Promise.reject(new TypeError("Cannot read properties of undefined (reading 'job_id')"));
+    setTimeout(()=>console.log('ALIVE'),80);`);
+  ok('[E1] unhandledRejection: logged with marker AND process survives',
+     rNet1.status === 0 && /ALIVE/.test(rNet1.stdout) && /UNHANDLED_ERROR_NET/.test(rNet1.stderr));
+
+  const rNet2 = runSub(netBlock + `
+    const e = new Error('Cannot set headers after they are sent to the client');
+    e.code = 'ERR_HTTP_HEADERS_SENT';
+    setTimeout(()=>{ throw e; }, 10);
+    setTimeout(()=>console.log('ALIVE'),80);`);
+  ok('[E2] uncaughtException ERR_HTTP_HEADERS_SENT (the #1789 class): survives',
+     rNet2.status === 0 && /ALIVE/.test(rNet2.stdout) && /"survivable":true/.test(rNet2.stderr));
+
+  const rNet3 = runSub(netBlock + `
+    setTimeout(()=>{ throw new Error('genuinely unknown sync corruption'); }, 10);
+    setTimeout(()=>console.log('ALIVE'),80);`);
+  ok('[E3] uncaughtException (unknown): logged THEN exits 1 (fail-stop preserved)',
+     rNet3.status === 1 && !/ALIVE/.test(rNet3.stdout) && /"survivable":false/.test(rNet3.stderr));
+
+  const rNet4 = runSub(netBlock + `
+    // a reason whose .stack getter throws -- the net itself must not throw
+    const evil = { get stack(){ throw new Error('evil'); }, toString(){ return 'evil-reason'; } };
+    Promise.reject(evil);
+    setTimeout(()=>console.log('ALIVE'),80);`);
+  ok('[E4] a poisoned rejection reason cannot kill the net', rNet4.status === 0 && /ALIVE/.test(rNet4.stdout));
+
+  console.log(`\n${pass}/${pass + fail} passed${fail ? '  ***FAILURES***' : ''}`);
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## The crash (3 prod pod restarts, 2026-08-08 22:04–22:06Z — killed the 14th O5 clock)

`GET /models/:mid/delete` runs an async tail after `res.json()` that nothing awaits. `getModelJobId()` returns `undefined` for any model with no `job_params_training` row, and the bare `jobData.job_id` deref became an unhandled rejection = fatal under node 16. **51 live models are unlinked** (the twin-row shape: each training job writes TWO model rows; jpt links one), across 22 projects — any user deleting one killed a prod pod. Proven live: user deletes of models 6390/6394/6396/6397 produced exactly the 3 restarts.

## Fixes
- **models.js delete tail: guard + contained try/catch.** BOTH layers proven required in the live container: a guard alone still dies when the read itself *rejects* (tested: guard-only = FATAL on DB error; guard+catch = contained). Skip is semantically **correct**, not a fallback — the jpt row may link a still-alive twin (6394/6395 both from job 168730; 6395 is alive), so resolving the job via the model `uri` would hide a live model's job.
- **Raised-at-6.4 guards**: `/models/:mid` + `/training-vector` (`[data]` destructure of empty result → `data.uri` throw) and `/validation-list` (`row.length` deref). At `DB_ENGINE=pg` a just-created model is PG-invisible until the next \*/2 delta tick, so these empty-result paths become reachable deterministically.
- **projects.js changeUserRole**: async-callback tail contained (unknown email / rejecting read → `callback(err)`, never an escape).
- **pattern_matchings.js unvalidateRois**: the floating `.then` chain is now returned — the caller's `.catch(next)` owns rejections.
- **bin/www: process-level UNHANDLED_ERROR_NET.** `unhandledRejection`: log loudly + survive (post-response tails; surviving preserves ~100 in-flight requests per crash). `uncaughtException`: survive ONLY the known `ERR_HTTP_HEADERS_SENT` double-send class (#1789); anything else logs then fail-stops. Installed before any require; can never itself throw (poisoned-reason proof). **A net, not a muffler** — stable greppable marker for alerting; site fixes remain mandatory (the known ones are in this PR).

## Verification
- Harness `test/p6-pod-kill-net/harness.js` **21/21** — locally, in the live prod container (node 16.20.2), and in the demo-tier candidate image. Subprocess proofs that the OLD shape exits 1 and all three net behaviours.
- **Live-executed pre-merge** (9th occurrence of the rule): real `getModelJobId` against prod data — 6397/6395 → hide the correct jobs; 6394/6396/6392/6402 → skip where deployed code THROWS the production crash. `hide()` stubbed; zero DB writes.
- **Demo-tier validation** (`apps-demo`, image `demo-podkillnet-84a37457`): serves 200, harness green in-image, and a `DB_ENGINE=pg` flip rehearsal — eligible reads served from PG, fixed tail correct on the pg engine (hide/hide/skip/skip), `dialect_error: 0`, 0 restarts.

Restarts the O5 clock (15th T0) per the clock-economics rule — a known clock-restarting defect is fixed now; this bundles the whole enumerated class.