### PR TITLE
aed-clustering: stop silently dropping sub-0.1 thresholds into null (unrunnable, poison-looping) jobs

### DIFF
--- a/app/model/audio-event-detections-clustering.js
+++ b/app/model/audio-event-detections-clustering.js
@@ -169,19 +169,31 @@ let AudioEventDetectionsClustering = {
             WHERE jpaec.project_id = ${dbpool.escape(projectId)} AND jpaec.deleted = 0 AND j.state = 'completed'`).get(0).get('count');
     },
 
+    // Every threshold is REQUIRED and must be a positive number.
+    //
+    // 2026-08-09: these were previously optional `joi.number()`. A missing
+    // field passed validation, then `Number(undefined)` -> NaN ->
+    // JSON.stringify -> `null` in job_params.parameters, and the AED worker
+    // died on `float(None)` for every chunk. The job then poison-looped
+    // (chunks nack -> DLQ -> empty lane -> reaper revives -> republish),
+    // burning worker capacity and never telling the user why.
+    // Real occurrences: 168288, 168463, and 168742/168743/168746/168748.
+    // `.required()` + `.positive()` makes the API the backstop, so no client
+    // (this form, a stale cached bundle, or a direct API call) can enqueue an
+    // unrunnable job.
     JOB_SCHEMA : joi.object().keys({
         user_id: joi.number().integer(),
         name: joi.string(),
         playlist_id: joi.number().integer(),
         params     : joi.object().keys({
-            areaThreshold: joi.number(),
-            amplitudeThreshold: joi.number(),
-            durationThreshold: joi.number(),
-            bandwidthThreshold: joi.number(),
-            filterSize: joi.number(),
+            areaThreshold: joi.number().positive().required(),
+            amplitudeThreshold: joi.number().positive().required(),
+            durationThreshold: joi.number().positive().required(),
+            bandwidthThreshold: joi.number().positive().required(),
+            filterSize: joi.number().positive().required(),
             minFrequency: joi.number(),
             maxFrequency: joi.number()
-        }),
+        }).required(),
     }),
 
     requestNewAudioEventDetectionClusteringJob: function(data){
@@ -233,6 +245,20 @@ let AudioEventDetectionsClustering = {
             'Area Threshold': Number(data.params.areaThreshold),
             'Filter Size': Number(data.params.filterSize),
         };
+        // Fail LOUDLY here rather than writing a NaN (which JSON.stringify
+        // turns into `null`) into job_params.parameters. A null threshold is
+        // unrunnable: the worker raises TypeError on float(None) for EVERY
+        // chunk, the chunks dead-letter, and the stalled-job reaper revives
+        // the job on a ~45-min cycle forever. Rejecting at enqueue time keeps
+        // the failure in front of the user, who can simply re-enter a value.
+        const invalid = Object.keys(params).filter(function(k){
+            return !isFinite(params[k]) || params[k] <= 0;
+        });
+        if (invalid.length) {
+            throw new Error(
+                'Invalid AED clustering parameter(s): ' + invalid.join(', ') +
+                ' must each be a number greater than 0.');
+        }
         return dbpool.query(
             'SELECT project_id FROM playlists WHERE playlist_id = ?', [data.playlist_id]
         ).then(function(rows){

--- a/assets/app/app/analysis/audio-event-detections-clustering/index.js
+++ b/assets/app/app/analysis/audio-event-detections-clustering/index.js
@@ -227,9 +227,32 @@ angular.module('a2.analysis.audio-event-detections-clustering', [
             $modalInstance.close({ cancel: true, url: url });
         },
 
+        // The five "Advanced Parameters". These are sent to the worker as
+        // `Number(value)`, so an undefined/blank field becomes NaN -> JSON null
+        // -> the AED worker dies on float(None) and the job poison-loops.
+        // They must therefore be validated here, exactly like the frequencies.
+        ADVANCED_PARAM_KEYS: ['durationThreshold', 'bandwidthThreshold',
+            'areaThreshold', 'filterSize'],
+
+        // True when any advanced param is missing or not a finite positive
+        // number. Drives both the submit guard and the inline error message.
+        showAdvancedParamWarning: function () {
+            if (!this.data || !this.data.params) return false;
+            var params = this.data.params;
+            return this.ADVANCED_PARAM_KEYS.some(function (key) {
+                var value = params[key];
+                return value === undefined || value === null || value === '' ||
+                    !isFinite(Number(value)) || Number(value) <= 0;
+            });
+        },
+
         isJobValid: function () {
             return this.data && this.data.name && this.data.name.length > 3 && this.data.playlist &&
-                !this.isNotDefined(this.data.params.maxFrequency) && !this.isNotDefined(this.data.params.minFrequency);
+                !this.isNotDefined(this.data.params.maxFrequency) && !this.isNotDefined(this.data.params.minFrequency) &&
+                // Advanced params are optional to EDIT (they carry defaults) but
+                // must never reach the worker as null -- see 2026-08-09 incident
+                // (jobs 168742/168743/168746/168748).
+                !this.showAdvancedParamWarning();
         },
 
         showNameWarning: function () {

--- a/assets/app/app/analysis/audio-event-detections-clustering/new-audio-event-detection-clustering.html
+++ b/assets/app/app/analysis/audio-event-detections-clustering/new-audio-event-detection-clustering.html
@@ -86,29 +86,31 @@
                 <img class="icon-info" src="/images/fi-info.svg"
                     tooltip="Minimum duration size (seconds)">
                 </img>
-                <input id="size" class="form-control" style="text-align:left;" min="0.1" step="0.1" ng-model="controller.data.params.durationThreshold" type="number"/>
+                <input id="size" class="form-control" style="text-align:left;" min="0.01" step="any" ng-model="controller.data.params.durationThreshold" type="number"/>
             </div>
             <div class="form-group">
                 <label for="bandwidth">Bandwidth Threshold</label>
                 <img class="icon-info" src="/images/fi-info.svg"
                     tooltip="Minimum frequency bandwidth (kHz)">
                 </img>
-                <input id="size" class="form-control" style="text-align:left;" min="0.1" step="0.1" ng-model="controller.data.params.bandwidthThreshold" type="number"/>
+                <input id="size" class="form-control" style="text-align:left;" min="0.01" step="any" ng-model="controller.data.params.bandwidthThreshold" type="number"/>
             </div>
             <div class="form-group">
               <label for="amplitude">Area Threshold</label>
               <img class="icon-info" src="/images/fi-info.svg"
                   tooltip="The minimum area of an audio event in (kHz * seconds)">
               </img>
-              <input id="area" class="form-control" style="text-align:left;" min="0.1" step="0.1" ng-model="controller.data.params.areaThreshold" type="number"/>
+              <input id="area" class="form-control" style="text-align:left;" min="0.01" step="any" ng-model="controller.data.params.areaThreshold" type="number"/>
             </div>
             <div class="form-group">
                 <label for="filterSize">Filter Size</label>
                 <img class="icon-info" src="/images/fi-info.svg"
                     tooltip="The size of the filter used to denoise the spectrogram (pixels)">
                 </img>
-                <input id="filterSize" class="form-control" style="text-align:left;" min="0.1" step="0.1" ng-model="controller.data.params.filterSize" type="number"/>
+                <input id="filterSize" class="form-control" style="text-align:left;" min="0.01" step="any" ng-model="controller.data.params.filterSize" type="number"/>
             </div>
+            <error-message ng-if="controller.showAdvancedParamWarning()"
+                message="'Every advanced parameter must be a number greater than 0. Values below the field minimum (or left blank) cannot be submitted.'"></error-message>
         </div>
     </form>
 </div>


### PR DESCRIPTION
## Summary

A user submitting an AED-for-clustering job with any threshold **below 0.1** had that value **silently discarded** and the job enqueued with `null` in its place. The job can never run, and it poison-loops: the worker raises `TypeError: float() argument must be a string or a number, not 'NoneType'` on every chunk → chunks dead-letter → the lane goes empty → the stalled-job reaper concludes the messages were lost and revives the job → republish → repeat every ~45 minutes. The user sees a job stuck at 0% with no explanation.

Found during a KEDA/analysis-scaling review on 2026-08-09; the AED autoscaler churn turned out to be a downstream echo of this bug.

## Root cause (all three links verified against live)

1. The "Advanced Parameters" inputs are `min="0.1" step="0.1"` → `0.05` fails HTML5 numeric validation → AngularJS writes `undefined` to the model.
2. `enqueueAEDClusteringJob` does `Number(undefined)` → `NaN`, and `JSON.stringify` renders `NaN` as **`null`** into `job_params_audio_event_detection_clustering.parameters`.
3. `isJobValid()` only checked min/max frequency, so **Start Job stayed enabled**, and `JOB_SCHEMA` declared every threshold optional, so the API accepted it.

## Live evidence

Jobs **168742, 168743, 168746, 168748** — one project, one afternoon. Each job's *name* records what the user actually typed, against a stored value of `null`:

| job | name says | stored |
|---|---|---|
| 168742 / 168743 | `0.05durationthreshold` | `null` |
| 168746 | `durationthreshold0.01` | `null` |
| 168748 | `Duration0.03`, `area0.05` | **both** `null` |

Every failing value is a sub-0.1 decimal; every *successful* neighbouring job used ≥0.1. Their 20 chunks were amplified into **239 dead-lettered messages** over ~15h. This is the **third** occurrence of the null-parameter class (previously 168288, 168463) — hence fixing it at the schema level rather than patching the form alone.

## The fix (defence in depth)

| Layer | Change |
|---|---|
| Form | `min="0.01" step="any"` — legitimate small thresholds are no longer rejected by the widget |
| Client validation | `isJobValid()` requires every advanced param to be finite and > 0, with an inline `error-message` explaining why the button is disabled (these fields previously had **no** validation feedback) |
| API schema | `JOB_SCHEMA` thresholds are `.positive().required()` — rejects unrunnable jobs from any client, including a stale cached bundle or direct API call |
| Enqueue guard | `enqueueAEDClusteringJob` throws before the DB write rather than persisting `NaN`→`null` |

The values users are entering are valid for the detector; only the widget disallowed them. **Defaults (0.2 / 0.5 / 1 / 10) are unaffected** — the only behaviour change for a well-formed submission is that small decimals now work as intended.

## Testing

Both new guards were unit-tested against the real incident payload shapes (including with this repo's own `joi`):

- Client guard: **10/10** — defaults valid; `0.05` and `0.01` now allowed; the 168742 and 168748 shapes blocked; null/empty/zero/negative blocked; numeric strings allowed.
- Schema: **5/5** — defaults and small values accepted; missing, explicitly-null, and zero thresholds rejected.
- `node --check` clean on both JS files. Change is scoped to the AED-clustering model (each model owns its own `JOB_SCHEMA`); the single caller is `POST /new`, whose `.catch(next)` turns the throw into a proper HTTP error.

## Operational note

The four stuck jobs have already been marked `error` in production with a user-facing remark naming the dropped value and the workaround, and the 239-message DLQ has been purged. That mitigation is per-incident; **this PR is what stops it recurring.**
