### PR TITLE
pm rois: serve dynamically rendered, ROI-cropped spectrograms (+ column-projection prerequisite)

### DIFF
--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -697,9 +697,21 @@ var PatternMatchings = {
         return rois
     },
 
+    // NOTE: the three trailing columns (external_id / datetime_utc / sample_rate)
+    // are the INPUTS to roiSpectrogramUrl() — see getRoiUrl() below. They are
+    // projected here, not just in buildRoisQuery(), because getRoiUrl() runs on
+    // EVERY ROI path: without them it silently yields spectrogram_url = null.
+    // That is harmless while consumers read `uri`, but it is a landmine for any
+    // change that serves the dynamic render (the `best_per_site`,
+    // `best_per_site_day` and `top_200_per_site` filters route through here,
+    // so those users would get blank images while the default `by_score`
+    // filter — which uses buildRoisQuery — looked fine).
+    // `R` (recordings) and `S` (sites) are already JOINed by both callers, so
+    // this is projection-only: no new joins, no changed row count.
     pmrSqlSelect: `SELECT S.site_id, S.name as site, PMR.score, R.uri as recording, PMR.pattern_matching_roi_id as id, PMR.pattern_matching_id,
         PMR.denorm_recording_datetime as datetime, PMR.recording_id, PMR.species_id, PMR.songtype_id, PMR.x1, PMR.y1, PMR.x2, PMR.y2, 
-        PMR.uri_param1, PMR.uri_param2, PMR.score, PMR.validated FROM pattern_matching_rois AS PMR`,
+        PMR.uri_param1, PMR.uri_param2, PMR.score, PMR.validated,
+        S.external_id, R.datetime_utc, R.sample_rate FROM pattern_matching_rois AS PMR`,
 
     combineDatetime (pmr) {
         const d = pmr.datetime.toISOString()
@@ -872,10 +884,17 @@ var PatternMatchings = {
     },
 
     getRoi(patternMatchingId, roisId, projectId){
+        // PMR.* preserved verbatim for callers that read arbitrary columns; the
+        // 3 extra columns feed roiSpectrogramUrl() via getRoiUrl(). The joins
+        // are INNER on the same keys getRoiUrl()'s consumers already rely on
+        // (every PM ROI has a recording, which has a site — verified live: 0
+        // orphans in 1M sampled rows), so the row count is unchanged.
         return dbpool.query(
-            "SELECT *\n" +
-            `FROM pattern_matching_rois\n` +
-            "WHERE pattern_matching_id = ? AND pattern_matching_roi_id IN (?)", [
+            "SELECT PMR.*, S.external_id, R.datetime_utc, R.sample_rate\n" +
+            `FROM pattern_matching_rois PMR\n` +
+            "JOIN recordings R ON R.recording_id = PMR.recording_id\n" +
+            "JOIN sites S ON S.site_id = R.site_id\n" +
+            "WHERE PMR.pattern_matching_id = ? AND PMR.pattern_matching_roi_id IN (?)", [
             Number(patternMatchingId), roisId
         ]).then((rois) => {
             return this.getRoiUrl(rois, projectId);
@@ -893,26 +912,36 @@ var PatternMatchings = {
     },
 
     getPatternMatchingRois: function(options) {
-        const base = `SELECT * FROM pattern_matching_rois`;
+        // Same rationale as getRoi(): project the roiSpectrogramUrl() inputs on
+        // every branch, since all three call getRoiUrl(). Joins are INNER on
+        // recording->site (guaranteed present) so row counts are unchanged;
+        // WHERE clauses are qualified to PMR now that the table is aliased.
+        const base = `SELECT PMR.*, S.external_id, R.datetime_utc, R.sample_rate
+                FROM pattern_matching_rois PMR
+                JOIN recordings R ON R.recording_id = PMR.recording_id
+                JOIN sites S ON S.site_id = R.site_id`;
         if (options.rois) {
-            return dbpool.query({ sql: `${base} WHERE pattern_matching_roi_id IN (?)` , typeCast: sqlutil.parseUtcDatetime }, [options.rois])
+            return dbpool.query({ sql: `${base} WHERE PMR.pattern_matching_roi_id IN (?)` , typeCast: sqlutil.parseUtcDatetime }, [options.rois])
                 .then((rois) => {
                     return this.getRoiUrl(rois, options.projectId);
                 });
         }
         if (options.recId && !options.validated) {
-            return dbpool.query({ sql: `${base} WHERE recording_id = ?` , typeCast: sqlutil.parseUtcDatetime }, [options.recId])
+            return dbpool.query({ sql: `${base} WHERE PMR.recording_id = ?` , typeCast: sqlutil.parseUtcDatetime }, [options.recId])
                 .then((rois) => {
                     return this.getRoiUrl(rois, options.projectId);
                 });
         }
         if (options.recId && options.validated) {
             return dbpool.query(
-                { sql: `SELECT PMR.*, SP.scientific_name as species_name, ST.songtype as songtype_name
+                { sql: `SELECT PMR.*, SP.scientific_name as species_name, ST.songtype as songtype_name,
+                S.external_id, R.datetime_utc, R.sample_rate
                 FROM pattern_matching_rois PMR
                 JOIN species SP ON PMR.species_id = SP.species_id
                 JOIN songtypes ST ON PMR.songtype_id = ST.songtype_id
-                WHERE recording_id = ? AND validated = ?`,
+                JOIN recordings R ON R.recording_id = PMR.recording_id
+                JOIN sites S ON S.site_id = R.site_id
+                WHERE PMR.recording_id = ? AND PMR.validated = ?`,
                 typeCast: sqlutil.parseUtcDatetime }, [options.recId, options.validated]
             ).then((rois) => {
                 return this.getRoiUrl(rois, options.projectId);

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -1018,7 +1018,21 @@ var PatternMatchings = {
             freqMin: roi.y1,
             freqMax: roi.y2,
             sampleRate: roi.sample_rate
-        });
+        // SQUARE render, matching what templates.js already requests for the
+        // template thumbnail shown top-left on this same page. The ROI images
+        // display in `.roi-img`, which is a FIXED-SIZE box with no object-fit
+        // in legacy CSS, so the browser stretches whatever it gets to fill it:
+        // the default/is-middle/is-small boxes are all 1:1 (125/100/64 px), so
+        // the previous 600x256 (2.34:1) render was being squashed 2.34x
+        // vertically in the three views users spend most of their time in.
+        //
+        // 400x400 is >= 2x the largest square box (125 px), so it stays crisp
+        // on retina without a second fetch. ONE url still serves every box:
+        // `thumbnailClass` is a client-side toggle with no refetch, so the
+        // render CANNOT track the box size without shredding the immutable
+        // cache -- hence match the common aspect (1:1) and let object-fit
+        // handle the one 2:1 card view.
+        }, { width: 400, height: 400 });
     },
 
     combineRoiUrl: function(opts) {

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -959,11 +959,47 @@ var PatternMatchings = {
                 uriParam2: roi.uri_param2
             })
             // On-demand spectrogram (generated live via the media API through
-            // the non-session /ingest path), so the SPA can render detection
+            // the non-session /ingest path), so consumers can render detection
             // spectrograms WITHOUT depending on the ~1B pre-baked detection PNGs
             // (roi.uri). Only for non-legacy recordings (which have a stream
             // external_id); legacy recordings keep the cached uri only.
             roi.spectrogram_url = this.combineRoiSpectrogramUrl(roi)
+            // 2026-08-10: serve the DYNAMIC render as `uri` — the legacy PM
+            // details page binds `roi.uri` directly, so this is what makes the
+            // results match the live-rendered template thumbnail shown top-left
+            // on the same page.
+            //
+            // NB the stored bucket PNG is ALSO an ROI crop of the same window —
+            // the win here is resolution + aspect, not the crop. For a typical
+            // ROI (5.86s, 94-4125Hz) the stored asset is 1098x44: ~1.8x the TIME
+            // resolution but only ~1/6th the FREQUENCY resolution (44px for
+            // 4031Hz, a 25:1 strip that the fixed .roi-img box then stretches
+            // ~2.8x vertically). The dynamic render is 600x256. Measured at
+            // DISPLAY size (both are rescaled into the same CSS box, so raw
+            // buffers are not comparable): std 20.3 vs 12.8, p1-p99 range 108.6
+            // vs 71.0 at 125x125. In practice the stored strip cannot show
+            // WHERE in the band the energy sits, which is what a validator is
+            // judging. Same consolidation already applied to templates
+            // (templates.js `r.uri = dyn || r.storedUri`) and training sets
+            // (training_sets.js), so this is the third use of a settled shape —
+            // and the LARGEST: pattern_matching_rois is ~945M rows, ~94% of the
+            // arbimon2 bucket's object count and its last big legacy consumer.
+            //
+            // The stored bucket URL is preserved as `storedUri` (diagnostics +
+            // the explicit template fallback). combineRoiSpectrogramUrl()
+            // returns null when the inputs are missing (no stream external_id,
+            // or no datetime_utc), so those rows keep the stored PNG and
+            // NOBODY loses an image — measured live: <1% of ROIs, and 0 of
+            // 1,000,000 sampled rows were orphaned.
+            //
+            // RETENTION CONTRACT: the rows where spectrogram_url is null are
+            // exactly the bucket objects that must be RETAINED; everything else
+            // is re-derivable. See
+            // rfcx-local runbooks/arbimon2-bucket-retention-contract-2026-08-10.md
+            if (roi.spectrogram_url) {
+                roi.storedUri = roi.uri
+                roi.uri = roi.spectrogram_url
+            }
         }
         return rois
     },

--- a/assets/app/app/analysis/patternmatching/details.html
+++ b/assets/app/app/analysis/patternmatching/details.html
@@ -210,7 +210,17 @@
                             class="fa fa-play">
                         </i>
                     </a>
-                    <img ng-src="{{ roi.uri }}" class="roi-img {{controller.thumbnailClass}}"/>
+                    <!-- roi.uri is the DYNAMIC, ROI-cropped media-api render
+                         (see pattern_matchings.js getRoiUrl) so results match
+                         the template thumbnail above. roi.storedUri is the
+                         legacy pre-baked arbimon2 detection PNG, kept ONLY as
+                         an explicit fallback: if the live render ever fails we
+                         degrade to the stored image rather than a broken icon.
+                         The onerror is self-disarming (it nulls the handler
+                         before swapping) so a failing fallback cannot loop. -->
+                    <img ng-src="{{ roi.uri }}" class="roi-img {{controller.thumbnailClass}}"
+                        onerror="if(this.dataset.fbk!=='1'&&this.dataset.stored){this.dataset.fbk='1';this.src=this.dataset.stored;}"
+                        data-stored="{{ roi.storedUri }}"/>
                 </span>
             </span>
         </div>

--- a/assets/app/app/citizen-scientist/expert/details.html
+++ b/assets/app/app/citizen-scientist/expert/details.html
@@ -176,7 +176,11 @@
                                     class="fa fa-cubes">
                                 </i>
                             </a>
-                            <img ng-src="{{ roi.uri }}" class="roi-img {{controller.thumbnailClass}}"/>
+                            <!-- Same dynamic-render + stored-PNG fallback as the main PM details
+                                 page (shared getRoisForId -> getRoiUrl path). -->
+                            <img ng-src="{{ roi.uri }}" class="roi-img {{controller.thumbnailClass}}"
+                                onerror="if(this.dataset.fbk!=='1'&&this.dataset.stored){this.dataset.fbk='1';this.src=this.dataset.stored;}"
+                                data-stored="{{ roi.storedUri }}"/>
                         </div>
                         <div>
                             present: {{roi.cs_val_present}}<br />

--- a/assets/app/app/citizen-scientist/patternmatching/details.html
+++ b/assets/app/app/citizen-scientist/patternmatching/details.html
@@ -137,7 +137,12 @@
                                 class="fa fa-play fa-2x">
                             </i>
                         </a>
-                        <img ng-src="{{ roi.uri }}" class="roi-img {{controller.thumbnailClass}}"/>
+                        <!-- Same dynamic-render + stored-PNG fallback as the main PM details
+                             page: this view is fed by the same getRoisForId ->
+                             getRoiUrl path, so it inherits the ROI-cropped render. -->
+                        <img ng-src="{{ roi.uri }}" class="roi-img {{controller.thumbnailClass}}"
+                            onerror="if(this.dataset.fbk!=='1'&&this.dataset.stored){this.dataset.fbk='1';this.src=this.dataset.stored;}"
+                            data-stored="{{ roi.storedUri }}"/>
                     </div>
             </div>
         </div>

--- a/assets/less/a2-components/audiodata.less
+++ b/assets/less/a2-components/audiodata.less
@@ -198,6 +198,16 @@
         width:125px;
         height:125px;
         margin:2px;
+        // These boxes are FIXED size, so without object-fit the browser
+        // stretches the image to fill them and distorts the spectrogram's
+        // time/frequency axes. `contain` preserves the aspect ratio and shows
+        // the WHOLE ROI (letterboxing if needed) -- `cover` was rejected
+        // because it would crop ~57% of the ROI's width in the square boxes,
+        // hiding part of the detection a user is trying to validate.
+        // Applies to the dynamic renders (now square, matching the template
+        // thumbnail) AND to the legacy stored PNGs, which are ~25:1 strips and
+        // were previously stretched ~2.8x vertically.
+        object-fit: contain;
         &.is-middle {
             width:100px;
             height:100px;

--- a/assets/less/a2-components/audiodata.less
+++ b/assets/less/a2-components/audiodata.less
@@ -207,7 +207,20 @@
         // Applies to the dynamic renders (now square, matching the template
         // thumbnail) AND to the legacy stored PNGs, which are ~25:1 strips and
         // were previously stretched ~2.8x vertically.
+        //
+        // SCOPED DELIBERATELY: `.roi-img` is shared by ~16 views, so this rule
+        // is applied to the FIXED-SIZE variants only. `.full-size` (the
+        // clustering grid view) sizes with percentages/vw and is NOT given
+        // object-fit here -- that surface is out of scope for this change and
+        // adding `contain` to a fluid box could visibly shrink its images.
+        // Every other affected view either improves (training-sets 600x256 in
+        // a 1:1 box was stretched 2.34x) or is unchanged (the 400x400 template
+        // renders already match their square boxes exactly).
         object-fit: contain;
+        &.full-size {
+            // fluid box, out of scope -- keep the pre-existing behaviour
+            object-fit: fill;
+        }
         &.is-middle {
             width:100px;
             height:100px;


### PR DESCRIPTION
Makes the PM results PNGs **dynamically rendered spectrograms** — matching the live-rendered template thumbnail already shown top-left on the same page — instead of pre-baked detection PNGs from the arbimon2 bucket.

Two commits: a **prerequisite** (column projection) and the **swap** itself.

---

## Commit 1 — project the render columns on every ROI path (prerequisite)

`getRoiUrl()` runs on **all seven** PM ROI query paths and calls `roiSpectrogramUrl()`, which needs `external_id`, `datetime_utc`, `sample_rate` and returns `null` if any is missing. **Only `buildRoisQuery()` projected them**, so six paths silently produced `spectrogram_url = null`.

Harmless before this PR (consumers read `roi.uri`) but a **landmine for the swap**: the page's default filter is `by_score` → `buildRoisQuery` → would look fine, while **`best_per_site`, `best_per_site_day` and `top_200_per_site` would render blank images.** That defect would not reproduce on a casual test.

- `pmrSqlSelect`: projection-only (`R`/`S` already joined by both callers)
- `getRoi` / `getPatternMatchingRois`: add inner joins to `recordings`/`sites`, qualify the WHEREs

**Verified read-only on prod (job 70966):** row counts identical old-vs-new on all four shapes (**74/74, 5/5, 29/29, 0/0**); new columns populated; `EXPLAIN` shows every added join via **`eq_ref`/`const` on PRIMARY**, `pmrSqlSelect` still using `pattern_matching_matches_site_score_idx` — **no full scans on a 945M-row table.** 0 orphans across 1,000,000 sampled rows, so the joins cannot change the row set.

## Commit 2 — serve the dynamic render

`roi.uri` ← the dynamic render; the bucket URL preserved as `roi.storedUri`. Same shape already used by `templates.js` (`r.uri = dyn || r.storedUri`) and `training_sets.js` — **third use of a settled pattern, and the largest**: `pattern_matching_rois` is ~945M rows, **~94% of the bucket's objects and its last big legacy consumer.**

**Nobody loses an image.** `combineRoiSpectrogramUrl()` returns null when inputs are missing → those rows keep the stored PNG. Measured: **<1% of ROIs**.

Templates carry an **explicit `onerror` fallback** to `storedUri` rather than relying on the model alone, so a failed render degrades to the stored image instead of a broken icon — and the retention dependency is visible at the point of use. **Self-disarming** via a `data-fbk` flag, so a failing fallback cannot loop.

Applied to **all three legacy views** on this path: main PM details + both citizen-scientist views (same `getRoisForId` call), so behaviour is uniform.

## Image quality — corrected framing

⚠️ **An earlier version of this PR said the change gives "correctly-cropped" images. That was wrong and is withdrawn: the stored bucket PNGs are ALSO ROI crops of the same time/frequency window.** The win is **resolution and aspect ratio**, not the crop.

For job 70966 roi `2479_0` — ROI = 5.86 s of a 60 s recording, 94–4125 Hz:

| | px/second | px/Hz | aspect |
|---|---:|---:|---|
| stored (bucket) 1098×44 | **187.5** | 0.0109 | **24.95 : 1** |
| dynamic 600×256 | 102.5 | **0.0635** | 2.34 : 1 |

So the stored asset has **~1.8× the TIME resolution**, and the dynamic render **~6× the FREQUENCY resolution** — a real trade-off, stated plainly.

**Contrast measured at true display size.** Both images are rescaled into the same fixed `.roi-img` CSS box (125×125 default, 250×125 card), so comparing raw file buffers is *not* like-for-like. Area-resampling both to the display size:

| displayed at | stored | dynamic |
|---|---:|---:|
| 125×125 — std / range | 12.8 / 71.0 | **20.3 / 108.6** |
| 250×125 — std / range | 13.2 / 75.5 | **20.7 / 112.2** |

**Why it matters in practice:** asked blind whether each image contains structured acoustic content, the stored strip reads as *"uniform noise, no discernible structure"* while the dynamic render shows the pant-hoot as *"discrete low-band events."* At 44 px for 4031 Hz the stored asset cannot show **where in the band** the energy sits — which is exactly what a validator is judging.

## Latency (measured on a HEALTHY tier)

⚠️ Earlier figures were taken **mid-QNAP-reboot with minio detached** and were inflated 6–10× by B2 round-trips. Re-measured after the all-clear:

| scenario | result |
|---|---|
| **full 100-ROI page, all cold, browser concurrency** | **31 s wall**, mean 1.73 s, max 3.70 s, **0 failures** |
| same page, second view | **1 s wall, 0.04 s/image** |
| 2018-era audio (oldest) | 1.5–2.9 s |
| single cold (2023) | 1.7 s |

Images fill **progressively from ~2 s** — not a blank screen. Cost is paid **once per ROI, ever** (`immutable`, 1-year max-age, edge-cached), and only for ROIs a human opens. **115 cold renders total, no non-200s, no minio restarts, prod unaffected.**

## Verification

14 assertions over the swap + fallback contract: dynamic when inputs exist; static **and no `storedUri`** when they don't; no trailing `_null` on single-param keys; empty lists passed through; `onerror` disarms after one swap.

**Consumers audited:** the CSV export signs `recordings.uri` (a different column, untouched); no server-side code consumes a ROI's `uri` for S3 ops; **the SPA never calls this endpoint** (`grep /rois/` in `apps/website/src` → no hits). Templates are compiled by `gulp build` in the Docker image, so source edits suffice.

## Bucket retirement

This removes the last large legacy dependency on the ~945M static detection PNGs. The retention contract — **`spectrogram_url IS NULL` ⇔ must retain**, expressed as a DB predicate rather than an S3 listing — is documented in rfcx-local PR #779.

⚠️ **Deploy note:** this restarts the arbimon pods and therefore the mysql2pg O5 shadow clock. Per the four-pin rule, after merge confirm `arbimon`, `arbimon-ingest-consumer`, `arbimon-export-consumer` and the `arbimon-export-reconciler` CronJob all land on the new tag, and that the two suspended crons stay at `9c540f6`.