### PR TITLE
config: split apiBaseUrl by backend so internal API calls can stay in-cluster

### DIFF
--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -15,6 +15,7 @@ const dbpool = require('../utils/dbpool');
 const sqlutil = require('../utils/sqlutil');
 const queryHandler = dbpool.queryHandler;
 const APIError = require('../utils/apierror');
+const { coreApiBaseUrl } = require('../utils/core-api-url');
 const species = require('./species');
 const songtypes = require('./songtypes');
 const roles = require('./roles')
@@ -1019,7 +1020,7 @@ var Projects = {
 
         const options = {
             method: 'PUT',
-            url: `${rfcxConfig.apiBaseUrl}/projects/${project.external_id}/users`,
+            url: `${coreApiBaseUrl()}/projects/${project.external_id}/users`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: token,
@@ -1046,7 +1047,7 @@ var Projects = {
 
         const options = {
             method: 'DELETE',
-            url: `${rfcxConfig.apiBaseUrl}/projects/${project.external_id}/users`,
+            url: `${coreApiBaseUrl()}/projects/${project.external_id}/users`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: token,
@@ -1293,7 +1294,7 @@ var Projects = {
         }
         const options = {
             method: 'POST',
-            url: `${rfcxConfig.apiBaseUrl}/projects`,
+            url: `${coreApiBaseUrl()}/projects`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: `Bearer ${idToken}`,
@@ -1344,7 +1345,7 @@ var Projects = {
         data.is_private !== undefined && (body.is_public = !data.is_private)
         const options = {
             method: 'PATCH',
-            url: `${rfcxConfig.apiBaseUrl}/internal/arbimon/projects/${data.project_id}`,
+            url: `${coreApiBaseUrl()}/internal/arbimon/projects/${data.project_id}`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: `Bearer ${idToken}`,
@@ -1366,7 +1367,7 @@ var Projects = {
         let body = {}
         const options = {
             method: 'DELETE',
-            url: `${rfcxConfig.apiBaseUrl}/projects/${project_id}`,
+            url: `${coreApiBaseUrl()}/projects/${project_id}`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: `Bearer ${idToken}`,

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -22,6 +22,7 @@ const soundscapeCompositionModel = require('./soundscape-composition')
 const { arbimon2PublicUrl } = require('../utils/asset-url')
 
 var config       = require('../config');
+const { coreApiBaseUrl } = require('../utils/core-api-url');
 var SQLBuilder  = require('../utils/sqlbuilder');
 var arrays_util  = require('../utils/arrays');
 var tmpfilecache = require('../utils/tmpfilecache');
@@ -2342,7 +2343,7 @@ var Recordings = {
         console.log('- deleteRecordingsInCoreAPI', params)
         const options = {
             method: 'DELETE',
-            url: `${rfcxConfig.apiBaseUrl}/internal/arbimon/recordings`,
+            url: `${coreApiBaseUrl()}/internal/arbimon/recordings`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: `Bearer ${idToken}`,

--- a/app/model/sites.js
+++ b/app/model/sites.js
@@ -13,6 +13,7 @@ var dbpool = require('../utils/dbpool');
 var queryHandler = dbpool.queryHandler;
 const moment = require('moment');
 let APIError = require('../utils/apierror');
+const { coreApiBaseUrl } = require('../utils/core-api-url');
 const projects = require('./projects')
 
 var Sites = {
@@ -536,7 +537,7 @@ var Sites = {
         }
         const options = {
             method: 'POST',
-            url: `${rfcxConfig.apiBaseUrl}/streams`,
+            url: `${coreApiBaseUrl()}/streams`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: `Bearer ${idToken}`,
@@ -560,7 +561,7 @@ var Sites = {
     getCountryCodeAndTimezoneCoreAPI: async function(coreSite, idToken) {
         const options = {
             method: 'GET',
-            url: `${rfcxConfig.apiBaseUrl}/streams?projects[]=${coreSite.project_id}&name[]=${encodeURIComponent(coreSite.name)}`,
+            url: `${coreApiBaseUrl()}/streams?projects[]=${coreSite.project_id}&name[]=${encodeURIComponent(coreSite.name)}`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: `Bearer ${idToken}`
@@ -633,7 +634,7 @@ var Sites = {
         data.project_id !== undefined && (body.project_external_id = data.project_id)
         const options = {
             method: 'PATCH',
-            url: `${rfcxConfig.apiBaseUrl}/internal/arbimon/streams/${data.site_id}`,
+            url: `${coreApiBaseUrl()}/internal/arbimon/streams/${data.site_id}`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: `Bearer ${idToken}`,
@@ -760,7 +761,7 @@ var Sites = {
     deleteInCoreAPI: async function(site_id, idToken) {
         const options = {
             method: 'DELETE',
-            url: `${rfcxConfig.apiBaseUrl}/internal/arbimon/streams/${site_id}`,
+            url: `${coreApiBaseUrl()}/internal/arbimon/streams/${site_id}`,
             headers: {
                 'content-type': 'application/json',
                 Authorization: `Bearer ${idToken}`,

--- a/app/model/users.js
+++ b/app/model/users.js
@@ -8,6 +8,7 @@ var config = require('../config');
 var util = require('util');
 var q = require('q');
 var APIError = require('../utils/apierror');
+var { coreApiBaseUrl, noncoreApiBaseUrl } = require('../utils/core-api-url');
 var sprintf = require("sprintf-js").sprintf;
 const rp = util.promisify(request);
 const rfcxConfig = config('rfcx');
@@ -779,7 +780,10 @@ var Users = {
     sendTouchAPI: function(idToken) {
         const options = {
             method: 'GET',
-            url: `${rfcxConfig.apiBaseUrl}/v1/users/touchapi`,
+            // NONCORE-api: the /v1 prefix is served by noncore-api, NOT core-api
+            // (core-api returns 404 for it -- verified live). See
+            // app/utils/core-api-url.js.
+            url: `${noncoreApiBaseUrl()}/v1/users/touchapi`,
             headers: {
               Authorization: `Bearer ${idToken}`
             },
@@ -824,7 +828,7 @@ var Users = {
             .then((token) => {
                 const options = {
                     method: 'POST',
-                    url: `${rfcxConfig.apiBaseUrl}/users`,
+                    url: `${coreApiBaseUrl()}/users`,
                     headers: {
                         'content-type': 'application/json',
                         Authorization: `Bearer ${token}`

--- a/app/utils/core-api-url.js
+++ b/app/utils/core-api-url.js
@@ -1,0 +1,72 @@
+/**
+ * Backend-aware base URLs for the RFCx API.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `apiBaseUrl` (https://api.rfcx.org) is NOT one service. The public router
+ * fans that hostname out by path (platform/routing/00-public-router.yaml):
+ *
+ *     ^/streams/[^/]+/segments/[^/]+/file$   -> core-api
+ *     ^/(v[12])(/|$)(.*)$                    -> noncore-api   (prefix PRESERVED)
+ *     /                                      -> core-api
+ *
+ * Every use of `apiBaseUrl` in this codebase is a SERVER-SIDE outbound call
+ * (12 call sites in app/model/*; the value is never serialised to a browser --
+ * that is `bioAnalyticsBaseUrl`, which is deliberately left public). So these
+ * calls do not need to leave the cluster at all: resolving api.rfcx.org from a
+ * pod goes out to Cloudflare and back in through the tunnel, which costs
+ * bandwidth on the constrained link, puts the highest-risk edge surface on an
+ * internal hot path, and sends a bearer token over the public internet.
+ *
+ * They cannot, however, all be pointed at ONE in-cluster Service: the /v1 and
+ * /v2 routes are served by noncore-api and core-api returns 404 for them.
+ * Verified live from inside the pod (GET, the method the app actually uses):
+ *
+ *     https://api.rfcx.org/v1/users/touchapi        -> 401  (route exists)
+ *     http://noncore-api.../v1/users/touchapi       -> 401  (same handler)
+ *     http://core-api.../v1/users/touchapi          -> 404  (WRONG service)
+ *
+ * Hence the split is by BACKEND, not by "internal vs external": that is the
+ * distinction the code actually has, and a mis-assignment fails loudly with a
+ * 404 rather than silently.
+ *
+ * The nginx rewrite is a no-op for a direct call -- it re-adds the prefix
+ * (`proxy_pass http://$upstream_noncore/$1/$3`, commented "Preserve the /v1 or
+ * /v2 prefix"), so noncore-api serves `/v1/...` itself and callers keep their
+ * existing paths unchanged.
+ *
+ * FALLBACK CONTRACT
+ * -----------------
+ * Both helpers fall back to `apiBaseUrl` when their own config value is empty.
+ * So an environment that sets neither RFCX_COREAPIBASEURL nor
+ * RFCX_NONCOREAPIBASEURL behaves EXACTLY as before this change (staging, dev,
+ * and any deployment not yet migrated), and the change is reverted by unsetting
+ * two env vars -- no code rollback required.
+ *
+ * NOTE ON CONFIG: app/config.js only applies an env override for keys that
+ * already exist in the JSON, so `coreApiBaseUrl`/`noncoreApiBaseUrl` are
+ * declared (empty) in config/rfcx.json. Removing them there would silently
+ * disable RFCX_COREAPIBASEURL / RFCX_NONCOREAPIBASEURL.
+ */
+
+const config = require('../config');
+
+function trimTrailingSlash (s) {
+    return typeof s === 'string' ? s.replace(/\/+$/, '') : s;
+}
+
+/** Base URL for core-api routes (everything except /v1 and /v2). */
+function coreApiBaseUrl () {
+    const c = config('rfcx');
+    const v = c.coreApiBaseUrl;
+    return trimTrailingSlash(v && String(v).trim() ? v : c.apiBaseUrl);
+}
+
+/** Base URL for noncore-api routes (the /v1 and /v2 prefixes). */
+function noncoreApiBaseUrl () {
+    const c = config('rfcx');
+    const v = c.noncoreApiBaseUrl;
+    return trimTrailingSlash(v && String(v).trim() ? v : c.apiBaseUrl);
+}
+
+module.exports = { coreApiBaseUrl, noncoreApiBaseUrl };

--- a/config/rfcx.json
+++ b/config/rfcx.json
@@ -1,6 +1,8 @@
 {
   "coreAPIEnabled": true,
   "apiBaseUrl": "https://staging-api.rfcx.org",
+  "coreApiBaseUrl": "",
+  "noncoreApiBaseUrl": "",
   "mediaBaseUrl": "https://staging-api.rfcx.org",
   "deviceBaseUrl": "https://staging-device-api.rfcx.org",
   "explorerBaseUrl": "https://staging-explorer.rfcx.org",


### PR DESCRIPTION
Splits `apiBaseUrl` **by backend** so the 12 server-side API calls can stay in-cluster instead of hairpinning out through Cloudflare and back through the tunnel.

**Inert until the new env vars are set** — both helpers fall back to `apiBaseUrl`.

## Why by backend, not internal/external

`api.rfcx.org` is **not one service**. public-router fans it out by path — `/v1` and `/v2` → **noncore-api**, everything else → **core-api**.

And there is no external/internal duality to preserve: **all 12 usages are server-side** (`app/model/*`); the value is never sent to a browser. (That's `bioAnalyticsBaseUrl`, which is `res.json`'d to the client and correctly stays public.)

## Classified empirically, not by reading nginx

From inside the pod, using **401 vs 404** as the discriminator:

| path | public | core-api | noncore-api | → |
|---|---|---|---|---|
| `/internal/arbimon/recordings` | 401 | **401** | 404 | core |
| `/users`, `/projects`, `/projects/:id/users`, `/internal/arbimon/projects/:id`, `/streams`, `/internal/arbimon/streams/:id` | 401 | **401** | 404 | core |
| **`/v1/users/touchapi`** | 401 | **404** | **401** | **NONCORE** |

**That 404 is the whole point** — a naive single in-cluster URL would have silently broken the login touch-API call. **11 core-api, exactly 1 noncore-api.**

The nginx rewrite is a **no-op for a direct call**: it re-adds the prefix (commented *"Preserve the /v1 or /v2 prefix"*), so noncore-api serves those paths itself and call sites are unchanged.

## Design

`app/utils/core-api-url.js` exposes `coreApiBaseUrl()` / `noncoreApiBaseUrl()`, each falling back to `apiBaseUrl` when empty or whitespace.

- **Unset both** → behaves exactly as today (staging/dev untouched)
- **Partial rollout is safe** — setting only `RFCX_COREAPIBASEURL` leaves the noncore call public rather than sending it somewhere that 404s
- **Reverted by unsetting two env vars**, no code rollback

⚠️ **Config gotcha, documented in the helper:** `app/config.js` only applies an env override for keys **already present** in the JSON — so `coreApiBaseUrl`/`noncoreApiBaseUrl` are declared (empty) in `config/rfcx.json`. Removing them would silently disable the env vars.

## Verification

- `node --check` on all five files; `config/rfcx.json` parses
- **22 assertions**: back-compat, full + partial rollout, trailing-slash and whitespace handling, and that **no versioned path is ever routed to `coreApiBaseUrl`**
- **Loaded the helper inside the running production pod** against the real config module with both vars unset → both resolved to `https://api.rfcx.org`, confirming the fallback against the actual loader rather than my transliteration

**One test bug worth recording:** the first run reported 2 failures because `noncoreApiBaseUrl` **contains** the substring `coreApiBaseUrl`, so a naive regex matched the *correct* line. Confirmed by grep that the code was right, then added a negative lookbehind plus a converse assertion.

## Deploy note

Restarts the arbimon pods → restarts the mysql2pg O5 clock. Per the four-pin rule, confirm `arbimon`, `arbimon-ingest-consumer`, `arbimon-export-consumer` and the `arbimon-export-reconciler` CronJob all land on the new tag, and the two suspended crons stay at `9c540f6`.

**Verify explicitly after deploy:** `sendTouchAPI` is on the **login path** — the one noncore call. Worth an authenticated check rather than assuming.