### PR TITLE
security: re-gate the media asset proxy behind the session (close the 2023 f6240fd2 regression)

### DIFF
--- a/app/routes/data-api/ingest-assets.js
+++ b/app/routes/data-api/ingest-assets.js
@@ -1,0 +1,102 @@
+/* jshint node:true */
+"use strict";
+
+/**
+ * SESSION-GATED media asset proxy.
+ *
+ * `GET /legacy-api/ingest/recordings/:attr` renders a spectrogram (or audio)
+ * for an arbitrary stream + time window by proxying core media-api's
+ * `/internal/assets/streams/:attr`.
+ *
+ * WHY THIS LIVES HERE AND NOT IN `ingest.js` / `non-session.js`
+ * -------------------------------------------------------------
+ * This route used to sit in `non-session.js` alongside the ingest POSTs. Those
+ * POSTs carry their own JWT guards (`verifyToken()` + `hasRole(['systemUser'])`)
+ * and are called SERVER-SIDE by rfcx-api, so they legitimately belong outside
+ * the session. This GET does NOT have a guard of its own -- it was protected
+ * only by the session middleware until commit f6240fd2 (2023-03-06,
+ * "don't use sessions for urls which use jwt") moved `/ingest` out of the
+ * session-gated router. That commit's reasoning held for 8 of the 9 routes it
+ * moved; this one was the exception and silently became public.
+ *
+ * The effect was that ANY anonymous caller could fetch spectrograms AND raw
+ * audio (`_fwav.wav`, `_fmp3.mp3`) for ANY stream -- including private projects
+ * -- because the proxy mints a machine-to-machine `systemUser` Auth0 token,
+ * which makes media-api skip its per-user `readableBy` scoping entirely.
+ * Verified live against production on 2026-08-10 before this change.
+ *
+ * Mounting it in `routes/index.js` AFTER the "Force login" middleware restores
+ * the pre-2023 protection. That works for a bare `<img src=...>` because the
+ * gate is COOKIE-based, not header-based: `parseTokenData()` reads the JWT from
+ * `req.session.idToken` (set at login in `model/users.js`) when no
+ * `Authorization` header is present, and a same-origin `<img>` sends the
+ * `arbimon` session cookie automatically. An `<img>` cannot send an
+ * `Authorization` header -- it does not need to.
+ *
+ * DO NOT move this back into `non-session.js`.
+ */
+
+let express = require('express');
+let router = express.Router();
+const request = require('request');
+
+const config = require('../../config');
+const rfcxConfig = config('rfcx');
+const auth0Service = require('../../model/auth0');
+
+router.get('/recordings/:attr', async function(req, res) {
+  const token = await auth0Service.getToken();
+  const apiUrl = `${rfcxConfig.mediaBaseUrl}/internal/assets/streams/${req.params.attr}`;
+  // Proxy the media-api asset. media-api pipes its response headers through
+  // verbatim (Content-Disposition: attachment + a short Cache-Control),
+  // which makes browsers treat inline spectrogram <img> resources as file
+  // downloads and re-fetch/re-render them on every page view. These asset
+  // URLs are CONTENT-ADDRESSED (every render param is encoded in
+  // req.params.attr), so for images we rewrite the headers to serve INLINE
+  // + immutable so browsers and the CDN cache them. Audio keeps download
+  // semantics. We must use res.writeHead (not setHeader + request.pipe)
+  // because the 'request' lib copies the upstream headers onto res during
+  // pipe, which would clobber our Content-Disposition.
+  //
+  // NOTE: the upstream URL is built from `req.params.attr` ALONE and NO query
+  // string is forwarded. That is deliberate and load-bearing: media-api
+  // supports `?refresh=true`, which skips the result cache and forces a
+  // re-render (a CPU/DoS amplifier). DO NOT add query-string forwarding here.
+  const attr = req.params.attr || '';
+  const isImage = /\.(png|jpe?g|webp)$/i.test(attr);
+  const upstream = request.get(apiUrl, {
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  upstream.on('error', () => {
+    if (!res.headersSent) res.status(502);
+    res.end();
+  });
+  upstream.on('response', (upRes) => {
+    const h = {};
+    const passthrough = ['content-type', 'content-length', 'accept-ranges',
+      'content-range', 'rfcx-stream-next-timestamp', 'rfcx-stream-gaps',
+      'access-control-expose-headers', 'last-modified', 'etag'];
+    passthrough.forEach((k) => {
+      if (upRes.headers[k] !== undefined) h[k] = upRes.headers[k];
+    });
+    if (isImage) {
+      if (!h['content-type']) h['content-type'] = 'image/png';
+      h['content-disposition'] = `inline; filename="${attr}"`;
+      // Private-project assets are now session-gated, so they must NOT be
+      // stored by shared caches (Cloudflare/proxies) where they could be
+      // served to a different, unauthenticated viewer. `private` keeps the
+      // long-lived browser caching that makes the render cache pay off while
+      // preventing shared-cache storage.
+      h['cache-control'] = 'private, max-age=31536000, immutable';
+    } else {
+      if (upRes.headers['content-disposition']) h['content-disposition'] = upRes.headers['content-disposition'];
+      if (upRes.headers['cache-control']) h['cache-control'] = upRes.headers['cache-control'];
+    }
+    res.writeHead(upRes.statusCode, h);
+    upRes.on('data', (chunk) => res.write(chunk));
+    upRes.on('end', () => res.end());
+    upRes.on('error', () => { try { res.end(); } catch (e) {} });
+  });
+})
+
+module.exports = router;

--- a/app/routes/data-api/ingest.js
+++ b/app/routes/data-api/ingest.js
@@ -4,16 +4,11 @@
 let express = require('express');
 let router = express.Router();
 let model = require('../../model');
-const request = require('request');
 const moment = require('moment');
 const authentication = require('../../middleware/jwt');
 const verifyToken = authentication.verifyToken;
 const hasRole = authentication.hasRole;
 const { EmptyResultError, httpErrorHandler, ArrayConverter } = require('@rfcx/http-utils');
-
-const config = require('../../config');
-const rfcxConfig = config('rfcx');
-const auth0Service = require('../../model/auth0');
 
 router.post('/recordings/create', verifyToken(), hasRole(['systemUser']), async function(req, res) {
   try {
@@ -105,49 +100,15 @@ router.post('/recordings/delete', verifyToken(), hasRole(['systemUser']), async 
   }
 })
 
-router.get('/recordings/:attr', async function(req, res) {
-  const token = await auth0Service.getToken();
-  const apiUrl = `${rfcxConfig.mediaBaseUrl}/internal/assets/streams/${req.params.attr}`;
-  // Proxy the media-api asset. media-api pipes its response headers through
-  // verbatim (Content-Disposition: attachment + a short Cache-Control),
-  // which makes browsers treat inline spectrogram <img> resources as file
-  // downloads and re-fetch/re-render them on every page view. These asset
-  // URLs are CONTENT-ADDRESSED (every render param is encoded in
-  // req.params.attr), so for images we rewrite the headers to serve INLINE
-  // + immutable so browsers and the CDN cache them. Audio keeps download
-  // semantics. We must use res.writeHead (not setHeader + request.pipe)
-  // because the 'request' lib copies the upstream headers onto res during
-  // pipe, which would clobber our Content-Disposition.
-  const attr = req.params.attr || '';
-  const isImage = /\.(png|jpe?g|webp)$/i.test(attr);
-  const upstream = request.get(apiUrl, {
-    headers: { 'Authorization': `Bearer ${token}` }
-  });
-  upstream.on('error', () => {
-    if (!res.headersSent) res.status(502);
-    res.end();
-  });
-  upstream.on('response', (upRes) => {
-    const h = {};
-    const passthrough = ['content-type', 'content-length', 'accept-ranges',
-      'content-range', 'rfcx-stream-next-timestamp', 'rfcx-stream-gaps',
-      'access-control-expose-headers', 'last-modified', 'etag'];
-    passthrough.forEach((k) => {
-      if (upRes.headers[k] !== undefined) h[k] = upRes.headers[k];
-    });
-    if (isImage) {
-      if (!h['content-type']) h['content-type'] = 'image/png';
-      h['content-disposition'] = `inline; filename="${attr}"`;
-      h['cache-control'] = 'public, max-age=31536000, immutable';
-    } else {
-      if (upRes.headers['content-disposition']) h['content-disposition'] = upRes.headers['content-disposition'];
-      if (upRes.headers['cache-control']) h['cache-control'] = upRes.headers['cache-control'];
-    }
-    res.writeHead(upRes.statusCode, h);
-    upRes.on('data', (chunk) => res.write(chunk));
-    upRes.on('end', () => res.end());
-    upRes.on('error', () => { try { res.end(); } catch (e) {} });
-  });
-})
+// NOTE: `GET /recordings/:attr` (the media-api asset proxy) used to live here.
+// It has NO guard of its own, so mounting it in `non-session.js` alongside
+// these JWT-guarded POSTs left it fully public -- anonymous callers could pull
+// spectrograms AND raw audio for private projects. It now lives in
+// `ingest-assets.js` and is mounted behind the "Force login" gate in
+// `routes/index.js`. See that file's header for the full rationale.
+//
+// The two POSTs above stay here: they are called SERVER-SIDE by rfcx-api
+// (core/_services/arbimon) with a systemUser JWT and must remain reachable
+// without a browser session.
 
 module.exports = router;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -97,6 +97,13 @@ router.use(function(req, res, next) {
     return next();
 });
 
+// Media asset proxy -- MUST stay below the "Force login" gate above.
+// `GET /legacy-api/ingest/recordings/:attr` renders spectrograms/audio for an
+// arbitrary stream+window and has no guard of its own; the session IS its
+// authentication. Mounted here (not in non-session.js) since 2026-08-10 to
+// close the f6240fd2 regression -- see app/routes/data-api/ingest-assets.js.
+router.use('/legacy-api/ingest', require('./data-api/ingest-assets'));
+
 router.use('/legacy-api', dataApi);
 router.use('/project', project);
 router.use('/citizen-scientist', require('./citizen-scientist'));

--- a/app/routes/non-session.js
+++ b/app/routes/non-session.js
@@ -1,6 +1,16 @@
 var express = require('express');
 var router = express.Router();
 
+// Routes mounted here run BEFORE the session middleware, so they must carry
+// their own authentication. Everything below is guarded by
+// `verifyToken()` + `hasRole([...])` and is called server-side (rfcx-api ->
+// core/_services/arbimon) with no browser session.
+//
+// The media asset proxy `GET /legacy-api/ingest/recordings/:attr` was moved OUT
+// of here on 2026-08-10: it has no guard of its own, so being here made it
+// publicly readable (private-project spectrograms + raw audio). It is now in
+// `data-api/ingest-assets.js`, mounted behind the login gate in `routes/index.js`.
+// Do not add unguarded routes to this file.
 router.use('/legacy-api/ingest', require('./data-api/ingest'));
 router.use('/legacy-api/integration', require('./data-api/integration'));
 

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -80,10 +80,20 @@ function arbimon2PublicUrl (key) {
  * `?stream-token=<this>` is authorised for exactly that stream+window with no
  * Authorization header -- which is what makes a bare <img> work.
  *
- * SCOPE (important): the token binds ONLY streamId + start + end. It does NOT
- * bind file type, so a token minted for a spectrogram also authorises the
- * AUDIO for the same window. Mint them only for windows the current user is
- * already entitled to see.
+ * SCOPE (by design, operator-confirmed 2026-08-10): the token binds streamId +
+ * start + end -- the SOURCE WINDOW. It deliberately does NOT bind file type,
+ * gain, frequency band or dimensions: permissions are determined in relation to
+ * the source data, and those parameters are only how that source data is
+ * RENDERED. So a token minted for a spectrogram also authorises the audio for
+ * the same window, which is correct -- it is the same protected resource.
+ * A mismatched time window IS rejected (401), so a token can never reach data
+ * outside the window it was minted for.
+ *
+ * The authorisation decision therefore happens at MINTING time: only mint for
+ * windows the current user is already entitled to see.
+ *
+ * NOTE: this mechanism has no expiry and no revocation short of rotating
+ * STREAM_TOKEN_SALT (which invalidates every outstanding token at once).
  *
  * Returns null when the salt is not configured, so callers can fall back to
  * the session-gated proxy path rather than emitting a URL that would 401.

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -38,6 +38,8 @@
  *     to be worth a separate PR.
  */
 
+const crypto = require('crypto');
+
 const DEFAULT_BASE = 'https://s3.arbimon.org/arbimon2';
 
 function trimTrailingSlash (s) {
@@ -66,6 +68,36 @@ function arbimon2PublicUrl (key) {
     if (typeof key !== 'string') return key;
     const k = key.replace(/^\/+/, '');
     return `${arbimon2PublicUrlBase()}/${k}`;
+}
+
+/**
+ * Mint a media-api "stream-token" for a stream + time window.
+ *
+ * This is the SAME construction core media-api verifies in
+ * `common/middleware/passport-stream-token` via `getStreamRangeToken`:
+ *     sha256(STREAM_TOKEN_SALT + "<streamId>_<startMs>_<endMs>")
+ * `authenticate()` there accepts ['jwt','stream-token'], so a request carrying
+ * `?stream-token=<this>` is authorised for exactly that stream+window with no
+ * Authorization header -- which is what makes a bare <img> work.
+ *
+ * SCOPE (important): the token binds ONLY streamId + start + end. It does NOT
+ * bind file type, so a token minted for a spectrogram also authorises the
+ * AUDIO for the same window. Mint them only for windows the current user is
+ * already entitled to see.
+ *
+ * Returns null when the salt is not configured, so callers can fall back to
+ * the session-gated proxy path rather than emitting a URL that would 401.
+ *
+ * @param {string} streamId  stream external id
+ * @param {number} startMs   window start, epoch ms
+ * @param {number} endMs     window end, epoch ms
+ */
+function mediaStreamToken (streamId, startMs, endMs) {
+    const salt = process.env.STREAM_TOKEN_SALT;
+    if (!salt || !streamId || !isFinite(startMs) || !isFinite(endMs)) return null;
+    return crypto.createHash('sha256')
+        .update(salt + `${streamId}_${startMs}_${endMs}`, 'utf8')
+        .digest('hex');
 }
 
 /**
@@ -136,6 +168,7 @@ function roiSpectrogramUrl (roi, opts) {
 }
 
 module.exports = {
+    mediaStreamToken,
     arbimon2PublicUrl,
     arbimon2PublicUrlBase,
     roiSpectrogramUrl


### PR DESCRIPTION
## Summary

`GET /legacy-api/ingest/recordings/:attr` — the media-api asset proxy — is **unauthenticated in production**, and has been since 2023-03-06. This PR re-gates it behind the session, and adds the minting helper for the follow-on work that retires the proxy entirely.

> ⚠️ **Merging this PR deploys to production.** `cd.yaml` triggers on push to `master` → namespace `production`. Please read “Release sequencing” below before merging — a **Cloudflare purge must follow immediately**, and this restarts the mysql2pg **O5 clock**.

## The problem

The route proxies core media-api's `/internal/assets/streams/:attr`, minting a machine-to-machine **`systemUser`** Auth0 token per request. It has **no guard of its own**, and since `f6240fd2` (*"don't use sessions for urls which use jwt"*) it has been mounted in `non-session.js` — i.e. **before** the session middleware.

That commit moved 9 routes out of the session-gated router. **8 of them carry their own `verifyToken()` + `hasRole([...])`** and are called server-side by rfcx-api, so the move was correct for them. This one relied on the session, and moving it removed its only protection.

Because the proxy substitutes a `systemUser` token, media-api skips its per-user `readableBy` scoping entirely (`has_system_role` → `readableBy: undefined` → no `hasPermission(READ, …)` check). So it was a credential-free read of **any** stream on the platform.

**Verified against production before this change** — no cookie, no `Authorization` header, from the public internet:

| request | result |
|---|---|
| ROI spectrogram `.png` | **200**, real 400×400 PNG, 54,634 bytes |
| same window, `_fwav.wav` | **200**, `audio/wav`, 562,220 bytes (16-bit mono 48 kHz PCM) |
| same window, `_fmp3.mp3` | **200**, `audio/mpeg`, 47,607 bytes |
| origin vs edge | `cf-cache-status: MISS` → **origin-served**, not just CDN cache |
| the streams sampled | **private project** (`is_public = f`) |

`checkAttrsValidity` permits windows up to **15 minutes** with arbitrary start/end/gain/frequency/dimensions — so the exposure was the audio corpus, not a fixed set of thumbnails. Demo tier was equally affected. **Exposure window: ~2 years 5 months.**

Mitigating: stream ids are 12-char alphanumeric and **not enumerable** (a well-formed wrong id 404s), so this required knowing a valid id + a real timestamp. It is capability-by-obscurity with **no expiry and no revocation** — those URLs live in browser history, CDN logs and `Referer` headers.

## The fix

- **`ingest-assets.js`** (new): the proxy moved verbatim into its own router, with a header explaining why it must stay session-gated.
- **`index.js`**: mounts `/legacy-api/ingest` **after** the “Force login” middleware, restoring the pre-2023 protection.
- **`ingest.js`**: drops the GET route and the imports only it used (`request`, `config`/`rfcxConfig`, `auth0Service`). **The two JWT-guarded POSTs stay** — rfcx-api calls them server-side and must not need a session.
- **`non-session.js`**: documents the invariant so an unguarded route isn’t added there again.
- Images now `Cache-Control: **private**, max-age=31536000, immutable` (was `public`). These responses are per-viewer authorised, so a **shared** cache entry could be served to an unauthenticated third party. `private` keeps the long-lived browser caching the render cache depends on.
- **`asset-url.js`**: adds `mediaStreamToken()` — mints core media-api stream-tokens. **Inert** (no callers) until the salt is shared and the edge route lands.

### Why a cookie gate works for `<img>`

A bare `<img>` cannot send an `Authorization` header — that is why the proxy existed — but it **does** send same-origin cookies. `parseTokenData()` (`app/middleware/jwt/index.js:58`) falls back to `req.session.idToken` when no header is present, and that is set at login (`model/users.js`). The SPA is same-origin with legacy (`https://arbimon.org`, baked into the shipped bundle) and already relies on this session for `/legacy-api/*`.

## Verification

**Demo tier** (`apps-demo`, image `arbimon:demo-roi-auth-0ce77c4d`), against live data:

```
ROI spectrogram, anonymous       302 -> /legacy-login   (was 200 + real PNG)
raw audio (_fwav.wav), anonymous 302
POST /ingest/recordings/create   401   (NOT 302 — rfcx-api path intact)
POST /ingest/recordings/delete   401
POST /integration/projects       401
/legacy-api/alive                200   (public by design, unchanged)
/legacy-api/user/tiering         302   (already gated, unchanged)
```

**The decisive check — the real browser path.** Earlier tests used an `Authorization` header; real users authenticate by **cookie**. Presenting **only** a session cookie, no header:

```
no cookie                                    302
session cookie ONLY, no auth header          200  image/png  54,634 bytes
  content-disposition: inline; filename="..."
  cache-control: private, max-age=31536000, immutable
```

Supporting facts (all verified live): SPA base URL is `https://arbimon.org` (same-origin); tile/thumbnail srcs are `BASE_URL + relative path`; the session cookie is `Path=/; HttpOnly; Secure` with **no `SameSite`** → default Lax → **sent on same-origin subresource loads**.

**Also verified:**
- Routing-order harness (real express, exact mount shape): POSTs 200 without session; anonymous GET 302; logged-in GET 200.
- `node --check` clean on all touched files.
- `mediaStreamToken()` parity vs media-api's reference impl: **7/7**; and a token minted by this helper with the **real production salt** was accepted by media-api over the public edge (**200 PNG**, no auth header).
- **Non-browser caller audit — clean.** Nothing fetches this path server-side; all 5 URL builders emit **relative** paths consumed by an authenticated browser; the OpenGraph/resource-card pages embedding `recording.thumbnail` are themselves session-gated (302 anonymously); rfcx-api calls only the two guarded POSTs, never the GET.

## Release sequencing (please follow)

1. **Merge → CD deploys** `arbimon` + `arbimon-ingest-consumer` automatically.
2. **Four-pin rule:** hand-roll `arbimon-export-consumer` **and** the `arbimon-export-reconciler` CronJob to the same image, then reconcile pins. *(Pre-checked: all four currently in lockstep at `c6b9b73`; export-consumer idle, no live claim.)*
3. **Cloudflare purge — mandatory, immediately after.** Existing responses were cached `public, immutable` and the edge serves them (`cf-cache-status: HIT` verified). Re-gating the origin does **not** evict them: cached private assets stay retrievable for up to a year. Purge `arbimon.org/legacy-api/ingest/recordings/*`. New responses are `private`, so the edge won't re-store them.
4. **O5 clock:** this restarts the mysql2pg soak clock (OPEN-ITEMS #40) — needs the usual authorisation, and record the new T0 timestamp.
5. **Post-deploy:** anonymous ROI → 302; anonymous audio → 302; both ingest POSTs → **401 (not 302** — a 302 there means rfcx-api's integration broke); `/alive` → 200. Then **as a logged-in user in a browser**, confirm PM results ROI images **and audio visualizer tiles** render (the visualizer is the wider blast radius).

**Rollback:** revert the image pin (single `kubectl set image`). No schema or data component.

**Residual:** anyone already holding a ROI URL keeps their own browser-cached copy until it expires; the CF purge covers the shared surface.

## Out of scope

- The direct stream-token route that ultimately retires this proxy (separate `rfcx-local` change: public-router `/media-api/*`).
- Sharing `STREAM_TOKEN_SALT` into `arbimon-prod-env` (operator-gated) — until then `mediaStreamToken()` returns `null`.
- Token **expiry** — the mechanism has none; salt rotation is the only revocation lever. Analysis + recommendation in `rfcx-local: runbooks/media-asset-auth-EXPIRY-analysis-2026-08-10.md`.
- The intentionally-anonymous `/legacy-api` endpoints (`/alive`, `/projects-count`) are unchanged.
