### PR TITLE
spectrograms: fix colour-by-omission on 3 surfaces + training-sets 600x256 squash

### DIFF
--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -183,6 +183,24 @@ select.push(
         return dbpool.query(sql).then(function (rois) {
             if (withSpectroCols && Array.isArray(rois)) {
                 for (const roi of rois) {
+                    // NOTE (2026-08-10): this value is COMPUTED BUT NOT YET
+                    // CONSUMED. The clustering grid
+                    // (assets/app/app/analysis/clustering-jobs/grid-view.html:164)
+                    // still binds `roi.uri` and fetches it through
+                    // /legacy-api/project/:url/clustering-jobs/asset?path=,
+                    // i.e. the pre-baked arbimon2 PNG -- it never reads
+                    // spectrogram_url.
+                    //
+                    // Deliberately left at the helper's 600x256 default rather
+                    // than "fixed" to 400x400 alongside training_sets.js: with
+                    // no consumer, changing the geometry would alter nothing a
+                    // user sees while implying a migration that has not
+                    // happened. Migrating the grid onto spectrogram_url is a
+                    // separate change -- it switches that view off the stored
+                    // PNG entirely -- and the geometry should be chosen THEN,
+                    // against the box it actually renders into (.roi-img, the
+                    // same 125x125 square as training sets, so 400x400 is the
+                    // likely answer).
                     roi.spectrogram_url = roiSpectrogramUrl({
                         externalId: roi.external_id,
                         datetimeUtc: roi.datetime_utc,

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -636,7 +636,19 @@ var Recordings = {
 
         switch (type) {
             case 'spectro':
-                asset = `rfull_g1_fspec_d10286.255_wdolph_z120.png`
+                // `mtrue` = MONOCHROME. Omitting it is not neutral: media-api
+                // reads `monochrome = findStartsWith('m') || 'false'`
+                // (segment-file-parsing.js), so NO token means COLOUR. This
+                // case had no `m` and was therefore serving an 8-bit RGB
+                // spectrogram while the `template` case below -- and every
+                // other ROI surface in the app -- serves greyscale.
+                // Measured 2026-08-10: colour costs ~2.4-2.8x the bytes
+                // (2048x255: 647,420 B RGB vs 264,849 B greyscale) for an
+                // image users expect to look like every other spectrogram.
+                // Colour IS offered deliberately elsewhere -- the visualizer's
+                // per-user palette (visualizer.spectro_color) -- which is
+                // untouched by this.
+                asset = `rfull_g1_fspec_mtrue_d10286.255_wdolph_z120.png`
                 break;
             case 'audio':
                 asset = `r${isFrequency ? fmin + '.' + fmax : 'full'}_g${isGain ? options.gain : 1}_${isFormat ? 'fwav.wav' : 'fmp3.mp3'}`

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -693,7 +693,34 @@ TrainingSets.types.roi_set = {
                         freqMin: rows[i].y1,
                         freqMax: rows[i].y2,
                         sampleRate: rows[i].sample_rate
-                    });
+                    // 2026-08-10: request 400x400 explicitly instead of
+                    // inheriting roiSpectrogramUrl's 600x256 default.
+                    //
+                    // The ROI thumbs on this page render into `.roi-img`, a
+                    // FIXED 125x125 box (100 / 64 for the smaller variants)
+                    // with no object-fit in legacy CSS -- so a 2.34:1 render
+                    // was being squashed ~2.34x vertically in the view users
+                    // spend most of their time in. This inherited default was
+                    // never a decision; PM (pattern_matchings.js) and
+                    // templates.js already pass 400x400 for exactly this
+                    // reason and this call site was simply missed.
+                    //
+                    // Trade-off, deliberately accepted: the DETAIL viewer
+                    // below (.thumbnail-viewer, 351x128) is 2.74:1, so it now
+                    // bends more than it did at 600x256. It also gains
+                    // vertical source detail (3.12 vs 2.00 source px per
+                    // displayed px), and its axes are unaffected -- the <axis>
+                    // directive draws over element.width()/height() (the BOX),
+                    // not over the source image, so tick alignment does not
+                    // depend on the render's aspect. This is the same trade PM
+                    // already ships: ONE 400x400 url serves its square thumbs
+                    // AND its 250x125 card view.
+                    //
+                    // Bonus: 400x400 is the identical cache key PM and
+                    // templates already request for the same ROI, so these
+                    // thumbs now SHARE cached objects instead of populating a
+                    // second 600x256 copy.
+                    }, { width: 400, height: 400 });
                     // 2026-08-04 consolidation: the legacy training-sets page
                     // binds roi.uri directly, and the STORED image can be a
                     // full-recording COLOUR spectrogram (tmpfilecache key

--- a/app/routes/data-api/models.js
+++ b/app/routes/data-api/models.js
@@ -319,8 +319,12 @@ async function getModelsData(validationUri, limit, offset) {
                     const dateFormat = 'YYYYMMDDTHHmmssSSS'
                     const start = momentStart.format(dateFormat)
                     const end = momentEnd.format(dateFormat)
+                    // `mtrue` = MONOCHROME. Without it media-api defaults
+                    // monochrome to false (segment-file-parsing.js) and returns an
+                    // 8-bit RGB spectrogram -- inconsistent with every other ROI
+                    // surface and ~2.8x the bytes at 600x512 (measured 2026-08-10).
                     recUrl = siteExternalId
-                        ? `/legacy-api/ingest/recordings/${siteExternalId}_t${start}Z.${end}Z_rfull_g1_fspec_d600.512_wdolph_z120.png`
+                        ? `/legacy-api/ingest/recordings/${siteExternalId}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d600.512_wdolph_z120.png`
                         : null
                 }
                 rowSent.push({

--- a/app/routes/data-api/models.js
+++ b/app/routes/data-api/models.js
@@ -322,9 +322,19 @@ async function getModelsData(validationUri, limit, offset) {
                     // `mtrue` = MONOCHROME. Without it media-api defaults
                     // monochrome to false (segment-file-parsing.js) and returns an
                     // 8-bit RGB spectrogram -- inconsistent with every other ROI
-                    // surface and ~2.8x the bytes at 600x512 (measured 2026-08-10).
+                    // surface and ~2.8x the bytes (measured 2026-08-10).
+                    //
+                    // 1200x160 for the SAME reason as classifications.js: this url
+                    // is bound to `selected.url` on modelinfo.html:413, which is the
+                    // SAME `.sm-result-thumb` strip (height:100px; width:100%)
+                    // that surface -- measured 700x100 / 920x100 / 1120x100 across
+                    // the Bootstrap-3 container widths, i.e. 7:1 to 11.2:1. The old
+                    // 600x512 (1.17:1) was stretched 6-9.6x horizontally at only
+                    // 0.54-0.86 source px per displayed px while wasting 5.12x
+                    // vertical resolution. Keeping the two endpoints on the SAME
+                    // geometry also keeps them sharing one cache object per window.
                     recUrl = siteExternalId
-                        ? `/legacy-api/ingest/recordings/${siteExternalId}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d600.512_wdolph_z120.png`
+                        ? `/legacy-api/ingest/recordings/${siteExternalId}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png`
                         : null
                 }
                 rowSent.push({

--- a/app/routes/data-api/project/classifications.js
+++ b/app/routes/data-api/project/classifications.js
@@ -77,10 +77,27 @@ router.get('/:classiId/more/:from/:total', function(req, res, next) {
                     // `mtrue` = MONOCHROME. media-api defaults monochrome to FALSE when
                     // the token is absent (segment-file-parsing.js), so this URL was
                     // silently requesting an 8-bit RGB spectrogram -- inconsistent with
-                    // every other ROI/detection surface, and ~2.8x the bytes at this
-                    // geometry (600x512: 355,576 B colour vs 128,061 B greyscale,
-                    // measured 2026-08-10).
-                    classiInfo.rec_image_url = `/legacy-api/ingest/recordings/${site[0].external_id}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d600.512_wdolph_z120.png`
+                    // every other ROI/detection surface, and ~2.8x the bytes
+                    // (measured 2026-08-10).
+                    //
+                    // 1200x160 (7.5:1), not the previous 600x512 (1.17:1): this
+                    // renders into `.sm-result-thumb`, which is
+                    // `height:100px; width:100%` (style.less:480) inside
+                    // `.vectorWrapper` -- so the box is CONTAINER-BOUND and very
+                    // wide. Measured in a browser across the Bootstrap-3 container
+                    // widths: 700x100 (7.0:1) / 920x100 (9.2:1) / 1120x100
+                    // (11.2:1). A 1.17:1 render was therefore stretched 6-9.6x
+                    // horizontally with only 0.54-0.86 SOURCE px per displayed px
+                    // (i.e. upscaled past its own resolution, visibly smeared)
+                    // while carrying 5.12x more vertical detail than the 100px-tall
+                    // box can show.
+                    //
+                    // 1200x160 gives x-density 1.30 and y-density 1.60 at the
+                    // common 970px container -- crisp in both axes, aspect bend down
+                    // from 7.85x to 1.23x -- AND it is SMALLER on the wire:
+                    // 94,164 B vs 140,366 B (-33%), because the wasted vertical
+                    // pixels cost more than the added horizontal ones.
+                    classiInfo.rec_image_url = `/legacy-api/ingest/recordings/${site[0].external_id}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png`
                 }
                 delete classiInfo.uri;
             }

--- a/app/routes/data-api/project/classifications.js
+++ b/app/routes/data-api/project/classifications.js
@@ -74,7 +74,13 @@ router.get('/:classiId/more/:from/:total', function(req, res, next) {
                     const dateFormat = 'YYYYMMDDTHHmmssSSS'
                     const start = momentStart.format(dateFormat)
                     const end = momentEnd.format(dateFormat)
-                    classiInfo.rec_image_url = `/legacy-api/ingest/recordings/${site[0].external_id}_t${start}Z.${end}Z_rfull_g1_fspec_d600.512_wdolph_z120.png`
+                    // `mtrue` = MONOCHROME. media-api defaults monochrome to FALSE when
+                    // the token is absent (segment-file-parsing.js), so this URL was
+                    // silently requesting an 8-bit RGB spectrogram -- inconsistent with
+                    // every other ROI/detection surface, and ~2.8x the bytes at this
+                    // geometry (600x512: 355,576 B colour vs 128,061 B greyscale,
+                    // measured 2026-08-10).
+                    classiInfo.rec_image_url = `/legacy-api/ingest/recordings/${site[0].external_id}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d600.512_wdolph_z120.png`
                 }
                 delete classiInfo.uri;
             }

--- a/app/utils/spectro-cache-key.selftest.js
+++ b/app/utils/spectro-cache-key.selftest.js
@@ -36,7 +36,7 @@ function buildMediaApiAttr (recording, type, options) {
         trimDuration = options.trim.duration ? (+options.trim.duration) : (to - trimFrom);
     }
     switch (type) {
-        case 'spectro': asset = `rfull_g1_fspec_d10286.255_wdolph_z120.png`; break;
+        case 'spectro': asset = `rfull_g1_fspec_mtrue_d10286.255_wdolph_z120.png`; break;
         case 'audio': asset = `r${isFrequency ? fmin + '.' + fmax : 'full'}_g${isGain ? options.gain : 1}_${isFormat ? 'fwav.wav' : 'fmp3.mp3'}`; break;
         case 'template': asset = `r${fmin}.${fmax}_g1_fspec_mtrue_d400.400_wdolph_z120.png`; break;
     }
@@ -111,10 +111,25 @@ ok('template attr carries the monochrome flag + 400x400 dims', () => {
     assert.ok(attr.endsWith('.png'));
 });
 
-ok('spectro attr is the FULL-recording colour variant (no mtrue)', () => {
+ok('spectro attr is the FULL-recording MONOCHROME variant', () => {
+    // 2026-08-10: this assertion previously REQUIRED the absence of `mtrue`,
+    // pinning a defect as if it were intent. media-api reads
+    // `monochrome = findStartsWith('m') || 'false'`, so omitting the token
+    // yields an 8-bit RGB render -- the full-recording spectrogram was the
+    // only ROI-family surface serving colour, at ~2.4-2.8x the bytes.
+    // Colour remains a deliberate, user-selectable feature in the VISUALIZER
+    // (localStorage visualizer.spectro_color); it is not this asset's job.
     const attr = buildMediaApiAttr(rec, 'spectro', {});
-    assert.ok(!attr.includes('mtrue'), 'spectro must not be monochrome: ' + attr);
+    assert.ok(attr.includes('_mtrue_'), 'spectro must be monochrome: ' + attr);
     assert.ok(attr.includes('d10286.255'));
+});
+
+ok('spectro and template are BOTH monochrome but still distinct keys', () => {
+    // Guards the 2026-06 collision fix while both are mtrue: they must stay
+    // distinct on GEOMETRY + clip, not on the colour flag.
+    const kSpec = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'spectro', {}), '.png');
+    const kTpl = buildAssetCacheKey(rec, buildMediaApiAttr(rec, 'template', roiA), '.png');
+    assert.notStrictEqual(kSpec, kTpl, 'spectro/template must not share a key');
 });
 
 ok('keys are filesystem-safe: one dot, no slashes, bounded length', () => {


### PR DESCRIPTION
## The bug

media-api parses `monochrome = findStartsWith('m') || 'false'`
([`segment-file-parsing.js`](https://github.com/rfcx/rfcx-api/blob/master/core/stream-segments/bl/segment-file-parsing.js)),
so **omitting the `m` token does not mean "default" — it means COLOUR.**

Three URL builders omitted it and were therefore requesting **8-bit RGB**
spectrograms, while every other ROI/detection surface in the app requests
greyscale. The images still looked plausible, so nothing ever surfaced it.

## Fixed (one token each)

| file | surface | geometry |
|---|---|---|
| `app/model/recordings.js` `buildMediaApiAttr` `'spectro'` | full-recording spectrogram | 10286×255 |
| `app/routes/data-api/project/classifications.js` `rec_image_url` | CNN classification results | 600×512 |
| `app/routes/data-api/models.js` `recUrl` | model detail | 600×512 |

The clearest evidence this was an oversight rather than intent: in
`buildMediaApiAttr`, the **same `switch`'s `'template'` case one line below
already emitted `mtrue`**.

## NOT changed, deliberately

The visualizer's tile colour. `getSpectroColor()` reads
`localStorage['visualizer.spectro_color']` from
`[mtrue, mfalse, mfalse_p2, p3, p4]` and **defaults to `mtrue`**, backing a real
user-facing palette picker (Red-Blue / Brown-Green / Orange-Yellow). Colour is a
feature there. It was never a feature on the three surfaces above.

## Measured saving (live, same audio + geometry)

| geometry | before | after | |
|---|---:|---:|---:|
| 600×512 | 333,470 B RGB | 140,366 B grey | **2.38× smaller** |
| 2048×255 | 644,046 B RGB | 264,592 B grey | **2.43× smaller** |

`file` reports `8-bit/color RGB` before and `8-bit grayscale` after, HTTP 200
with correct dimensions on both.

## Selftest updated — it pinned the defect as expected behaviour

`spectro-cache-key.selftest.js` asserted *"spectro attr is the FULL-recording
**colour** variant (no mtrue)"* and required the token's **absence**. That now
requires its **presence**, and the file's inline `buildMediaApiAttr` replica was
updated in lockstep as its own comment instructs.

Added a companion assertion — *"spectro and template are BOTH monochrome but
still distinct keys"* — so the 2026-06 cache-collision fix stays guarded now
that the colour flag no longer distinguishes them; they must remain distinct on
**geometry + clip**. **10/10 pass** (was 9/9), executed against the live pod's
`node_modules`.

## Safety review (3 passes)

- **No pixel/channel logic depends on colour.** `training_sets.js` and
  `templates.js` only crop by geometry via jimp, then re-encode.
- **The S3-persisted training-set/template ROI is unaffected** — it comes from
  `fetchTemplateFile` (already `mtrue`) on the media-api branch.
  `fetchSpectrogramFile` is reached only for **legacy** recordings, which render
  locally via `audioTools.spectrogram` and still honour `recording.spectroColor`.
- **Legacy sweep:** 0 remaining `fspec` URLs without an `m` token; the only
  non-`mtrue` site is the intentional visualizer palette.
- **SPA sweep:** its sole spec caller passes `monochrome: true`; its tile path
  uses the user setting. No SPA change required.

## Cache impact

`m` is part of `combineStandardFilename`'s rebuilt key, so these three surfaces
move to new cache objects — a genuine one-off re-render of their working set
(unlike parameter *order*, which the server normalises away). The replacements
are ~2.4× smaller than the objects they retire.