### PR TITLE
fix(media): sign the TRUNCATED millisecond window — fractional ROI offsets 401'd

### DIFF
--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -189,8 +189,18 @@ function roiSpectrogramUrl (roi, opts) {
         return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}T` +
             `${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}${p(d.getUTCMilliseconds(), 3)}`;
     };
-    const start = fmtTs(baseMs + from * 1000);
-    const end = fmtTs(baseMs + to * 1000);
+    // ROI x1/x2 are FRACTIONAL seconds, so baseMs + from*1000 is routinely a
+    // NON-INTEGER millisecond value (e.g. …942.5). `fmtTs` prints via Date(),
+    // which truncates to whole ms — so the printed filename and the raw value
+    // disagree. media-api re-parses start/end FROM THE FILENAME, so the token
+    // must be signed over the TRUNCATED values or it can never verify.
+    // Round once, here, and use these for BOTH the filename and the signature.
+    // (This bit live on 2026-08-10: ROIs whose offsets happened to land on a
+    // whole ms worked, everything else 401'd.)
+    const startMs = Math.round(baseMs + from * 1000);
+    const endMs = Math.round(baseMs + to * 1000);
+    const start = fmtTs(startMs);
+    const end = fmtTs(endMs);
     const fmin = Math.max(0, Math.min(Number(roi.freqMin), Number(roi.freqMax)));
     let fmax = Math.max(Number(roi.freqMin), Number(roi.freqMax));
     if (isNaN(fmin) || isNaN(fmax)) return null;
@@ -226,8 +236,6 @@ function roiSpectrogramUrl (roi, opts) {
     // FALLS BACK to the session-gated proxy when the salt is unset, so a
     // misconfigured environment degrades to the (still authenticated) legacy
     // path rather than emitting URLs that would 401.
-    const startMs = baseMs + from * 1000;
-    const endMs = baseMs + to * 1000;
     const exp = mediaAssetExpiry();
     const token = mediaStreamToken(roi.externalId, startMs, endMs, exp);
     if (token) {


### PR DESCRIPTION
## Live defect

On the Arbimon-Debug browser at `/project/<slug>/analysis/patternmatching`, **9 of 10** Track B ROI images were **broken** — every one returning **401** from a well-formed stream-token URL.

## Root cause

ROI `x1`/`x2` are **fractional seconds**, so `baseMs + from * 1000` is routinely a **non-integer** millisecond (e.g. `…942.5`).

The filename is printed via `Date()`, which **truncates** to whole ms — but the token was signed over the **raw fractional** value. media-api re-parses start/end **from the filename**, so it hashed `…942` while arbimon had hashed `…942.5`. Different message → different digest → guaranteed 401.

**Only ROIs whose offsets happened to land on a whole millisecond worked.**

## Why my verification missed it

The single ROI I tested all session (`899ivjdm93uo`, `timeMin 12.837` / `timeMax 18.693` against a `.000Z` base) lands on whole ms — so it passed **every** check: offline harness, live production fetch, and a real browser render. One sample, one accidental property, total blindness to the general case.

## Fix

Round **once**, up front, and use the same integers for **both** the filename and the signature.

## Verified against both revisions

| | result |
|---|---|
| **pre-fix** | 2 passed, **2 FAILED** — the live-failing ROI, and **400/400** fuzz cases |
| **post-fix** | **4 passed, 0 failed** |

Cases:
- **(a)** the exact ROI that 401'd in production (`338getd9wjfd`, fractional offsets)
- **(b)** a **400-case fuzz** over random fractional offsets, each asserting the token verifies against the window **re-parsed from the filename** — i.e. media-api's own view
- **(c)** whole-ms offsets still verify (the old happy path)
- **(d)** repeated calls still produce identical URLs (CDN/browser cache stability)

**(c) passed on both revisions** — that is the blind spot that let this ship, kept deliberately so the harness documents the difference.