### PR TITLE
clustering grid: serve the DYNAMIC ROI render (unblocks AED pre-warm)

### DIFF
--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -183,24 +183,22 @@ select.push(
         return dbpool.query(sql).then(function (rois) {
             if (withSpectroCols && Array.isArray(rois)) {
                 for (const roi of rois) {
-                    // NOTE (2026-08-10): this value is COMPUTED BUT NOT YET
-                    // CONSUMED. The clustering grid
-                    // (assets/app/app/analysis/clustering-jobs/grid-view.html:164)
-                    // still binds `roi.uri` and fetches it through
-                    // /legacy-api/project/:url/clustering-jobs/asset?path=,
-                    // i.e. the pre-baked arbimon2 PNG -- it never reads
-                    // spectrogram_url.
+                    // 2026-08-10: the clustering grid now serves the DYNAMIC render,
+                    // the same consolidation already applied to PM
+                    // (pattern_matchings.js getRoiUrl), templates.js and
+                    // training_sets.js. Previously this value was computed and
+                    // never consumed: grid-view.html bound `roi.uri` and fetched
+                    // the pre-baked arbimon2 PNG through
+                    // /legacy-api/project/:url/clustering-jobs/asset?path=.
                     //
-                    // Deliberately left at the helper's 600x256 default rather
-                    // than "fixed" to 400x400 alongside training_sets.js: with
-                    // no consumer, changing the geometry would alter nothing a
-                    // user sees while implying a migration that has not
-                    // happened. Migrating the grid onto spectrogram_url is a
-                    // separate change -- it switches that view off the stored
-                    // PNG entirely -- and the geometry should be chosen THEN,
-                    // against the box it actually renders into (.roi-img, the
-                    // same 125x125 square as training sets, so 400x400 is the
-                    // likely answer).
+                    // 400x400 (not the helper's 600x256 default) because these
+                    // render into `.roi-img` -- the SAME fixed 125x125 square
+                    // box (100/64 for the smaller variants) that training sets
+                    // use, with no object-fit in legacy CSS. A 2.34:1 render was
+                    // being squashed ~2.34x vertically. It is also the identical
+                    // cache key PM and templates already request for the same
+                    // ROI, so these thumbs SHARE cached objects rather than
+                    // populating a second 600x256 copy.
                     roi.spectrogram_url = roiSpectrogramUrl({
                         externalId: roi.external_id,
                         datetimeUtc: roi.datetime_utc,
@@ -209,7 +207,24 @@ select.push(
                         freqMin: roi.frequency_min,
                         freqMax: roi.frequency_max,
                         sampleRate: roi.sample_rate
-                    });
+                    }, { width: 400, height: 400 });
+
+                    // Serve the dynamic render as `uri` and keep the stored
+                    // bucket path as `storedUri`. Same shape as PM/templates/
+                    // training-sets, and the SAME retention contract: rows where
+                    // spectrogram_url is null (no stream external_id, or no
+                    // datetime_utc) keep the stored PNG, so nobody loses an
+                    // image -- those rows are exactly the must-retain set in
+                    // runbooks/arbimon2-bucket-retention-contract-2026-08-10.md.
+                    //
+                    // NB the grid fetches through the /clustering-jobs/asset
+                    // proxy, which prefixes the bucket path. A dynamic URL is
+                    // already absolute (/legacy-api/ingest/recordings/...), so
+                    // the template must bind it DIRECTLY -- see grid-view.html.
+                    if (roi.spectrogram_url) {
+                        roi.storedUri = roi.uri;
+                        roi.uri = roi.spectrogram_url;
+                    }
                 }
             }
             return rois;

--- a/assets/app/app/analysis/clustering-jobs/grid-view.html
+++ b/assets/app/app/analysis/clustering-jobs/grid-view.html
@@ -161,7 +161,18 @@
                                     class="fa fa-play">
                                 </i>
                             </a>
-                            <img ng-src="/legacy-api/project/{{projectUrl}}/clustering-jobs/asset?path={{roi.uri}}" class="roi-img" ng-class="{ 'full-size': !isSquareSize }"/>
+                            <!-- 2026-08-10: roi.uri is now the DYNAMIC media-api
+                                 render (clustering-jobs.js sets uri = spectrogram_url
+                                 when renderable, keeping the stored path as storedUri).
+                                 A dynamic URL is ABSOLUTE (/legacy-api/ingest/recordings/...),
+                                 so it must be bound directly -- wrapping it in the
+                                 /clustering-jobs/asset?path= proxy would produce a
+                                 broken request. Rows that are NOT renderable keep the
+                                 stored bucket path in roi.uri and still need the proxy,
+                                 so branch on storedUri: it is set ONLY when the swap
+                                 happened. -->
+                            <img ng-if="roi.storedUri" ng-src="{{roi.uri}}" class="roi-img" ng-class="{ 'full-size': !isSquareSize }"/>
+                            <img ng-if="!roi.storedUri" ng-src="/legacy-api/project/{{projectUrl}}/clustering-jobs/asset?path={{roi.uri}}" class="roi-img" ng-class="{ 'full-size': !isSquareSize }"/>
                         </span>
                     </div>
                 </span>


### PR DESCRIPTION
The clustering grid was the last ROI surface still bound to the pre-baked `arbimon2` PNG. `clustering-jobs.js` **computed** `spectrogram_url` and nothing consumed it — `grid-view.html` fetched `roi.uri` through `/clustering-jobs/asset?path=`.

That made AED pre-warm pointless: warming dynamic renders would fill a cache no view reads. **This is the ordering fix, not an optimisation.**

## Server
- request **400×400** instead of the helper's 600×256 default. These render into `.roi-img` — the same fixed 125×125 square box training sets use, no `object-fit` — so 2.34:1 was squashed ~2.34× vertically. It is also the **identical cache key** PM and templates already request, so these thumbs now **share** cached objects.
- swap `uri ← spectrogram_url` when renderable, keeping the stored path as `storedUri`. Same shape and same retention contract as PM/templates/training-sets.

## Template — the load-bearing half
A dynamic URL is **absolute**, so wrapping it in the asset proxy would produce a broken request. The `img` now branches on `storedUri` (set **only** when the swap happened): renderable rows bind `roi.uri` directly, un-renderable rows keep the proxy. **Migrating the model without this would have broken every thumbnail.**

## Verified (live pod, real `audio_event_detections_clustering` rows)
- 500/500 sampled AED ROIs have `external_id` + `datetime_utc` + `sample_rate`
- migrated code produces working URLs for real rows, incl. the `frequency_min = 0` case (`r0.646`)
- the must-retain shape correctly leaves `storedUri` unset and falls back to the proxy
- **CSV export and `perDate` untouched** — both set `withSpectroCols=false`, so neither can receive a dynamic URL (the export derives columns from `Object.keys`, so a leak would corrupt user CSVs)
- the SPA does not consume this proxy

## Cache-key proof
Track B landed mid-session and switched `roiSpectrogramUrl` to direct media-api URLs with `stream-token` + `exp`. I fetched one never-rendered window **both ways** — warmer (no query, systemUser bearer) and browser (token+exp) — then listed the bucket. **Exactly one object** exists for that attr, same bytes (69,581 B). The token/exp are auth only, **not** part of the cache key, so pre-warmed objects serve the browser path.