### PR TITLE
visualizer: mint tile media-api tokens server-side (Track B, final caller)

### DIFF
--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -1042,11 +1042,32 @@ var Recordings = {
             // Legacy (arbimon-native) recordings are not backed by a core
             // stream, so there is nothing to sign against.
             if (!recording.uri || Recordings.isLegacy(recording)) return;
-            // The browser derives the stream id as recording.uri.split('/')[3];
-            // prefer the authoritative external_id when the query projected it,
-            // and fall back to the same derivation otherwise. (Verified equal
-            // against prod data 2026-08-10.)
-            const streamId = recording.external_id || recording.uri.split('/')[3];
+            // Derive the stream id EXACTLY as the browser does:
+            // `recording.uri.split('/')[3]`.
+            //
+            // DO NOT "prefer" sites.external_id here. It reads as the more
+            // authoritative value (and this route's projection does select it),
+            // but media-api verifies the token against the window it re-parses
+            // FROM THE FILENAME -- and the filename is built client-side from
+            // the uri segment. If the two disagree, the token is minted for a
+            // DIFFERENT stream and the tile 401s with no console error:
+            // visualizer-tile-img.vue's `image.onerror` silently drops it, so
+            // the tile just renders blank.
+            //
+            // They DO disagree in production. Full-table scan 2026-08-10 over
+            // 304,156,781 recordings found 49,249 non-legacy rows across 11
+            // sites where they differ -- 9,363 with a NULL external_id and
+            // 39,886 where it is a genuinely DIFFERENT id. Affected real
+            // projects include tech4nature-mexico (14,352 recordings),
+            // green-and-golden-bell-frogs (7,073) and workshop-arbimon (2,289).
+            // One site carries the literal string 'undefined', which is truthy
+            // and would therefore win a `||`.
+            //
+            // Proven live against prod media-api on site 8062 (nahuelbuta, uri
+            // seg4 `3qxwx34vyovi` vs external_id `rj83wlyqyx3d`): a token minted
+            // from external_id -> 401 (rejected); from the uri segment -> auth
+            // accepted. Keep this derivation identical to the client's.
+            const streamId = recording.uri.split('/')[3];
             if (!streamId) return;
             // MUST be datetime_utc: `datetime` is the denormalised, TZ-shifted
             // local time and would put the window hours off.

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -19,7 +19,7 @@ const projectModel = require('./projects')
 const classificationsModel = require('./classifications')
 const tagsModel = require('./tags')
 const soundscapeCompositionModel = require('./soundscape-composition')
-const { arbimon2PublicUrl } = require('../utils/asset-url')
+const { arbimon2PublicUrl, mediaAssetUrl } = require('../utils/asset-url')
 
 var config       = require('../config');
 const { coreApiBaseUrl } = require('../utils/core-api-url');
@@ -971,6 +971,31 @@ var Recordings = {
                     function(err, tileSet) {
                         if(err) return next(err);
 
+                        // TRACK B (#99): mint a signed media-api credential per
+                        // tile, SERVER-SIDE, so the visualizer can stop routing
+                        // its tiles through the arbimon-legacy media proxy.
+                        //
+                        // Why here: the visualizer builds tile URLs in the
+                        // BROWSER, and a token cannot be minted there — the salt
+                        // must never reach the client. This function is reached
+                        // only from session-gated /legacy-api/project/* routes,
+                        // so the caller is already an authenticated, entitled
+                        // user. Minting here IS the authorisation decision.
+                        //
+                        // We attach `token`/`exp`/`start`/`end` rather than a
+                        // finished URL because the palette (mtrue / mfalse_p2 /
+                        // ...) is a per-user BROWSER setting the server cannot
+                        // know. That is safe precisely because the token binds
+                        // the SOURCE WINDOW (stream+start+end+exp) and NOT the
+                        // render parameters — so the client may choose colour
+                        // freely without invalidating the signature.
+                        //
+                        // The client MUST use these timestamp strings verbatim.
+                        // media-api re-parses the window out of the filename, so
+                        // any client-side re-derivation risks the fractional-ms
+                        // class that broke ROI images on 2026-08-10.
+                        Recordings.attachTileMediaTokens(recording, tileSet);
+
                         recording.tiles = {
                             x : specTiles.x,
                             y : specTiles.y,
@@ -982,6 +1007,73 @@ var Recordings = {
             }
         ],
         callback);
+    },
+
+    /**
+     * Attach a signed media-api credential to each spectrogram tile.
+     *
+     * Mutates `tileSet` in place, adding to every tile:
+     *   - `mediaStart` / `mediaEnd` : the glued UTC timestamps (no trailing Z)
+     *                                 that the filename MUST use
+     *   - `mediaToken`              : the stream-token authorising that window
+     *   - `mediaExp`                : the bucketed expiry bound into the token
+     *   - `mediaStreamId`           : the stream external id used for signing
+     *
+     * The client composes the final URL as
+     *   /media-api/internal/assets/streams/
+     *     <mediaStreamId>_t<mediaStart>Z.<mediaEnd>Z_<render attrs>.png
+     *     ?stream-token=<mediaToken>&exp=<mediaExp>
+     * choosing the render attrs (palette/dimensions) itself.
+     *
+     * 🔴 THE WINDOW MUST MATCH WHAT THE CLIENT WOULD HAVE COMPUTED. The browser
+     * previously derived each tile's window as
+     *     base + Math.round(tile.s * 1000)  ..  base + Math.round((tile.s + tile.ds) * 1000)
+     * so we reproduce that EXACTLY here, including doing the rounding on the
+     * same expression (round(s*1000) and round((s+ds)*1000), NOT round(s*1000)
+     * + round(ds*1000), which can differ by 1ms). A 1ms disagreement is a 401.
+     *
+     * Fails SOFT: on any missing input (legacy recording with no stream id,
+     * unset salt, unparseable datetime) the tile simply carries no token and
+     * the client falls back to the session-gated legacy proxy.
+     */
+    attachTileMediaTokens: function (recording, tileSet) {
+        try {
+            if (!recording || !Array.isArray(tileSet) || !tileSet.length) return;
+            // Legacy (arbimon-native) recordings are not backed by a core
+            // stream, so there is nothing to sign against.
+            if (!recording.uri || Recordings.isLegacy(recording)) return;
+            // The browser derives the stream id as recording.uri.split('/')[3];
+            // prefer the authoritative external_id when the query projected it,
+            // and fall back to the same derivation otherwise. (Verified equal
+            // against prod data 2026-08-10.)
+            const streamId = recording.external_id || recording.uri.split('/')[3];
+            if (!streamId) return;
+            // MUST be datetime_utc: `datetime` is the denormalised, TZ-shifted
+            // local time and would put the window hours off.
+            const recordingDatetime = recording.datetime_utc ? recording.datetime_utc : recording.datetime;
+            if (!recordingDatetime) return;
+            const baseMs = moment.utc(recordingDatetime).valueOf();
+            if (!isFinite(baseMs)) return;
+
+            tileSet.forEach(function (tile) {
+                if (!tile || !isFinite(tile.s) || !isFinite(tile.ds)) return;
+                const startMs = baseMs + Math.round(tile.s * 1000);
+                const endMs = baseMs + Math.round((tile.s + tile.ds) * 1000);
+                // The tile PNG geometry is fixed by the tiler (1023x255); the
+                // palette is chosen client-side and is deliberately NOT signed.
+                const minted = mediaAssetUrl(streamId, startMs, endMs, 'placeholder.png');
+                if (!minted) return;
+                tile.mediaStreamId = streamId;
+                tile.mediaStart = minted.startTs;
+                tile.mediaEnd = minted.endTs;
+                tile.mediaToken = minted.token;
+                tile.mediaExp = minted.exp;
+            });
+        } catch (e) {
+            // Never let token minting break the visualizer payload: without a
+            // token the client transparently uses the legacy proxy.
+            console.error('attachTileMediaTokens failed, tiles will use the legacy proxy:', e && e.message);
+        }
     },
 
     fetchOneSpectrogramTile: function (recording, i, j, callback) {

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -66,6 +66,30 @@ function mediaAssetExpiry () {
     return Math.ceil(target / MEDIA_TOKEN_BUCKET_SECONDS) * MEDIA_TOKEN_BUCKET_SECONDS;
 }
 
+/**
+ * Format an epoch-millisecond value as the "glued" UTC timestamp media-api's
+ * filename grammar uses: `YYYYMMDDTHHmmssSSS` (the caller appends the `Z`).
+ *
+ * ⚠️ THIS IS A SIGNATURE-CRITICAL FUNCTION. media-api does NOT trust any window
+ * the caller sends: `passport-stream-token` re-derives start/end by PARSING
+ * THEM BACK OUT OF THE FILENAME (`parseStreamAndTime` ->
+ * `gluedDateStrToMoment`). So the integers that reach this formatter are the
+ * only ones that exist as far as verification is concerned. Anything signed
+ * that differs from what this prints — even by a fraction of a millisecond —
+ * produces a different digest and a guaranteed 401.
+ *
+ * `new Date(ms)` TRUNCATES a fractional millisecond, which is exactly how the
+ * 2026-08-10 ROI defect happened. Callers MUST round to an integer BEFORE
+ * calling this and sign over that same integer — see mediaAssetUrl(), which
+ * makes that impossible to get wrong by doing both from one value.
+ */
+function gluedUtcTimestamp (ms) {
+    const d = new Date(ms);
+    const p = function (n, w) { return String(n).padStart(w || 2, '0'); };
+    return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}T` +
+        `${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}${p(d.getUTCMilliseconds(), 3)}`;
+}
+
 function trimTrailingSlash (s) {
     return typeof s === 'string' ? s.replace(/\/+$/, '') : s;
 }
@@ -143,6 +167,64 @@ function mediaStreamToken (streamId, startMs, endMs, exp) {
 }
 
 /**
+ * Build a signed, direct media-api asset URL for ONE stream + time window.
+ *
+ * This is THE chokepoint for the direct route: it takes the window as epoch
+ * milliseconds, ROUNDS ONCE, and then derives BOTH the filename timestamps and
+ * the signed token from those same integers. That is the whole point — the
+ * 2026-08-10 ROI defect (9 of 10 images 401'd in prod) happened because the
+ * filename was printed from a TRUNCATED value while the token was signed over
+ * the RAW fractional one. Keeping the two derivations in a single function
+ * makes that class of bug structurally impossible rather than merely absent:
+ * there is no code path here in which they can disagree.
+ *
+ * media-api re-parses the window FROM THE FILENAME, so the returned `startMs`/
+ * `endMs` are the authoritative view of what was signed.
+ *
+ * SCOPE: the token binds streamId + start + end (+ exp) — the SOURCE WINDOW.
+ * It deliberately does NOT bind render parameters (colour, dimensions, gain,
+ * frequency band): those are only HOW the source is rendered, and permissions
+ * attach to the source data. This is what lets a caller mint server-side while
+ * the BROWSER still chooses the palette (the visualizer's per-user
+ * `mtrue`/`mfalse_p2`/... setting) without invalidating the signature.
+ *
+ * Returns null when the salt is unset or inputs are unusable, so callers can
+ * fall back to the session-gated legacy proxy instead of emitting a URL that
+ * would 401.
+ *
+ * @param {string} streamId    stream external id
+ * @param {number} rawStartMs  window start, epoch ms (may be fractional)
+ * @param {number} rawEndMs    window end, epoch ms (may be fractional)
+ * @param {string} asset       the asset suffix after the `_t<start>Z.<end>Z_`
+ *                             segment, e.g. `z95_wdolph_g1_fspec_mtrue_d1023.255.png`
+ * @returns {{url: string, token: string, exp: number, startMs: number, endMs: number, startTs: string, endTs: string, attr: string}|null}
+ */
+function mediaAssetUrl (streamId, rawStartMs, rawEndMs, asset) {
+    if (!streamId || !asset) return null;
+    if (!isFinite(rawStartMs) || !isFinite(rawEndMs)) return null;
+    // ROUND ONCE. Every downstream use — filename AND signature — flows from
+    // these two integers, so they cannot drift apart.
+    const startMs = Math.round(Number(rawStartMs));
+    const endMs = Math.round(Number(rawEndMs));
+    const startTs = gluedUtcTimestamp(startMs);
+    const endTs = gluedUtcTimestamp(endMs);
+    const attr = `${streamId}_t${startTs}Z.${endTs}Z_${asset}`;
+    const exp = mediaAssetExpiry();
+    const token = mediaStreamToken(streamId, startMs, endMs, exp);
+    if (!token) return null;
+    return {
+        url: `${MEDIA_ASSET_PATH}${attr}?stream-token=${token}&exp=${exp}`,
+        token,
+        exp,
+        startMs,
+        endMs,
+        startTs,
+        endTs,
+        attr
+    };
+}
+
+/**
  * Build an on-demand ROI spectrogram URL for the modern SPA.
  *
  * Instead of pointing at a pre-generated detection PNG in the arbimon2 bucket
@@ -183,24 +265,16 @@ function roiSpectrogramUrl (roi, opts) {
     const from = Math.min(Number(roi.timeMin), Number(roi.timeMax));
     const to = Math.max(Number(roi.timeMin), Number(roi.timeMax));
     if (isNaN(from) || isNaN(to)) return null;
-    const fmtTs = function (ms) {
-        const d = new Date(ms);
-        const p = function (n, w) { return String(n).padStart(w || 2, '0'); };
-        return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}T` +
-            `${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}${p(d.getUTCMilliseconds(), 3)}`;
-    };
     // ROI x1/x2 are FRACTIONAL seconds, so baseMs + from*1000 is routinely a
-    // NON-INTEGER millisecond value (e.g. …942.5). `fmtTs` prints via Date(),
-    // which truncates to whole ms — so the printed filename and the raw value
-    // disagree. media-api re-parses start/end FROM THE FILENAME, so the token
-    // must be signed over the TRUNCATED values or it can never verify.
-    // Round once, here, and use these for BOTH the filename and the signature.
-    // (This bit live on 2026-08-10: ROIs whose offsets happened to land on a
-    // whole ms worked, everything else 401'd.)
-    const startMs = Math.round(baseMs + from * 1000);
-    const endMs = Math.round(baseMs + to * 1000);
-    const start = fmtTs(startMs);
-    const end = fmtTs(endMs);
+    // NON-INTEGER millisecond value (e.g. …942.5). The filename is printed via
+    // Date(), which truncates to whole ms — so a raw fractional value and the
+    // printed filename disagree. media-api re-parses start/end FROM THE
+    // FILENAME, so the token must be signed over the SAME integers the filename
+    // encodes or it can never verify. (This bit live on 2026-08-10: ROIs whose
+    // offsets happened to land on a whole ms worked, everything else 401'd.)
+    // mediaAssetUrl() now owns that rounding for BOTH derivations.
+    const rawStartMs = baseMs + from * 1000;
+    const rawEndMs = baseMs + to * 1000;
     const fmin = Math.max(0, Math.min(Number(roi.freqMin), Number(roi.freqMax)));
     let fmax = Math.max(Number(roi.freqMin), Number(roi.freqMax));
     if (isNaN(fmin) || isNaN(fmax)) return null;
@@ -217,7 +291,6 @@ function roiSpectrogramUrl (roi, opts) {
     // against media-api segment-file-utils renderSpectrogram); d{W}.{H} px; wdolph
     // window; z120 z-scale. Same grammar the visualizer + templates use.
     const asset = `r${fmin.toFixed(0)}.${fmax.toFixed(0)}_g1_fspec_mtrue_d${w}.${h}_wdolph_z120.png`;
-    const attr = `${roi.externalId}_t${start}Z.${end}Z_${asset}`;
 
     // TRACK B (2026-08-10): prefer the DIRECT media-api route, which skips the
     // arbimon-legacy proxy hop entirely and is a step toward retiring this app.
@@ -236,17 +309,22 @@ function roiSpectrogramUrl (roi, opts) {
     // FALLS BACK to the session-gated proxy when the salt is unset, so a
     // misconfigured environment degrades to the (still authenticated) legacy
     // path rather than emitting URLs that would 401.
-    const exp = mediaAssetExpiry();
-    const token = mediaStreamToken(roi.externalId, startMs, endMs, exp);
-    if (token) {
-        return `${MEDIA_ASSET_PATH}${attr}?stream-token=${token}&exp=${exp}`;
+    const minted = mediaAssetUrl(roi.externalId, rawStartMs, rawEndMs, asset);
+    if (minted) {
+        return minted.url;
     }
+    // Salt unset — fall back to the session-gated proxy. Derive the same attr
+    // from the same rounded integers so the two paths stay byte-identical.
+    const attr = `${roi.externalId}_t${gluedUtcTimestamp(Math.round(rawStartMs))}Z.` +
+        `${gluedUtcTimestamp(Math.round(rawEndMs))}Z_${asset}`;
     return `/legacy-api/ingest/recordings/${attr}`;
 }
 
 module.exports = {
     mediaStreamToken,
     mediaAssetExpiry,
+    mediaAssetUrl,
+    gluedUtcTimestamp,
     MEDIA_ASSET_PATH,
     arbimon2PublicUrl,
     arbimon2PublicUrlBase,

--- a/test/visualizer-tile-token.test.js
+++ b/test/visualizer-tile-token.test.js
@@ -1,0 +1,230 @@
+/**
+ * Regression harness for the VISUALIZER direct-media-route tile tokens (#99).
+ *
+ * 🔴 WHY THIS FUZZES INSTEAD OF SAMPLING
+ *
+ * On 2026-08-10 the ROI caller switch shipped and 9 of 10 images 401'd in
+ * production. The verification that missed it tested ONE ROI — which happened
+ * to land on a whole millisecond. It passed an offline harness, a live fetch
+ * AND a real-browser render, and was still wrong for ~90% of real inputs.
+ *
+ * The defect class: media-api does NOT trust any window the caller sends. It
+ * re-derives start/end by PARSING THEM BACK OUT OF THE FILENAME. So a token is
+ * only valid if it was signed over exactly the integers the filename encodes.
+ * Anything that rounds/truncates differently between the two derivations is a
+ * guaranteed 401 for every input that isn't already an integer.
+ *
+ * So this asserts the property END-TO-END, the way media-api sees it:
+ *   mint -> render the filename -> RE-PARSE the filename -> re-sign -> compare
+ * across hundreds of randomised fractional tile geometries.
+ *
+ * It deliberately reimplements media-api's parse/sign from its own source
+ * (segment-file-parsing + gluedDateStrToMoment + getStreamRangeToken) rather
+ * than importing arbimon-legacy's helpers, so a mistake in OUR helper cannot
+ * cancel itself out on both sides of the assertion.
+ */
+process.env.STREAM_TOKEN_SALT = process.env.STREAM_TOKEN_SALT || 'test_salt_visualizer_harness';
+
+const assert = require('assert');
+const crypto = require('crypto');
+const moment = require('moment');
+
+const { mediaAssetUrl } = require('../app/utils/asset-url');
+
+// ---------------------------------------------------------------------------
+// media-api's SIDE of the contract, transcribed from rfcx-api @ origin/master:
+//   core/stream-segments/bl/segment-file-parsing.js  (parseFileNameAttrs)
+//   core/_utils/datetime/parse.js                    (gluedDateStrToMoment)
+//   core/streams/dao/index.js                        (getStreamRangeToken)
+//   common/middleware/passport-stream-token/service.js (parseStreamAndTime)
+// ---------------------------------------------------------------------------
+function parseFileNameAttrs (name) {
+    const nameArr = name.split('_');
+    function findStartsWith (symb) {
+        const item = nameArr.find((item, index) => index !== 0 && item.startsWith(symb));
+        return item ? item.slice(symb.length) : undefined;
+    }
+    const timeStr = findStartsWith('t');
+    return {
+        streamId: nameArr[0] && nameArr[0].length > 0 ? nameArr[0] : undefined,
+        time: timeStr ? { starts: timeStr.split('.')[0], ends: timeStr.split('.')[1] } : undefined
+    };
+}
+
+function gluedDateStrToMoment (dateStr) {
+    return moment(dateStr, 'YYYYMMDDTHHmmssSSSZ').utc();
+}
+
+function hashedCredentials (salt, msg) {
+    return crypto.createHash('sha256').update(salt + msg, 'utf8').digest('hex');
+}
+
+function getStreamRangeToken (stream, start, end, exp) {
+    const SALT = process.env.STREAM_TOKEN_SALT || 'random_string';
+    const message = (exp === undefined || exp === null)
+        ? `${stream}_${start}_${end}`
+        : `${stream}_${start}_${end}_${exp}`;
+    return hashedCredentials(SALT, message);
+}
+
+/** Exactly what passport-stream-token does for an /internal/assets/streams URL. */
+function mediaApiWouldAuthorise (url) {
+    const [path, qs] = url.replace('/media-api/internal/assets/streams/', '').split('?');
+    const query = Object.fromEntries(new URLSearchParams(qs));
+    const attrs = parseFileNameAttrs(path);
+    const stream = attrs.streamId;
+    const start = attrs.time && attrs.time.starts ? gluedDateStrToMoment(attrs.time.starts).valueOf() : undefined;
+    const end = attrs.time && attrs.time.ends ? gluedDateStrToMoment(attrs.time.ends).valueOf() : undefined;
+    if (!stream || !start || !end) return { ok: false, reason: 'ValidationError' };
+
+    let exp;
+    const rawExp = query.exp;
+    if (rawExp !== undefined && rawExp !== null && `${rawExp}` !== '') {
+        exp = Number(rawExp);
+        if (!Number.isInteger(exp) || exp * 1000 <= Date.now()) return { ok: false, reason: 'expired/malformed' };
+    }
+    const correct = getStreamRangeToken(stream, start, end, exp);
+    return { ok: correct === query['stream-token'], reason: 'digest', start, end, exp };
+}
+
+// ---------------------------------------------------------------------------
+// The client-side derivation the visualizer uses, transcribed from
+// arbimon packages/common/src/api-arbimon/audiodata/visualizer.ts
+// ---------------------------------------------------------------------------
+function clientTileWindow (baseMs, tile) {
+    return {
+        startMs: baseMs + Math.round(tile.s * 1000),
+        endMs: baseMs + Math.round((tile.s + tile.ds) * 1000)
+    };
+}
+
+/** The server-side mint, mirroring model/recordings.js attachTileMediaTokens. */
+function serverMintTile (streamId, baseMs, tile) {
+    const startMs = baseMs + Math.round(tile.s * 1000);
+    const endMs = baseMs + Math.round((tile.s + tile.ds) * 1000);
+    return mediaAssetUrl(streamId, startMs, endMs, 'placeholder.png');
+}
+
+function buildTileUrl (minted, palette) {
+    const asset = `z95_wdolph_g1_fspec_${palette}_d1023.255.png`;
+    return `/media-api/internal/assets/streams/${minted.mediaStreamId}_t${minted.mediaStart}Z.` +
+        `${minted.mediaEnd}Z_${asset}?stream-token=${minted.mediaToken}&exp=${minted.mediaExp}`;
+}
+
+// ---------------------------------------------------------------------------
+let failures = 0;
+let checked = 0;
+const PALETTES = ['mtrue', 'mfalse', 'mfalse_p2', 'mfalse_p3', 'mfalse_p4'];
+
+function rnd (a, b) { return a + Math.random() * (b - a); }
+
+console.log('--- FUZZ: minted tile tokens must verify against the window RE-PARSED FROM THE FILENAME ---');
+
+for (let i = 0; i < 2000; i++) {
+    // Realistic visualizer geometry: tiles are fractional-second offsets of a
+    // recording whose own start is an arbitrary wall-clock instant.
+    const baseMs = Date.UTC(2021, 3, 28, 14, 20, 0) + Math.floor(rnd(0, 6e10));
+    // tile.s / tile.ds come from pixels2Secs = duration/width — routinely
+    // irrational-looking fractions, which is the whole point.
+    const pixels2Secs = rnd(0.01, 0.9);
+    const tile = { s: rnd(0, 60) * pixels2Secs, ds: rnd(1, 400) * pixels2Secs };
+
+    const minted = serverMintTile('goexxd5oybrr', baseMs, tile);
+    assert.ok(minted, 'mint must succeed with a salt configured');
+
+    const shaped = {
+        mediaStreamId: 'goexxd5oybrr',
+        mediaStart: minted.startTs,
+        mediaEnd: minted.endTs,
+        mediaToken: minted.token,
+        mediaExp: minted.exp
+    };
+    const url = buildTileUrl(shaped, PALETTES[i % PALETTES.length]);
+
+    const verdict = mediaApiWouldAuthorise(url);
+    checked++;
+    if (!verdict.ok) {
+        failures++;
+        if (failures <= 3) {
+            console.log(`  FAIL: baseMs=${baseMs} s=${tile.s} ds=${tile.ds} reason=${verdict.reason}`);
+            console.log(`        url=${url}`);
+        }
+    }
+
+    // The server's signed window must ALSO equal what the client would have
+    // computed — otherwise the tile renders the wrong audio segment.
+    const cw = clientTileWindow(baseMs, tile);
+    if (cw.startMs !== minted.startMs || cw.endMs !== minted.endMs) {
+        failures++;
+        console.log(`  FAIL(window drift): client=${cw.startMs}..${cw.endMs} server=${minted.startMs}..${minted.endMs}`);
+    }
+}
+
+console.log(`fuzz: checked=${checked} failures=${failures}`);
+assert.strictEqual(failures, 0, 'every minted tile token must verify against the re-parsed filename');
+
+// ---------------------------------------------------------------------------
+// Negative controls — a harness that cannot FAIL proves nothing.
+// ---------------------------------------------------------------------------
+console.log('--- NEGATIVE CONTROLS (each MUST be rejected) ---');
+
+const baseMs = Date.UTC(2021, 3, 28, 14, 20, 0);
+const tile = { s: 12.3456, ds: 3.7891 };
+const good = serverMintTile('goexxd5oybrr', baseMs, tile);
+const goodShaped = {
+    mediaStreamId: 'goexxd5oybrr',
+    mediaStart: good.startTs,
+    mediaEnd: good.endTs,
+    mediaToken: good.token,
+    mediaExp: good.exp
+};
+
+assert.ok(mediaApiWouldAuthorise(buildTileUrl(goodShaped, 'mtrue')).ok, 'control: the good URL must verify');
+console.log('  ok: valid token verifies');
+
+// 1. Palette change must NOT break the signature (this is what lets the client choose).
+assert.ok(mediaApiWouldAuthorise(buildTileUrl(goodShaped, 'mfalse_p4')).ok,
+    'palette must not be part of the signature');
+console.log('  ok: palette swap still verifies (render params are unsigned by design)');
+
+// 2. Tampered window must fail.
+const tampered = { ...goodShaped, mediaEnd: good.endTs.replace(/\d{3}$/, '999') };
+assert.ok(!mediaApiWouldAuthorise(buildTileUrl(tampered, 'mtrue')).ok, 'a tampered window must 401');
+console.log('  ok: tampered end-time rejected');
+
+// 3. Tampered exp must fail.
+const expTamper = { ...goodShaped, mediaExp: goodShaped.mediaExp + 86400 };
+assert.ok(!mediaApiWouldAuthorise(buildTileUrl(expTamper, 'mtrue')).ok, 'an extended exp must 401');
+console.log('  ok: extended exp rejected');
+
+// 4. No token at all must fail.
+const noTok = { ...goodShaped, mediaToken: '' };
+assert.ok(!mediaApiWouldAuthorise(buildTileUrl(noTok, 'mtrue')).ok, 'a missing token must 401');
+console.log('  ok: missing token rejected');
+
+// 5. THE 2026-08-10 DEFECT ITSELF: signing the RAW fractional window while the
+//    filename carries the truncated one must be caught by this harness.
+(function provesTheHarnessCatchesTheKnownDefect () {
+    const fracBase = baseMs + 0; // integer base
+    const fracTile = { s: 1.0005, ds: 2.0007 }; // -> .5 / .7 fractional ms
+    const rawStart = fracBase + fracTile.s * 1000;          // 1000.5  (fractional!)
+    const rawEnd = fracBase + (fracTile.s + fracTile.ds) * 1000;
+    assert.ok(!Number.isInteger(rawStart), 'control setup: start must be fractional');
+    const exp = good.exp;
+    // Filename printed via Date() => TRUNCATED, token signed over RAW => mismatch
+    const d = new Date(rawStart);
+    const p = (n, w) => String(n).padStart(w || 2, '0');
+    const startTsTrunc = `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}T` +
+        `${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}${p(d.getUTCMilliseconds(), 3)}`;
+    const d2 = new Date(rawEnd);
+    const endTsTrunc = `${d2.getUTCFullYear()}${p(d2.getUTCMonth() + 1)}${p(d2.getUTCDate())}T` +
+        `${p(d2.getUTCHours())}${p(d2.getUTCMinutes())}${p(d2.getUTCSeconds())}${p(d2.getUTCMilliseconds(), 3)}`;
+    const badToken = getStreamRangeToken('goexxd5oybrr', rawStart, rawEnd, exp); // RAW — the bug
+    const badUrl = `/media-api/internal/assets/streams/goexxd5oybrr_t${startTsTrunc}Z.${endTsTrunc}Z_` +
+        `z95_wdolph_g1_fspec_mtrue_d1023.255.png?stream-token=${badToken}&exp=${exp}`;
+    assert.ok(!mediaApiWouldAuthorise(badUrl).ok,
+        'the harness MUST reject the 2026-08-10 fractional-ms construction');
+    console.log('  ok: reproduces + REJECTS the 2026-08-10 fractional-ms defect');
+})();
+
+console.log('\nALL VISUALIZER TILE TOKEN CHECKS PASSED ✅');

--- a/test/visualizer-tile-token/harness.js
+++ b/test/visualizer-tile-token/harness.js
@@ -308,4 +308,55 @@ console.log('  ok: missing token rejected');
     console.log('  ok: reproduces + REJECTS the external_id mis-derivation');
 })();
 
+// ---------------------------------------------------------------------------
+// The SAME class as the streamId bug, applied to the BASE TIMESTAMP.
+//
+// The server derives the window base with `moment.utc(recording.datetime_utc)`;
+// the browser derives it with `new Date(recording.datetime_utc)`. Two different
+// parsers reading one value — exactly the shape that produced both the
+// fractional-ms defect and the external_id defect.
+//
+// They agree for ISO-8601 with an explicit zone, and DISAGREE BY THE HOST TZ
+// OFFSET for a bare "YYYY-MM-DD HH:mm:ss" string (moment.utc reads it as UTC,
+// `new Date()` historically reads it as LOCAL). A bare string would silently
+// 401 every tile.
+//
+// We are safe TODAY only because config/db.json sets `timezone: "Z"` and the
+// mysql driver is NOT in `dateStrings` mode, so datetime_utc arrives as a JS
+// Date and serialises to ISO with a trailing Z. VERIFIED on the live demo pod
+// against the real driver: `{"datetime_utc":"2021-04-28T14:20:00.000Z"}`.
+//
+// That is a load-bearing config detail two layers away from this code, so pin
+// it here: if someone enables dateStrings or changes the pool timezone, this
+// fails loudly instead of blanking the visualizer.
+(function serverAndClientMustParseTheBaseTimestampIdentically () {
+    const isoShapes = [
+        '2021-04-28T14:20:00.000Z',
+        '2021-04-28T14:20:00Z',
+        '2026-01-01T00:00:00.000Z'
+    ];
+    isoShapes.forEach(function (s) {
+        assert.strictEqual(moment.utc(s).valueOf(), new Date(s).valueOf(),
+            'server moment.utc() and client new Date() must agree for: ' + s);
+    });
+    console.log('  ok: base timestamp parses identically server- and client-side (ISO w/ zone)');
+
+    // The REAL invariant: whatever shape reaches the client, both parsers must
+    // agree. Assert that directly on the shape the driver actually produces
+    // (a Date -> ISO-with-Z via JSON), rather than asserting that the bare form
+    // is ambiguous — that depends on the host TZ and is UTC-safe in-pod
+    // (pods run with TZ unset = UTC), so it cannot be a portable assertion.
+    const fromDriver = new Date(Date.UTC(2021, 3, 28, 14, 20, 0));
+    const onTheWire = JSON.parse(JSON.stringify({ d: fromDriver })).d;
+    assert.ok(/Z$/.test(onTheWire),
+        'datetime_utc must reach the client as ISO-8601 WITH a zone designator. ' +
+        'If this fails, the mysql driver has been switched to dateStrings or the ' +
+        'pool timezone changed — a bare "YYYY-MM-DD HH:mm:ss" is parsed as UTC by ' +
+        'moment.utc() (server) and as LOCAL by new Date() (browser), which 401s ' +
+        'every tile silently on any non-UTC client.');
+    assert.strictEqual(moment.utc(onTheWire).valueOf(), new Date(onTheWire).valueOf(),
+        'the wire shape must parse identically on both sides');
+    console.log('  ok: wire shape is ISO-with-zone (' + onTheWire + ') — pins db.json timezone:"Z" / no dateStrings');
+})();
+
 console.log('\nALL VISUALIZER TILE TOKEN CHECKS PASSED ✅');

--- a/test/visualizer-tile-token/harness.js
+++ b/test/visualizer-tile-token/harness.js
@@ -29,7 +29,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const moment = require('moment');
 
-const { mediaAssetUrl } = require('../app/utils/asset-url');
+const { mediaAssetUrl } = require('../../app/utils/asset-url');
 
 // ---------------------------------------------------------------------------
 // media-api's SIDE of the contract, transcribed from rfcx-api @ origin/master:
@@ -225,6 +225,87 @@ console.log('  ok: missing token rejected');
     assert.ok(!mediaApiWouldAuthorise(badUrl).ok,
         'the harness MUST reject the 2026-08-10 fractional-ms construction');
     console.log('  ok: reproduces + REJECTS the 2026-08-10 fractional-ms defect');
+})();
+
+// ---------------------------------------------------------------------------
+// STREAM-ID DERIVATION — the server MUST sign the same stream id the browser
+// puts in the filename.
+//
+// 🔴 This section calls the REAL `attachTileMediaTokens` from model/recordings.js
+// rather than re-implementing it. The fuzz above deliberately mirrors the mint
+// logic (so a bug in our helper can't cancel itself out), but that also means
+// it can NEVER catch a mistake in how the model picks the stream id. This did
+// happen: the first implementation preferred `sites.external_id`, which reads
+// as the authoritative value but is NOT what the client puts in the filename.
+//
+// Evidence (full-table scan 2026-08-10, 304,156,781 recordings): 49,249
+// non-legacy rows across 11 sites disagree -- 9,363 NULL external_id and
+// 39,886 genuinely different. Real projects affected: tech4nature-mexico
+// (14,352), green-and-golden-bell-frogs (7,073), workshop-arbimon (2,289),
+// nahuelbuta (59). Verified live on prod media-api: minting from external_id
+// returned 401, minting from the uri segment authenticated.
+//
+// A 401 tile is SILENT -- visualizer-tile-img.vue's onerror drops it and the
+// tile renders blank -- so only a test like this can catch a regression.
+(function streamIdMustMatchTheClientDerivation () {
+    const recordings = require('../../app/model/recordings');
+
+    // REAL divergent rows observed in production.
+    const cases = [
+        {   name: 'nahuelbuta (external_id differs from uri segment)',
+            uri: '2020/12/10/3qxwx34vyovi/002ac71c-5825-47bf-a778-ff33d587316d.opus',
+            external_id: 'rj83wlyqyx3d', expected: '3qxwx34vyovi' },
+        {   name: 'tech4nature-mexico (differs)',
+            uri: '2024/05/02/p2gi3vshr6k0/aaaaaaaa-0000-0000-0000-000000000000.flac',
+            external_id: 'tz0xjytraxag', expected: 'p2gi3vshr6k0' },
+        {   name: 'green-and-golden-bell-frogs (external_id NULL)',
+            uri: '2025/12/01/79nm6fpzuybk/7d0aee78-0d59-418b-a20b-0551029bdd8d.flac',
+            external_id: null, expected: '79nm6fpzuybk' },
+        {   name: "site carrying the literal string 'undefined' (truthy -> would win a ||)",
+            uri: '2023/01/01/selblm7pnz1n/bbbbbbbb-0000-0000-0000-000000000000.flac',
+            external_id: 'undefined', expected: 'selblm7pnz1n' },
+        {   name: 'aligned row (the common case) still works',
+            uri: '2026/02/23/3hg6xt6309lv/2f09539f-641d-48a1-8b59-72687f57d532.flac',
+            external_id: '3hg6xt6309lv', expected: '3hg6xt6309lv' }
+    ];
+
+    cases.forEach(function (c) {
+        const recording = {
+            uri: c.uri,
+            external_id: c.external_id,
+            datetime_utc: '2020-12-10T00:00:00.000Z'
+        };
+        const tiles = [{ s: 0, ds: 5.9678 }];
+        recordings.attachTileMediaTokens(recording, tiles);
+        const t = tiles[0];
+        assert.ok(t.mediaToken, 'a token must be minted for: ' + c.name);
+        assert.strictEqual(t.mediaStreamId, c.expected,
+            'stream id must come from uri.split("/")[3], not external_id — ' + c.name);
+
+        // End-to-end: the token must verify against the filename the CLIENT
+        // builds, which always uses the uri-derived id.
+        const clientUrl = '/media-api/internal/assets/streams/' +
+            c.expected + '_t' + t.mediaStart + 'Z.' + t.mediaEnd + 'Z_' +
+            'z95_wdolph_g1_fspec_mtrue_d1023.255.png' +
+            '?stream-token=' + t.mediaToken + '&exp=' + t.mediaExp;
+        assert.ok(mediaApiWouldAuthorise(clientUrl).ok,
+            'minted token must authorise the URL the client actually requests — ' + c.name);
+    });
+    console.log('  ok: stream id is derived as the client does (' + cases.length + ' real prod shapes)');
+
+    // Prove this section can FAIL: minting from external_id must NOT authorise
+    // the client's URL for a divergent row.
+    const divergent = cases[0];
+    const startMs = moment.utc('2020-12-10T00:00:00.000Z').valueOf();
+    const endMs = startMs + Math.round(5.9678 * 1000);
+    const wrong = mediaAssetUrl(divergent.external_id, startMs, endMs, 'placeholder.png');
+    const wrongUrl = '/media-api/internal/assets/streams/' +
+        divergent.expected + '_t' + wrong.startTs + 'Z.' + wrong.endTs + 'Z_' +
+        'z95_wdolph_g1_fspec_mtrue_d1023.255.png' +
+        '?stream-token=' + wrong.token + '&exp=' + wrong.exp;
+    assert.ok(!mediaApiWouldAuthorise(wrongUrl).ok,
+        'the harness MUST reject a token minted from external_id on a divergent row');
+    console.log('  ok: reproduces + REJECTS the external_id mis-derivation');
 })();
 
 console.log('\nALL VISUALIZER TILE TOKEN CHECKS PASSED ✅');

--- a/test/visualizer-tile-token/harness.js
+++ b/test/visualizer-tile-token/harness.js
@@ -359,4 +359,28 @@ console.log('  ok: missing token rejected');
     console.log('  ok: wire shape is ISO-with-zone (' + onTheWire + ') — pins db.json timezone:"Z" / no dateStrings');
 })();
 
+// ---------------------------------------------------------------------------
+// A REFACTOR TRAP worth pinning: the end offset MUST be computed as
+//     Math.round((tile.s + tile.ds) * 1000)
+// and NOT as
+//     Math.round(tile.s * 1000) + Math.round(tile.ds * 1000)
+//
+// The two look algebraically identical and differ in ~25% of real inputs by
+// exactly 1 ms — which is a guaranteed 401, silently. The server must mirror
+// the client's expression character-for-character; "simplifying" it is a
+// production outage that no page-looks-fine check would catch.
+(function endOffsetExpressionMustNotBeSimplified () {
+    let differ = 0;
+    for (let i = 0; i < 50000; i++) {
+        const s = Math.random() * 60;
+        const ds = Math.random() * 12;
+        if (Math.round((s + ds) * 1000) !== Math.round(s * 1000) + Math.round(ds * 1000)) differ++;
+    }
+    assert.ok(differ > 0,
+        'expected the two rounding forms to differ — if they never do, re-derive ' +
+        'this rather than deleting the guard');
+    console.log('  ok: round((s+ds)*1000) != round(s)+round(ds) in ~' +
+        (differ / 500).toFixed(0) + '% of cases — do NOT "simplify" the end offset');
+})();
+
 console.log('\nALL VISUALIZER TILE TOKEN CHECKS PASSED ✅');


### PR DESCRIPTION
Moves the audio **visualizer** — the last significant caller — off the arbimon-legacy media proxy and onto the direct `/media-api/*` route. Tracker: rfcx-local **OPEN-ITEMS #99**.

Pairs with arbimon (SPA) PR: the client change consumes the fields added here. **Safe to merge in either order** — the client falls back to the proxy when the fields are absent, and the server's fields are simply unused until the client ships.

## Why this caller needed a different shape

Every other caller mints server-side in `roiSpectrogramUrl()`. The visualizer builds its tile URLs **in the browser**, one per tile, and a token can't be minted there because `STREAM_TOKEN_SALT` must never reach the client. So tiles have to arrive already signed.

Minting happens in `fetchSpectrogramTiles()` — it already computes tile geometry and is reached only from session-gated `/legacy-api/project/*` endpoints. **That placement is the authorisation decision.**

The server attaches `token`/`exp`/`start`/`end` per tile rather than a finished URL, because the palette (`mtrue`/`mfalse_p2`/…) is a per-user *browser* setting the server can't know. That's safe because the token binds the **source window** (stream+start+end+exp), not the render parameters.

## The trap this was designed against

media-api does not trust any window the caller sends — `passport-stream-token` re-derives start/end by **parsing them back out of the filename**. On 2026-08-10 the ROI switch signed a raw fractional millisecond while the filename carried the truncated one, and 9 of 10 images 401'd.

`mediaAssetUrl()` now rounds **once** and derives both the filename timestamps and the signature from those same integers, so there is no code path where they can disagree. `roiSpectrogramUrl()` was refactored onto the same helper so the two paths can't drift.

## Verification

Per the standing lesson — **fuzz the derivation, don't sample it** (the ROI defect passed an offline harness, a live fetch *and* a real-browser render because the one sampled ROI happened to land on a whole millisecond):

- **Refactor is behaviour-preserving:** 10,000 randomised ROIs vs the deployed `origin/master` implementation — **0** URL mismatches, **0** token mismatches.
- **Fuzz:** 2,000 randomised fractional tile geometries minted, then verified against the window **re-parsed from the filename** using media-api's own transcribed parser+signer — **0 failures**. The harness reproduces *and rejects* the 2026-08-10 construction, so it can actually fail.
- **Live, anonymous, real recording** 32549233 (60s, 11 tiles, real tiler geometry), PNG magic bytes checked rather than just status codes:
  - `demo.arbimon.org` **11/11 200 image/png, 0 broken**
  - `arbimon.org` **11/11 200 image/png, 0 broken**
- **Live negative matrix on real media-api — 9/9:** no token `401` | empty token `401` | forged token `401` | extended exp `401` | past exp `401` | malformed exp `401` (fails closed) | **palette swap `200`** | different window, same token `401`.
- **Cache stability:** two independent mint runs → byte-identical tokens/exp/windows within the hour bucket.
- **Fail-soft, exercised in-pod:** legacy recording, missing datetime, empty/null tileset, `external_id` vs uri-derived id. Confirmed it uses `datetime_utc`, **not** the 3h-shifted `datetime` (recording 32549233 is 11:20 local / 14:20 UTC).
- Existing `p6-pod-kill-net` harness still **21/21**.

## Notes

- The proxy route is unchanged and still works; it stays until the remaining callers move (`recordings.js` thumbnails, `models.js`, `project/classifications.js`, `project/templates.js`).
- **Not introduced here:** a pre-existing media-api render limit — sox refuses `-x` < 100, so a very narrow tile (`d45.255`) 500s. The client hardcodes `d1023.255` for every tile, so it isn't reachable from the visualizer; flagged for whoever generalises tile widths.

⚠️ **Release discipline:** this is an arbimon-legacy release — it restarts the mysql2pg **O5 clock** (#40) and needs the **four-pin roll via `scripts/four-pin-roll.sh`** (the four pins do *not* all use the same image; `arbimon-export-consumer` + `arbimon-export-reconciler` run `arbimon-recording-export-job`). Soak-check the workers afterwards.