### PR TITLE
fix: derive media-api stream ids from the recording uri, not sites.external_id

### DIFF
--- a/app/model/clustering-jobs.js
+++ b/app/model/clustering-jobs.js
@@ -120,7 +120,7 @@ select.push(
         if (withSpectroCols) {
             tables.push("JOIN recordings RSPEC ON A.recording_id = RSPEC.recording_id");
             tables.push("JOIN sites SSPEC ON SSPEC.site_id = RSPEC.site_id");
-            select.push("SSPEC.external_id as external_id, RSPEC.datetime_utc as datetime_utc");
+            select.push("SSPEC.external_id as external_id, RSPEC.uri as rec_uri, RSPEC.datetime_utc as datetime_utc");
             // Needed by the SPA 'expand' modal to frame a padded full-band
             // window: sample_rate -> nyquist (freq axis), duration -> clamp
             // the padded window. Cheap columns on the already-joined RSPEC.
@@ -200,6 +200,8 @@ select.push(
                     // ROI, so these thumbs SHARE cached objects rather than
                     // populating a second 600x256 copy.
                     roi.spectrogram_url = roiSpectrogramUrl({
+                        // uri-first stream id (OPEN-ITEMS #107)
+                        recUri: roi.rec_uri,
                         externalId: roi.external_id,
                         datetimeUtc: roi.datetime_utc,
                         timeMin: roi.time_min,

--- a/app/model/pattern_matchings.js
+++ b/app/model/pattern_matchings.js
@@ -890,7 +890,10 @@ var PatternMatchings = {
         // (every PM ROI has a recording, which has a site — verified live: 0
         // orphans in 1M sampled rows), so the row count is unchanged.
         return dbpool.query(
-            "SELECT PMR.*, S.external_id, R.datetime_utc, R.sample_rate\n" +
+            // `R.uri as rec_uri` (NOT plain `uri` — PMR.* already carries the
+            // stored-PNG `uri` column) feeds the uri-first stream derivation
+            // in combineRoiSpectrogramUrl (OPEN-ITEMS #107).
+            "SELECT PMR.*, S.external_id, R.uri as rec_uri, R.datetime_utc, R.sample_rate\n" +
             `FROM pattern_matching_rois PMR\n` +
             "JOIN recordings R ON R.recording_id = PMR.recording_id\n" +
             "JOIN sites S ON S.site_id = R.site_id\n" +
@@ -916,7 +919,9 @@ var PatternMatchings = {
         // every branch, since all three call getRoiUrl(). Joins are INNER on
         // recording->site (guaranteed present) so row counts are unchanged;
         // WHERE clauses are qualified to PMR now that the table is aliased.
-        const base = `SELECT PMR.*, S.external_id, R.datetime_utc, R.sample_rate
+        // `R.uri as rec_uri` on every branch: uri-first stream derivation
+        // (OPEN-ITEMS #107). Aliased because PMR.* carries the stored-PNG `uri`.
+        const base = `SELECT PMR.*, S.external_id, R.uri as rec_uri, R.datetime_utc, R.sample_rate
                 FROM pattern_matching_rois PMR
                 JOIN recordings R ON R.recording_id = PMR.recording_id
                 JOIN sites S ON S.site_id = R.site_id`;
@@ -935,7 +940,7 @@ var PatternMatchings = {
         if (options.recId && options.validated) {
             return dbpool.query(
                 { sql: `SELECT PMR.*, SP.scientific_name as species_name, ST.songtype as songtype_name,
-                S.external_id, R.datetime_utc, R.sample_rate
+                S.external_id, R.uri as rec_uri, R.datetime_utc, R.sample_rate
                 FROM pattern_matching_rois PMR
                 JOIN species SP ON PMR.species_id = SP.species_id
                 JOIN songtypes ST ON PMR.songtype_id = ST.songtype_id
@@ -1011,6 +1016,12 @@ var PatternMatchings = {
      */
     combineRoiSpectrogramUrl: function(roi) {
         return roiSpectrogramUrl({
+            // uri-first stream id (OPEN-ITEMS #107): `rec_uri` from the
+            // PMR.*-shaped queries (getRoi/getPatternMatchingRois), `recording`
+            // from buildRoisQuery/pmrSqlSelect (still the FULL uri here —
+            // completePMRResults truncates it to the basename only AFTER
+            // getRoiUrl has run). external_id stays as the fallback.
+            recUri: roi.rec_uri || roi.recording,
             externalId: roi.external_id,
             datetimeUtc: roi.datetime_utc,
             timeMin: roi.x1,

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -19,7 +19,7 @@ const projectModel = require('./projects')
 const classificationsModel = require('./classifications')
 const tagsModel = require('./tags')
 const soundscapeCompositionModel = require('./soundscape-composition')
-const { arbimon2PublicUrl, mediaAssetUrl } = require('../utils/asset-url')
+const { arbimon2PublicUrl, mediaAssetUrl, mediaStreamId } = require('../utils/asset-url')
 
 var config       = require('../config');
 const { coreApiBaseUrl } = require('../utils/core-api-url');
@@ -443,7 +443,11 @@ var Recordings = {
                         d.legacy = Recordings.isLegacy(d);
                         d.meta = d.meta ? Recordings.__parse_meta_data(d.meta) : null;
                         d.file = d.meta && d.meta.filename? d.meta.filename : d.file;
-                        d.explorerUrl = d.legacy ? null : `${rfcxConfig.explorerBaseUrl}/explorer/${d.external_id}` + (d.datetime_utc ? `?t=${moment(d.datetime_utc).format('YYYYMMDDTHHmmssSSS')}Z` : '');
+                        // uri-first stream id (OPEN-ITEMS #107): external_id is wrong/NULL
+                        // for 11 sites, which pointed this link at a different (or
+                        // deleted) stream in Explorer.
+                        const explorerStreamId = d.legacy ? null : mediaStreamId(d.uri, d.external_id);
+                        d.explorerUrl = explorerStreamId ? `${rfcxConfig.explorerBaseUrl}/explorer/${explorerStreamId}` + (d.datetime_utc ? `?t=${moment(d.datetime_utc).format('YYYYMMDDTHHmmssSSS')}Z` : '') : null;
                     })
                     return data;
                 }
@@ -668,7 +672,15 @@ var Recordings = {
         const dateFormat = 'YYYYMMDDTHHmmssSSS'
         const start = momentStart.format(dateFormat)
         const end = momentEnd.format(dateFormat)
-        return `${recording.external_id}_t${start}Z.${end}Z_${asset}`
+        // Stream id from the recording's own uri, external_id as fallback —
+        // NOT external_id-first. external_id is stale/NULL/'undefined' for 11
+        // sites (49,249 recordings, OPEN-ITEMS #107) and every one of their
+        // core segments is owned by the URI's stream. This was the defect that
+        // broke audio/spectrograms/templates for tech4nature-mexico,
+        // green-and-golden-bell-frogs, workshop-arbimon and nahuelbuta.
+        // Same derivation as attachTileMediaTokens — keep them identical.
+        const streamId = mediaStreamId(recording.uri, recording.external_id)
+        return `${streamId}_t${start}Z.${end}Z_${asset}`
     },
 
     /** Per-VARIANT tmpfilecache key.
@@ -1067,7 +1079,15 @@ var Recordings = {
             // seg4 `3qxwx34vyovi` vs external_id `rj83wlyqyx3d`): a token minted
             // from external_id -> 401 (rejected); from the uri segment -> auth
             // accepted. Keep this derivation identical to the client's.
-            const streamId = recording.uri.split('/')[3];
+            //
+            // NO external_id fallback HERE, on purpose (unlike
+            // buildMediaApiAttr): the BROWSER builds the tile filename from
+            // uri.split('/')[3] on its own, so a server-side fallback would
+            // sign a DIFFERENT id than the filename carries — guaranteed 401
+            // — whereas minting nothing degrades to the session-gated proxy.
+            // mediaStreamId(uri, null) == uri.split('/')[3] plus the
+            // 'undefined'-string guard (site 43570).
+            const streamId = mediaStreamId(recording.uri, null);
             if (!streamId) return;
             // MUST be datetime_utc: `datetime` is the denormalised, TZ-shifted
             // local time and would put the window hours off.
@@ -1521,7 +1541,12 @@ var Recordings = {
             const dateFormat = 'YYYYMMDDTHHmmssSSS'
             const start = momentStart.format(dateFormat)
             const end = momentEnd.format(dateFormat)
-            recording.thumbnail = `/legacy-api/ingest/recordings/${site.external_id}_t${start}Z.${end}Z_z95_wdolph_g1_fspec_mtrue_d420.154.png`
+            // uri-first stream id (site.external_id is wrong/NULL for 11 sites
+            // — OPEN-ITEMS #107; same derivation as buildMediaApiAttr).
+            const streamId = mediaStreamId(recording.uri, site && site.external_id)
+            recording.thumbnail = streamId
+                ? `/legacy-api/ingest/recordings/${streamId}_t${start}Z.${end}Z_z95_wdolph_g1_fspec_mtrue_d420.154.png`
+                : null
         }
     },
     __compute_spectrogram_tiles : function(recording, callback){

--- a/app/model/templates.js
+++ b/app/model/templates.js
@@ -154,6 +154,8 @@ var Templates = {
                 var r = rows[i];
                 var dyn = (r.dynRecUri && String(r.dynRecUri).indexOf('project_') !== 0)
                     ? roiSpectrogramUrl({
+                        // uri-first stream id (OPEN-ITEMS #107)
+                        recUri: r.dynRecUri,
                         externalId: r.dynExternalId,
                         datetimeUtc: r.dynDatetimeUtc,
                         timeMin: Math.min(r.x1, r.x2),
@@ -269,6 +271,8 @@ var Templates = {
                 var r = rows[i];
                 var dyn = (r.dynRecUri && String(r.dynRecUri).indexOf('project_') !== 0)
                     ? roiSpectrogramUrl({
+                        // uri-first stream id (OPEN-ITEMS #107)
+                        recUri: r.dynRecUri,
                         externalId: r.dynExternalId,
                         datetimeUtc: r.dynDatetimeUtc,
                         timeMin: Math.min(r.x1, r.x2),

--- a/app/model/training_sets.js
+++ b/app/model/training_sets.js
@@ -675,7 +675,7 @@ TrainingSets.types.roi_set = {
         if (withSpectro) {
             tables.push("JOIN recordings RSPEC ON RSPEC.recording_id = TSD.recording_id");
             tables.push("JOIN sites SSPEC ON SSPEC.site_id = RSPEC.site_id");
-            fields.push("SSPEC.external_id as external_id", "RSPEC.datetime_utc as datetime_utc");
+            fields.push("SSPEC.external_id as external_id", "RSPEC.uri as rec_uri", "RSPEC.datetime_utc as datetime_utc");
             // Needed by the SPA 'expand' modal to frame a padded full-band
             // window: sample_rate -> nyquist (freq axis), duration -> clamp
             // the padded window. Cheap columns on the already-joined RSPEC.
@@ -686,6 +686,8 @@ TrainingSets.types.roi_set = {
             if (!err && withSpectro && Array.isArray(rows)) {
                 for (var i = 0; i < rows.length; i++) {
                     rows[i].spectrogram_url = roiSpectrogramUrl({
+                        // uri-first stream id (OPEN-ITEMS #107)
+                        recUri: rows[i].rec_uri,
                         externalId: rows[i].external_id,
                         datetimeUtc: rows[i].datetime_utc,
                         timeMin: rows[i].x1,

--- a/app/routes/data-api/models.js
+++ b/app/routes/data-api/models.js
@@ -9,7 +9,7 @@ const q = require('q');
 const model = require('../../model');
 const pokeDaMonkey = require('../../utils/monkey');
 const config = require('../../config');
-const { arbimon2PublicUrl } = require('../../utils/asset-url');
+const { arbimon2PublicUrl, mediaStreamId } = require('../../utils/asset-url');
 const APIError = require('../../utils/apierror');
 const router = express.Router();
 const { createS3Client } = require('../../utils/storage');
@@ -333,8 +333,11 @@ async function getModelsData(validationUri, limit, offset) {
                     // 0.54-0.86 source px per displayed px while wasting 5.12x
                     // vertical resolution. Keeping the two endpoints on the SAME
                     // geometry also keeps them sharing one cache object per window.
-                    recUrl = siteExternalId
-                        ? `/legacy-api/ingest/recordings/${siteExternalId}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png`
+                    // uri-first stream id (site external_id is wrong/NULL for 11
+                    // sites — OPEN-ITEMS #107; same derivation as buildMediaApiAttr).
+                    const streamId = mediaStreamId(recording.uri, siteExternalId)
+                    recUrl = streamId
+                        ? `/legacy-api/ingest/recordings/${streamId}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png`
                         : null
                 }
                 rowSent.push({

--- a/app/routes/data-api/project/classifications.js
+++ b/app/routes/data-api/project/classifications.js
@@ -8,7 +8,7 @@ const { createS3Client } = require('../../../utils/storage');
 const config = require('../../../config');
 const model = require('../../../model');
 const pokeDaMonkey = require('../../../utils/monkey');
-const { arbimon2PublicUrl } = require('../../../utils/asset-url');
+const { arbimon2PublicUrl, mediaStreamId } = require('../../../utils/asset-url');
 const router = express.Router();
 const moment = require('moment');
 const { httpErrorHandler } = require('@rfcx/http-utils');
@@ -97,7 +97,12 @@ router.get('/:classiId/more/:from/:total', function(req, res, next) {
                     // from 7.85x to 1.23x -- AND it is SMALLER on the wire:
                     // 94,164 B vs 140,366 B (-33%), because the wasted vertical
                     // pixels cost more than the added horizontal ones.
-                    classiInfo.rec_image_url = `/legacy-api/ingest/recordings/${site[0].external_id}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png`
+                    // uri-first stream id (site external_id is wrong/NULL for 11 sites
+                    // — OPEN-ITEMS #107; same derivation as buildMediaApiAttr).
+                    const streamId = mediaStreamId(recording.uri, site && site[0] && site[0].external_id)
+                    classiInfo.rec_image_url = streamId
+                        ? `/legacy-api/ingest/recordings/${streamId}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png`
+                        : null
                 }
                 delete classiInfo.uri;
             }

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -95,6 +95,52 @@ function trimTrailingSlash (s) {
 }
 
 /**
+ * THE stream-id derivation. One function, used by every URL builder.
+ *
+ * Derives the core media-api stream id for a recording, preferring the 4th
+ * segment of the recording's own `uri` (`YYYY/MM/DD/<streamId>/<segUuid>.flac`)
+ * over `sites.external_id`.
+ *
+ * WHY URI-FIRST (OPEN-ITEMS #107, measured live 2026-08-10): the two disagree
+ * for 49,249 recordings across 11 sites (9,363 NULL external_id + 39,886
+ * genuinely different), and a bulk join of every one of those recordings'
+ * uri-filename UUIDs against core `stream_segments` proved the segment is
+ * owned by the URI's stream — NEVER by external_id's — for 100% of the rows
+ * that have segments at all. `sites.external_id` is a per-SITE column that
+ * goes stale when a site aggregates multiple stream deployments (site 35021
+ * carries TWO streams; one column cannot name both) or was never backfilled
+ * (NULL). The recording's uri names the stream that actually owns its bytes.
+ *
+ * The `externalId` fallback exists for rows whose uri cannot yield a segment
+ * (legacy `project_*` uris handled by callers; malformed/short uris) — for
+ * the 99.983% of the corpus where both agree it changes nothing.
+ *
+ * ⚠ THE LITERAL STRING 'undefined' IS NOT AN ID. Site 43570 stores it (a
+ * failed-ingest artifact); it is truthy, so a naive `a || b` picks it and
+ * signs/fetches it verbatim. Filter it on BOTH inputs.
+ *
+ * DO NOT "simplify" this back to external_id-first: that was the defect
+ * (`buildMediaApiAttr` pre-2026-08) — it broke audio, spectrograms, template
+ * crops and thumbnails for tech4nature-mexico, green-and-golden-bell-frogs,
+ * workshop-arbimon and nahuelbuta.
+ */
+// Standard ingest key shape: YYYY/MM/DD/<streamId>/<file>. Only a uri of
+// this shape is allowed to nominate its 4th segment as the stream id — an
+// unrecognised shape falls back to external_id instead of yielding a date
+// fragment or filename as a "stream id". (Verified live 2026-08-10: 3M-row
+// sample of non-legacy uris = 100% this shape, 0 odd.)
+var STREAM_URI_SHAPE = /^\d{4}\/\d{2}\/\d{2}\/([^/]+)\/[^/]+$/;
+
+function mediaStreamId (uri, externalId) {
+    if (typeof uri === 'string' && uri.indexOf('project_') !== 0) {
+        const m = STREAM_URI_SHAPE.exec(uri);
+        if (m && m[1] !== 'undefined') return m[1];
+    }
+    if (externalId && externalId !== 'undefined') return externalId;
+    return null;
+}
+
+/**
  * Returns the public URL base (no trailing slash) for the arbimon2
  * bucket. Read from `ARBIMON2_PUBLIC_URL_BASE` or, if unset, falls
  * back to the rfcx-local default.
@@ -245,7 +291,8 @@ function mediaAssetUrl (streamId, rawStartMs, rawEndMs, asset) {
  * and MUST NOT fall back to the cached detection PNG.
  *
  * @param {object} roi
- * @param {string} roi.externalId  stream external id
+ * @param {string} [roi.recUri]     recording uri (PREFERRED stream-id source — see mediaStreamId)
+ * @param {string} [roi.externalId] site external id (fallback stream-id source)
  * @param {string|Date} roi.datetimeUtc  recording start (UTC)
  * @param {number} roi.timeMin  ROI start, seconds into the recording
  * @param {number} roi.timeMax  ROI end, seconds into the recording
@@ -257,7 +304,13 @@ function mediaAssetUrl (streamId, rawStartMs, rawEndMs, asset) {
  * @param {number} [opts.height=256]
  */
 function roiSpectrogramUrl (roi, opts) {
-    if (!roi || !roi.externalId) return null;
+    if (!roi) return null;
+    // One derivation everywhere: uri-segment first, external_id fallback
+    // (see mediaStreamId above — external_id is wrong/NULL for 11 sites).
+    // Callers that can project the recording uri pass it as roi.recUri;
+    // callers that cannot still work exactly as before via the fallback.
+    const streamId = mediaStreamId(roi.recUri, roi.externalId);
+    if (!streamId) return null;
     const base = roi.datetimeUtc;
     if (!base) return null;
     const baseMs = new Date(base).getTime();
@@ -309,13 +362,13 @@ function roiSpectrogramUrl (roi, opts) {
     // FALLS BACK to the session-gated proxy when the salt is unset, so a
     // misconfigured environment degrades to the (still authenticated) legacy
     // path rather than emitting URLs that would 401.
-    const minted = mediaAssetUrl(roi.externalId, rawStartMs, rawEndMs, asset);
+    const minted = mediaAssetUrl(streamId, rawStartMs, rawEndMs, asset);
     if (minted) {
         return minted.url;
     }
     // Salt unset — fall back to the session-gated proxy. Derive the same attr
     // from the same rounded integers so the two paths stay byte-identical.
-    const attr = `${roi.externalId}_t${gluedUtcTimestamp(Math.round(rawStartMs))}Z.` +
+    const attr = `${streamId}_t${gluedUtcTimestamp(Math.round(rawStartMs))}Z.` +
         `${gluedUtcTimestamp(Math.round(rawEndMs))}Z_${asset}`;
     return `/legacy-api/ingest/recordings/${attr}`;
 }
@@ -324,6 +377,7 @@ module.exports = {
     mediaStreamToken,
     mediaAssetExpiry,
     mediaAssetUrl,
+    mediaStreamId,
     gluedUtcTimestamp,
     MEDIA_ASSET_PATH,
     arbimon2PublicUrl,

--- a/app/utils/spectro-cache-key.selftest.js
+++ b/app/utils/spectro-cache-key.selftest.js
@@ -48,7 +48,13 @@ function buildMediaApiAttr (recording, type, options) {
         momentEnd = momentStart.clone().add(trimDuration, 'seconds');
     }
     const dateFormat = 'YYYYMMDDTHHmmssSSS';
-    return `${recording.external_id}_t${momentStart.format(dateFormat)}Z.${momentEnd.format(dateFormat)}Z_${asset}`;
+    // Lockstep with asset-url.js mediaStreamId: shape-validated uri segment
+    // first, external_id fallback, 'undefined' never usable — OPEN-ITEMS #107.
+    const m = (typeof recording.uri === 'string' && recording.uri.indexOf('project_') !== 0)
+        ? /^\d{4}\/\d{2}\/\d{2}\/([^/]+)\/[^/]+$/.exec(recording.uri) : null;
+    const streamId = (m && m[1] !== 'undefined') ? m[1]
+        : ((recording.external_id && recording.external_id !== 'undefined') ? recording.external_id : null);
+    return `${streamId}_t${momentStart.format(dateFormat)}Z.${momentEnd.format(dateFormat)}Z_${asset}`;
 }
 
 function buildAssetCacheKey (recording, variant, ext) {
@@ -65,7 +71,9 @@ function hash_key (key) {
 
 // ---------------------------------------------------------------- fixtures
 const rec = {
-    uri: 'streams/aBc123XyZ/2026/07/13/aBc123XyZ_t20260713T000000000Z.wav',
+    // Standard ingest key shape (YYYY/MM/DD/<streamId>/<file>) so the uri-first
+    // stream derivation resolves; uri segment == external_id (the 99.983% case).
+    uri: '2026/07/13/aBc123XyZ/aBc123XyZ_t20260713T000000000Z.wav',
     external_id: 'aBc123XyZ',
     datetime: '2026-07-13 00:00:00',
     datetime_utc: '2026-07-13 00:00:00',

--- a/test/media-stream-id/harness.js
+++ b/test/media-stream-id/harness.js
@@ -1,0 +1,143 @@
+/**
+ * Regression harness for the STREAM-ID DERIVATION (OPEN-ITEMS #107).
+ *
+ * THE DEFECT CLASS: two independent code paths deciding "which stream is this
+ * recording?" differently. `buildMediaApiAttr()` used `sites.external_id`;
+ * `attachTileMediaTokens()` used `uri.split('/')[3]`. They disagree for
+ * 49,249 production recordings across 11 sites (measured 2026-08-10):
+ * external_id can be stale (site aggregates several stream deployments), NULL
+ * (never backfilled), the literal string 'undefined' (failed ingest), or name
+ * a soft-deleted stream. A bulk join of every divergent recording's
+ * uri-filename UUID against core `stream_segments` proved the segment is owned
+ * by the URI's stream — never external_id's — for 100% of rows with segments.
+ *
+ * THE FIX: one derivation — `mediaStreamId(uri, externalId)` in
+ * app/utils/asset-url.js — uri-segment first (shape-validated), external_id
+ * fallback, 'undefined' never usable. Every URL builder now flows through it.
+ *
+ * WHY REAL FUNCTIONS + REAL ROW SHAPES: the fixtures below are the actual
+ * production shapes of the 11 affected sites (ids included, values verbatim
+ * from the 2026-08-10 measurement). The harness calls the REAL exported
+ * functions, and includes CONTROLS that assert the OLD behaviour would fail —
+ * so it fails on any revert to external_id-first ("tidying" this back is the
+ * standing risk the fix's comments warn about).
+ */
+process.env.STREAM_TOKEN_SALT = process.env.STREAM_TOKEN_SALT || 'test_salt_stream_id_harness';
+
+const assert = require('assert');
+const { mediaStreamId, roiSpectrogramUrl } = require('../../app/utils/asset-url');
+const recordings = require('../../app/model/recordings');
+
+let passed = 0;
+function ok (name, fn) { fn(); passed++; console.log('  ok -', name); }
+
+console.log('media-stream-id harness');
+
+// ---------------------------------------------------------------- fixtures
+// Real production shapes (2026-08-10 measurement, OPEN-ITEMS #107):
+const CASES = [
+    // site 8062 nahuelbuta: stale external_id (points at 0-segment sibling)
+    { site: 8062,  uri: '2015/01/01/3qxwx34vyovi/a35152a4-73a6-44f2-b874-3c4893268458.opus',
+      external_id: 'rj83wlyqyx3d', want: '3qxwx34vyovi' },
+    // site 31491 workshop-arbimon: NULL external_id
+    { site: 31491, uri: '2021/04/12/WGwJJYGoDZrt/01156080-9496-4165-a652-103c464da248.flac',
+      external_id: null, want: 'WGwJJYGoDZrt' },
+    // site 43570: the literal STRING 'undefined' — truthy, must never win
+    { site: 43570, uri: '2023/07/21/undefined/undefined.flac',
+      external_id: 'undefined', want: null },
+    // site 43570's one good recording: valid uri beats the bad external_id
+    { site: 43570, uri: '2022/05/18/selblm7pnz1n/a4f49c20-bb8d-407e-8273-51cbcaf578b1.flac',
+      external_id: 'undefined', want: 'selblm7pnz1n' },
+    // site 36114 tech4nature: external_id names a soft-deleted stream
+    { site: 36114, uri: '2022/07/20/p2gi3vshr6k0/07f52877-5bfd-4541-bffc-1ba7fc13ed24.flac',
+      external_id: 'tz0xjytraxag', want: 'p2gi3vshr6k0' },
+    // the 99.983% case: both agree — derivation change is a no-op
+    { site: 0, uri: '2022/02/10/s4dcrtuk5gfi/aaaaaaaa-0000-0000-0000-000000000000.flac',
+      external_id: 's4dcrtuk5gfi', want: 's4dcrtuk5gfi' },
+];
+
+ok('mediaStreamId: every production divergence case resolves to the URI stream', function () {
+    for (const c of CASES) {
+        assert.strictEqual(mediaStreamId(c.uri, c.external_id), c.want,
+            `site ${c.site}: uri=${c.uri} ext=${c.external_id}`);
+    }
+});
+
+ok('mediaStreamId: legacy project_* uri falls back to external_id', function () {
+    assert.strictEqual(mediaStreamId('project_123/site_1/x.flac', 'realid99'), 'realid99');
+    assert.strictEqual(mediaStreamId('project_123/site_1/x.flac', null), null);
+});
+
+ok('mediaStreamId: non-standard uri shape cannot nominate a bogus segment', function () {
+    // a malformed uri must not yield a date fragment / filename as stream id
+    assert.strictEqual(mediaStreamId('2022/07/20', 'fallback1'), 'fallback1');
+    assert.strictEqual(mediaStreamId('not/a/date/shape/file.flac', 'fallback2'), 'fallback2');
+    assert.strictEqual(mediaStreamId(null, 'fallback3'), 'fallback3');
+    assert.strictEqual(mediaStreamId(undefined, undefined), null);
+});
+
+// ---------------------------------------------------------------- the REAL builder
+ok('buildMediaApiAttr derives from the uri, not external_id (all asset types)', function () {
+    const rec = {
+        uri: '2015/01/01/3qxwx34vyovi/a35152a4-73a6-44f2-b874-3c4893268458.opus',
+        external_id: 'rj83wlyqyx3d',   // the STALE value — must not appear
+        datetime: '2015-01-01 00:02:43', datetime_utc: '2015-01-01 00:02:43', duration: 90
+    };
+    for (const [type, opts] of [['spectro', {}], ['audio', {}],
+        ['template', { minFreq: 100, maxFreq: 2000, trim: { from: 1, to: 3 } }]]) {
+        const attr = recordings.buildMediaApiAttr(rec, type, opts);
+        assert.ok(attr.startsWith('3qxwx34vyovi_t'), `${type}: got ${attr}`);
+        assert.ok(attr.indexOf('rj83wlyqyx3d') === -1, `${type}: stale id leaked into ${attr}`);
+    }
+});
+
+ok('CONTROL: the OLD external_id-first derivation FAILS this harness', function () {
+    // Re-create the pre-fix behaviour and assert the harness would catch it.
+    // If someone "simplifies" mediaStreamId back to `externalId || uriSeg`,
+    // this control documents exactly which production rows break.
+    const oldDerivation = function (rec) { return rec.external_id; };
+    const rec = CASES[0]; // nahuelbuta
+    assert.notStrictEqual(oldDerivation(rec), mediaStreamId(rec.uri, rec.external_id),
+        'old and new derivations must disagree on the divergent fixtures — ' +
+        'if they agree, the fixtures no longer exercise the defect');
+    // and the truthy-'undefined' trap:
+    const bad = { external_id: 'undefined' };
+    assert.strictEqual(oldDerivation(bad), 'undefined', 'control precondition');
+    assert.strictEqual(mediaStreamId('2023/07/21/undefined/undefined.flac', 'undefined'), null,
+        "the literal string 'undefined' must never be used as a stream id");
+});
+
+// ---------------------------------------------------------------- roiSpectrogramUrl
+ok('roiSpectrogramUrl prefers recUri, keeps externalId fallback', function () {
+    const base = {
+        datetimeUtc: '2022-06-05 17:05:00', timeMin: 1.5, timeMax: 3.25,
+        freqMin: 200, freqMax: 8000, sampleRate: 48000
+    };
+    const withUri = roiSpectrogramUrl({ ...base,
+        recUri: '2022/06/05/tjqpfo6tujqv/01242685-a42e-4faa-9567-37af5c033185.flac',
+        externalId: 'suqvtulc2n80' });
+    assert.ok(withUri && withUri.indexOf('tjqpfo6tujqv_t') !== -1, 'uri stream must win: ' + withUri);
+    assert.ok(withUri.indexOf('suqvtulc2n80') === -1, 'stale id leaked: ' + withUri);
+    // no recUri projected (old callers / partial rows): externalId still works
+    const fallback = roiSpectrogramUrl({ ...base, externalId: 'suqvtulc2n80' });
+    assert.ok(fallback && fallback.indexOf('suqvtulc2n80_t') !== -1, 'fallback broken: ' + fallback);
+    // neither: null (renders keep the stored PNG — the settled fail-soft shape)
+    assert.strictEqual(roiSpectrogramUrl({ ...base }), null);
+    // 'undefined' externalId with no uri: null, not a signed 'undefined' URL
+    assert.strictEqual(roiSpectrogramUrl({ ...base, externalId: 'undefined' }), null);
+});
+
+ok('agreeing-corpus invariant: when uri seg == external_id the URL is unchanged', function () {
+    const base = {
+        datetimeUtc: '2022-02-10 23:21:00', timeMin: 0.5, timeMax: 2.5,
+        freqMin: 100, freqMax: 4000, sampleRate: 24000
+    };
+    const withBoth = roiSpectrogramUrl({ ...base,
+        recUri: '2022/02/10/s4dcrtuk5gfi/aaaaaaaa-0000-0000-0000-000000000000.flac',
+        externalId: 's4dcrtuk5gfi' });
+    const extOnly = roiSpectrogramUrl({ ...base, externalId: 's4dcrtuk5gfi' });
+    assert.strictEqual(withBoth, extOnly,
+        '99.983% of the corpus agrees — for those rows the fix must be a byte-identical no-op');
+});
+
+console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
## The defect (OPEN-ITEMS #107)

`buildMediaApiAttr()` — the single chokepoint for audio, full-recording spectrograms and template/ROI crops — named the media-api stream by `sites.external_id`. That column disagrees with the recording's own `uri` for **49,249 recordings across 11 sites** (measured live 2026-08-10): stale after multi-deployment sites, NULL, the literal string `'undefined'`, or naming a soft-deleted stream. Affected real projects: tech4nature-mexico, green-and-golden-bell-frogs, workshop-arbimon, nahuelbuta.

The data verdict behind this (rfcx-local `runbooks/media-external-id-divergence-INVESTIGATION-2026-08-10.md`): a bulk join of every divergent recording's uri-filename UUID against core `stream_segments` proved the segment is owned by the **URI's** stream — never external_id's — for 100% of rows that have segments.

## The fix

ONE derivation — `mediaStreamId(uri, externalId)` in `asset-url.js`: shape-validated uri 4th segment first, external_id fallback, `'undefined'` never usable. Threaded through **every** URL builder that names a stream: buildMediaApiAttr, thumbnails, CNN result strips (classifications/models), roiSpectrogramUrl + its 5 consumers (PM, training sets, clustering, templates ×2), explorerUrl, attachTileMediaTokens (no fallback there on purpose — the browser derives from the uri on its own).

## Verified live pre-merge (prod media-api, real system token, in-pod)

| case | FIXED attr | OLD attr |
|---|---|---|
| nahuelbuta 8062 | **200 PNG 1.74MB** | 404 no-audio |
| workshop-arbimon 31491 (NULL ext) | **200 PNG 1.66MB** | (no URL derivable) |
| jack-s-test 35014 | **200 PNG 1.67MB** | 404 no-audio |
| tech4nature 36114 | **200 PNG 1.66MB** | 404 Stream not found |

(tech4nature renders because the uri names the REAL owning streams — better than expected from the earlier probe, which had used a synthetic window.)

## Tests

- **New `test/media-stream-id/harness.js`**: real functions against the real production row shapes of the affected sites, including a CONTROL that asserts the old external_id-first derivation FAILS (a revert cannot pass), and the agreeing-corpus invariant: for the 99.983% of rows where the two ids agree the URLs are **byte-identical** (no cache churn).
- Existing harnesses green in the prod-image pod: spectro-cache-key 10/10 (fixture updated to the standard uri shape), visualizer tile-token 4/4, p6-pod-kill-net 21/21.

## Out of scope, tracked in #107

- `deleteRecordingsInCoreAPI` also keys deletions by `site_external_id` — a WRITE path, flagged for separate treatment, deliberately untouched here.
- Sites 36114 (quarantined duplicates) / 87447 (segment-less ingest) / 43570 (junk) need data decisions, not rendering changes.