### PR TITLE
fix(dbpool): hoist two-arg callback normalization — getConnection error path crashed the pod

### DIFF
--- a/app/utils/dbpool.js
+++ b/app/utils/dbpool.js
@@ -172,6 +172,20 @@ var dbpool = {
     },
 
     queryHandler: function (query, options, callback) {
+        // Normalize the two-arg call form (queryHandler(sql, cb)) ONCE, up
+        // front, for EVERY branch. Previously only the pg-flip and exports-pg
+        // branches normalized; the default MariaDB branch relied on
+        // queryWithConnHandler doing it downstream — which is fine on the
+        // happy path but the getConnection ERROR path called callback(err)
+        // with callback still undefined (it was sitting in `options`),
+        // throwing "TypeError: callback is not a function" as an uncaught
+        // exception and killing the pod. Latent until a DB connection error
+        // occurs (first seen 2026-08-11 under a PROTOCOL_SEQUENCE_TIMEOUT
+        // during host memory pressure).
+        if (callback === undefined && options instanceof Function) {
+            callback = options;
+            options = undefined;
+        }
         // -------- Phase 6.4 read flip (INERT unless DB_ENGINE=pg) ----------
         // Serve eligible plain SELECTs from PostgreSQL. Writes and anything the
         // allowlist classifier does not positively identify as a plain read fall
@@ -181,10 +195,6 @@ var dbpool = {
         // page. Placed at the SAME chokepoint the shadow taps, so the code path
         // validated for a week by shadow is the code path that now serves.
         if (pgshadow.isPg) {
-            if (callback === undefined && options instanceof Function) {
-                callback = options;
-                options = undefined;
-            }
             var pgRaw = (typeof query === 'string') ? query
                 : (query && typeof query.sql === 'string') ? query.sql : null;
             if (pgRaw !== null && pgshadow.pgRouteEligible(pgRaw)) {
@@ -212,10 +222,6 @@ var dbpool = {
             }
         }
         if (EXPORTS_PG_ENGINE) {
-            if(callback === undefined && options instanceof Function){
-                callback = options;
-                options = undefined;
-            }
             try {
                 var rawSql = (typeof query === 'string') ? query
                     : (query && typeof query.sql === 'string') ? query.sql : null;


### PR DESCRIPTION
## The defect
`queryHandler(sql, cb)` two-arg calls (used throughout `app/model/*`: species, models, sites, jobs, news, species_taxons…) only had the callback normalized inside the `DB_ENGINE=pg` and `EXPORTS_PG_ENGINE` branches. The default MariaDB branch relied on `queryWithConnHandler` normalizing downstream — fine on the happy path, but the `getConnection` **error** path called `callback(err)` while `callback` was still `undefined` (the real cb was sitting in `options`), throwing an uncaught `TypeError: callback is not a function` → `UNHANDLED_ERROR_NET {survivable:false}` → pod restart.

Latent until a DB **connection** error occurs on a two-arg call. First fired 2026-08-11 ~03:36Z under a storm-induced `PROTOCOL_SEQUENCE_TIMEOUT` (ms5 memory pressure): 3 restarts on one prod frontend pod. 15 prior O5 clocks never saw it because the trigger requires a getConnection failure.

## The fix
Normalize once, at the top of `queryHandler`, for every branch; remove the two branch-local copies. Mechanical, no behavior change on any path that previously worked.

## Proof (in-pod, node 16, real runtime — live-executed pre-merge per the P6 standing rule)
- **Control:** harness stubs `getPool().getConnection` to fail like a conn timeout; **deployed** module → `RESULT: CRASH (uncaughtException): callback is not a function` (exact prod signature incl. the `[err getConnection] … [Function (anonymous)] undefined` line).
- **Fixed:** same harness → `RESULT: CALLBACK_GOT_ERROR`, exit 0. The error now reaches the caller's cb.
- **Happy path:** `queryHandler('SELECT 1 AS ok', cb)` against the real DB → identical rows on deployed and fixed; three-arg form `(sql, undefined, cb)` also verified on fixed.

Part of mysql2pg P6 (#40) day-1 duty: UNHANDLED_ERROR_NET lines are defect reports; this triages the 2026-08-11 site.