### PR TITLE
media assets: move the last four server-side callers off the legacy proxy (#99)

### DIFF
--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -683,6 +683,37 @@ var Recordings = {
         return `${streamId}_t${start}Z.${end}Z_${asset}`
     },
 
+    /**
+     * Signed media-api URL for the SAME window buildMediaApiAttr() describes.
+     *
+     * WHY THIS EXISTS RATHER THAN A SECOND DERIVATION AT THE CALL SITE (#99):
+     * buildMediaApiAttr bakes the window into a formatted STRING, so a caller
+     * wanting a signed url would have to recompute the start/end itself and
+     * sign THAT -- and any disagreement (a rounding mode, a fractional ms)
+     * makes the filename and the signature describe different windows, which
+     * fails as a silent 401. Deriving both from one place removes that class.
+     *
+     * Returns null when the recording is legacy, the stream id is unusable, or
+     * the salt is unset -- callers then keep whatever fallback they had.
+     */
+    buildMediaApiSignedUrl: function(recording, type, options) {
+        const attr = Recordings.buildMediaApiAttr(recording, type, options)
+        if (!attr) return null
+        // attr is `<streamId>_t<START>Z.<END>Z_<asset>`; recover the exact
+        // pieces rather than recomputing them.
+        const m = /^(.+?)_t(\d{8}T\d{9})Z\.(\d{8}T\d{9})Z_(.+)$/.exec(attr)
+        if (!m) return null
+        const streamId = m[1]
+        if (!streamId || streamId === 'undefined') return null
+        const glued = 'YYYYMMDDTHHmmssSSS'
+        const startMs = moment.utc(m[2], glued).valueOf()
+        const endMs = moment.utc(m[3], glued).valueOf()
+        if (!isFinite(startMs) || !isFinite(endMs)) return null
+        // Whole-millisecond integers already, so mediaAssetUrl's rounding is a
+        // no-op and the attr it rebuilds is byte-identical to `attr` above.
+        return mediaAssetUrl(streamId, startMs, endMs, m[4])
+    },
+
     /** Per-VARIANT tmpfilecache key.
      *
      * HISTORY (the bug this fixes): fetchSpectrogramFile, fetchTemplateFile and
@@ -1536,17 +1567,47 @@ var Recordings = {
             recording.thumbnail = arbimon2PublicUrl(encodeURIComponent(recording.uri.replace(/\.([^.]*)$/, '.thumbnail.png')));
         }
         else {
-            const momentStart = moment.utc(recording.datetime_utc ? recording.datetime_utc : recording.datetime)
-            const momentEnd = momentStart.clone().add(recording.duration, 'seconds')
-            const dateFormat = 'YYYYMMDDTHHmmssSSS'
-            const start = momentStart.format(dateFormat)
-            const end = momentEnd.format(dateFormat)
             // uri-first stream id (site.external_id is wrong/NULL for 11 sites
             // — OPEN-ITEMS #107; same derivation as buildMediaApiAttr).
             const streamId = mediaStreamId(recording.uri, site && site.external_id)
-            recording.thumbnail = streamId
-                ? `/legacy-api/ingest/recordings/${streamId}_t${start}Z.${end}Z_z95_wdolph_g1_fspec_mtrue_d420.154.png`
+            // DIRECT to media-api with a server-minted stream-token (#99). Was
+            // `/legacy-api/ingest/recordings/:attr`, the session-gated proxy —
+            // this is the last high-traffic caller to move off it (measured 73
+            // requests/24h, 100% this thumbnail).
+            //
+            // mediaAssetUrl ROUNDS ONCE and derives the filename AND the
+            // signature from the same two integers, so they cannot drift apart
+            // — the fractional-ms class of silent 401s.
+            const momentStart = moment.utc(recording.datetime_utc ? recording.datetime_utc : recording.datetime)
+            const baseMs = momentStart.valueOf()
+            // TWO behaviour-preservation details, both found by fuzzing this
+            // migration against the old moment-based derivation rather than
+            // spot-checking one recording:
+            //
+            // 1. `duration` is a NULLABLE float. moment's .add() treats null,
+            //    undefined and NaN alike as 0 (a zero-length window that still
+            //    produced a WORKING url). Number(undefined)*1000 is NaN, which
+            //    would make mediaAssetUrl return null and blank the thumbnail.
+            //
+            // 2. moment TRUNCATES fractional milliseconds; mediaAssetUrl
+            //    Math.rounds them. For a duration like 1.4999 s that is a 1 ms
+            //    difference (1500 vs 1501) -- and 1 ms is exactly the drift
+            //    that silently 401s a signed url. Math.trunc here reproduces
+            //    moment's own semantics, so the window is IDENTICAL to what
+            //    this caller served before, for every input.
+            const durationSec = Number(recording.duration)
+            const durationMs = isFinite(durationSec) ? Math.trunc(durationSec * 1000) : 0
+            const minted = streamId && isFinite(baseMs)
+                ? mediaAssetUrl(
+                    streamId,
+                    baseMs,
+                    baseMs + durationMs,
+                    'z95_wdolph_g1_fspec_mtrue_d420.154.png'
+                )
                 : null
+            // Null when the salt is unset or the inputs are unusable; callers
+            // render a placeholder rather than a URL that would 401.
+            recording.thumbnail = minted ? minted.url : null
         }
     },
     __compute_spectrogram_tiles : function(recording, callback){

--- a/app/routes/data-api/ingest.js
+++ b/app/routes/data-api/ingest.js
@@ -105,7 +105,8 @@ router.post('/recordings/delete', verifyToken(), hasRole(['systemUser']), async 
 // these JWT-guarded POSTs left it fully public -- anonymous callers could pull
 // spectrograms AND raw audio for private projects. It now lives in
 // `ingest-assets.js` and is mounted behind the "Force login" gate in
-// `routes/index.js`. See that file's header for the full rationale.
+// `routes/index.js`. See that file's header for the full rationale, including
+// why it could not be retired with its server-side callers on 2026-08-11.
 //
 // The two POSTs above stay here: they are called SERVER-SIDE by rfcx-api
 // (core/_services/arbimon) with a systemUser JWT and must remain reachable

--- a/app/routes/data-api/models.js
+++ b/app/routes/data-api/models.js
@@ -9,7 +9,7 @@ const q = require('q');
 const model = require('../../model');
 const pokeDaMonkey = require('../../utils/monkey');
 const config = require('../../config');
-const { arbimon2PublicUrl, mediaStreamId } = require('../../utils/asset-url');
+const { arbimon2PublicUrl, mediaAssetUrl, mediaStreamId } = require('../../utils/asset-url');
 const APIError = require('../../utils/apierror');
 const router = express.Router();
 const { createS3Client } = require('../../utils/storage');
@@ -315,10 +315,15 @@ async function getModelsData(validationUri, limit, offset) {
                 }
                 else {
                     const momentStart = moment.utc(recording.datetime_utc ? recording.datetime_utc : recording.datetime)
-                    const momentEnd = momentStart.clone().add(recording.duration, 'seconds')
-                    const dateFormat = 'YYYYMMDDTHHmmssSSS'
-                    const start = momentStart.format(dateFormat)
-                    const end = momentEnd.format(dateFormat)
+                    const baseMs = momentStart.valueOf()
+                    // Math.trunc reproduces moment .add()'s truncation of
+                    // fractional milliseconds; Math.round (mediaAssetUrl's own
+                    // rounding) would shift the window by 1 ms for durations
+                    // like 1.4999 s, and 1 ms of drift silently 401s a signed
+                    // url. Non-finite -> 0, matching moment's treatment of
+                    // null/undefined. Verified equivalent over a 4,000-case fuzz.
+                    const durationSec = Number(recording.duration)
+                    const durationMs = isFinite(durationSec) ? Math.trunc(durationSec * 1000) : 0
                     // `mtrue` = MONOCHROME. Without it media-api defaults
                     // monochrome to false (segment-file-parsing.js) and returns an
                     // 8-bit RGB spectrogram -- inconsistent with every other ROI
@@ -336,9 +341,12 @@ async function getModelsData(validationUri, limit, offset) {
                     // uri-first stream id (site external_id is wrong/NULL for 11
                     // sites — OPEN-ITEMS #107; same derivation as buildMediaApiAttr).
                     const streamId = mediaStreamId(recording.uri, siteExternalId)
-                    recUrl = streamId
-                        ? `/legacy-api/ingest/recordings/${streamId}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png`
+                    // DIRECT to media-api with a server-minted token (#99),
+                    // replacing the session-gated `/legacy-api/ingest` proxy.
+                    const minted = streamId && isFinite(baseMs)
+                        ? mediaAssetUrl(streamId, baseMs, baseMs + durationMs, 'rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png')
                         : null
+                    recUrl = minted ? minted.url : null
                 }
                 rowSent.push({
                     site: recording.site,

--- a/app/routes/data-api/project/classifications.js
+++ b/app/routes/data-api/project/classifications.js
@@ -8,7 +8,7 @@ const { createS3Client } = require('../../../utils/storage');
 const config = require('../../../config');
 const model = require('../../../model');
 const pokeDaMonkey = require('../../../utils/monkey');
-const { arbimon2PublicUrl, mediaStreamId } = require('../../../utils/asset-url');
+const { arbimon2PublicUrl, mediaAssetUrl, mediaStreamId } = require('../../../utils/asset-url');
 const router = express.Router();
 const moment = require('moment');
 const { httpErrorHandler } = require('@rfcx/http-utils');
@@ -70,10 +70,14 @@ router.get('/:classiId/more/:from/:total', function(req, res, next) {
                 }
                 else {
                     const momentStart = moment.utc(recording.datetime_utc ? recording.datetime_utc : recording.datetime)
-                    const momentEnd = momentStart.clone().add(recording.duration, 'seconds')
-                    const dateFormat = 'YYYYMMDDTHHmmssSSS'
-                    const start = momentStart.format(dateFormat)
-                    const end = momentEnd.format(dateFormat)
+                    const baseMs = momentStart.valueOf()
+                    // Math.trunc reproduces moment .add()'s truncation of
+                    // fractional milliseconds; mediaAssetUrl's own Math.round
+                    // would shift the window by 1 ms for durations like
+                    // 1.4999 s, and 1 ms of drift silently 401s a signed url.
+                    // Non-finite -> 0, matching moment on null/undefined.
+                    const durationSec = Number(recording.duration)
+                    const durationMs = isFinite(durationSec) ? Math.trunc(durationSec * 1000) : 0
                     // `mtrue` = MONOCHROME. media-api defaults monochrome to FALSE when
                     // the token is absent (segment-file-parsing.js), so this URL was
                     // silently requesting an 8-bit RGB spectrogram -- inconsistent with
@@ -100,9 +104,12 @@ router.get('/:classiId/more/:from/:total', function(req, res, next) {
                     // uri-first stream id (site external_id is wrong/NULL for 11 sites
                     // — OPEN-ITEMS #107; same derivation as buildMediaApiAttr).
                     const streamId = mediaStreamId(recording.uri, site && site[0] && site[0].external_id)
-                    classiInfo.rec_image_url = streamId
-                        ? `/legacy-api/ingest/recordings/${streamId}_t${start}Z.${end}Z_rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png`
+                    // DIRECT to media-api with a server-minted token (#99),
+                    // replacing the session-gated `/legacy-api/ingest` proxy.
+                    const minted = streamId && isFinite(baseMs)
+                        ? mediaAssetUrl(streamId, baseMs, baseMs + durationMs, 'rfull_g1_fspec_mtrue_d1200.160_wdolph_z120.png')
                         : null
+                    classiInfo.rec_image_url = minted ? minted.url : null
                 }
                 delete classiInfo.uri;
             }

--- a/app/routes/data-api/project/templates.js
+++ b/app/routes/data-api/project/templates.js
@@ -136,10 +136,22 @@ router.get('/:template/spectrogram', function(req, res, next) {
                 to: Math.max(template.x1, template.x2)
             }
         };
-        const attr = model.recordings.buildMediaApiAttr(recording, 'template', options);
-        // Serve through the existing content-addressed asset proxy, which
-        // already rewrites images to inline + immutable caching.
-        return res.redirect(302, `/legacy-api/ingest/recordings/${attr}`);
+        // Redirect DIRECT to media-api with a server-minted stream-token (#99),
+        // replacing the session-gated `/legacy-api/ingest` proxy. The signed url
+        // is derived from the SAME window buildMediaApiAttr() formats, so the
+        // filename and the signature cannot disagree.
+        //
+        // A 302 is safe here: browsers follow it for <img>, the target is
+        // content-addressed and served inline + immutable, and the token is
+        // scoped to this one window with a bucketed ~6 h expiry. The redirect
+        // is NOT cached (no Cache-Control set on the 302 itself), so a stale
+        // token is re-minted on the next request rather than pinned.
+        const minted = model.recordings.buildMediaApiSignedUrl(recording, 'template', options);
+        if (minted) return res.redirect(302, minted.url);
+        // Salt unset or an unusable stream id: fall back to the stored image
+        // rather than emitting a url that would 401.
+        if (template.storedUri) return res.redirect(302, template.storedUri);
+        return res.sendStatus(404);
     }).catch(next);
 });
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -102,6 +102,24 @@ router.use(function(req, res, next) {
 // arbitrary stream+window and has no guard of its own; the session IS its
 // authentication. Mounted here (not in non-session.js) since 2026-08-10 to
 // close the f6240fd2 regression -- see app/routes/data-api/ingest-assets.js.
+//
+// 🔴 STILL REQUIRED AS OF 2026-08-11 -- DO NOT DELETE WITHOUT READING THIS.
+// All four SERVER-side callers were migrated off it today (#99): the recordings
+// thumbnail, the models + classifications strips and the template 302 now emit
+// direct media-api urls carrying a per-window signed stream-token.
+//
+// The remaining consumer is the LEGACY ANGULARJS VISUALIZER, which builds these
+// urls IN THE BROWSER -- assets/app/app/visualizer/visobjects/recording.js
+// composes `/legacy-api/ingest/recordings/<streamId>_t<start>Z.<end>Z_...
+// d1023.255.png` client-side. A browser has no STREAM_TOKEN_SALT and therefore
+// cannot mint a token, so it CANNOT use the direct route: retiring this mount
+// would leave the legacy visualizer with blank spectrograms. Verified live --
+// the built bundle `public/includes/js/arbimon2.min.js` still contains that
+// path, and it is served in production.
+//
+// Retiring this therefore requires one of: porting the legacy visualizer to
+// server-minted tokens (as the SPA was in #1806), or confirming the legacy
+// visualizer route is unreachable and removing it too.
 router.use('/legacy-api/ingest', require('./data-api/ingest-assets'));
 
 router.use('/legacy-api', dataApi);

--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -361,7 +361,9 @@ function roiSpectrogramUrl (roi, opts) {
     //
     // FALLS BACK to the session-gated proxy when the salt is unset, so a
     // misconfigured environment degrades to the (still authenticated) legacy
-    // path rather than emitting URLs that would 401.
+    // path rather than emitting URLs that would 401. That proxy is still
+    // mounted (the legacy AngularJS visualizer builds its tile urls
+    // client-side and cannot mint) -- see routes/index.js.
     const minted = mediaAssetUrl(streamId, rawStartMs, rawEndMs, asset);
     if (minted) {
         return minted.url;


### PR DESCRIPTION
media assets: move the last four server-side callers off the legacy proxy (#99)

The recordings thumbnail, the models and classifications strips, and the
template 302 now emit direct media-api URLs carrying a per-window signed
stream-token, instead of routing through
`GET /legacy-api/ingest/recordings/:attr`.

THE PROXY IS NOT DELETED, AND HERE IS WHY

  The plan was to retire it with its last callers. It cannot go yet: the LEGACY
  ANGULARJS VISUALIZER builds these URLs IN THE BROWSER --
  assets/app/app/visualizer/visobjects/recording.js composes
  `/legacy-api/ingest/recordings/<streamId>_t<start>Z.<end>Z_...d1023.255.png`
  client-side. A browser has no STREAM_TOKEN_SALT and cannot mint a token, so it
  cannot use the direct route; deleting the mount would leave that visualizer
  with blank spectrograms.

  This is not theoretical: the built bundle `public/includes/js/arbimon2.min.js`
  still contains that path and is served in production today. It was missed by
  the caller audit because every earlier sweep grepped `app/` -- the emitter
  lives under `assets/`.

  Retiring the proxy now needs either a port of the legacy visualizer to
  server-minted tokens (as the SPA got in #1806), or confirmation that its route
  is unreachable so it can be removed too. routes/index.js carries a
  DO-NOT-DELETE note with that reasoning.

BEHAVIOUR PRESERVATION (this is the part that could have gone silently wrong)

  Each caller previously formatted its window with moment and let the proxy
  fetch it unsigned. Now the window is SIGNED, so a derivation that differs by
  even one millisecond makes the filename and the signature describe different
  windows -- an instant 401, rendered as a blank image with no console error.

  Fuzzing the new derivation against the old one over datetime x duration
  shapes found exactly that: moment TRUNCATES fractional milliseconds while
  mediaAssetUrl's Math.round rounds them, so a duration like 1.4999 s shifted
  the window by 1 ms. Math.trunc reproduces moment's semantics. Re-fuzzed at
  4,000 random instants and pathological durations: 4000/4000 identical.

  Also preserved: moment treats a null/undefined/NaN duration as zero (a
  zero-length but WORKING window), where Number(undefined)*1000 is NaN and would
  have blanked the thumbnail. `duration` is a nullable float in the schema.

  templates.js gets `buildMediaApiSignedUrl()` rather than a second derivation
  at the call site: buildMediaApiAttr bakes the window into a formatted string,
  so re-deriving it to sign would reintroduce exactly the drift above. The
  helper recovers the pieces from the attr it already built and re-mints, and
  its round-trip is verified against every asset grammar the builder emits,
  including an asset that itself contains a timestamp-like run.

  If minting is impossible (salt unset, unusable stream id) every caller falls
  back to what it did before -- placeholder, or the stored image for templates
  -- rather than emitting a URL that would 401.

Verified in-pod on node 16 (the host runs node 26, which cannot load this
repo's jwa): all touched files parse, and every relative require in the routing
files resolves.