### PR TITLE
legacy visualizer: use the server-minted tile tokens it already receives (#99)

### DIFF
--- a/assets/app/app/visualizer/visobjects/recording.js
+++ b/assets/app/app/visualizer/visobjects/recording.js
@@ -69,12 +69,42 @@ angular.module('a2.visobjects.recording', [
         this.tiles.set.forEach((function(tile){
             if (!!data.legacy) {
                 tile.src="/legacy-api/project/"+Project.getUrl()+"/recordings/tiles/"+this.id+"/"+tile.i+"/"+tile.j+"/"+randomString;
+            } else if (tile.mediaToken && tile.mediaStart && tile.mediaEnd) {
+                // DIRECT to media-api with the token the SERVER minted for this
+                // exact tile window (#99). The payload this view already fetches
+                // (/legacy-api/project/:url/recordings/info/:id -> 
+                // fetchSpectrogramTiles -> attachTileMediaTokens) has carried
+                // mediaToken/mediaStreamId/mediaStart/mediaEnd/mediaExp on every
+                // tile since #1806 -- this view was simply ignoring them and
+                // composing a proxy URL instead.
+                //
+                // 🔴 USE THE SERVER'S start/end VERBATIM. Do NOT recompute them
+                // (as the line this replaces did): the token signs
+                // streamId_startMs_endMs[_exp], so re-deriving the window
+                // client-side risks disagreeing with what was signed by a
+                // millisecond -- and a mismatch is a SILENT 401 that renders as
+                // blank space, because the tile <img> has no error surface.
+                // That is exactly the fractional-ms defect class fixed in the
+                // SPA on 2026-08-10.
+                //
+                // The palette stays client-side: render params are deliberately
+                // NOT part of the signed message, so the per-user spectro colour
+                // still works without a re-mint.
+                var streamId = tile.mediaStreamId || data.uri.split('/')[3];
+                tile.src = '/media-api/internal/assets/streams/' + streamId +
+                    '_t' + tile.mediaStart + 'Z.' + tile.mediaEnd + 'Z' +
+                    '_z95_wdolph_g1_fspec_' + spectroColoredCache + '_d1023.255.png' +
+                    '?stream-token=' + tile.mediaToken +
+                    (tile.mediaExp ? '&exp=' + tile.mediaExp : '');
             } else {
-                var streamId = data.uri.split('/')[3]
+                // FALLBACK: server could not mint (salt unset, or an older
+                // backend). Keep the session-gated proxy so a misconfigured
+                // environment degrades rather than showing blank tiles.
+                var fallbackStreamId = data.uri.split('/')[3]
                 const datetime = data.datetime_utc ? data.datetime_utc : data.datetime
                 var start = new Date(new Date(datetime).valueOf() + Math.round(tile.s * 1000)).toISOString()
                 var end = new Date(new Date(datetime).valueOf() + Math.round((tile.s + tile.ds) * 1000)).toISOString()
-                tile.src = '/legacy-api/ingest/recordings/' + streamId + '_t' + start.replace(/-|:|\./g, '') + '.' + end.replace(/-|:|\./g, '') + '_z95_wdolph_g1_fspec_' + spectroColoredCache + '_d1023.255.png';
+                tile.src = '/legacy-api/ingest/recordings/' + fallbackStreamId + '_t' + start.replace(/-|:|\./g, '') + '.' + end.replace(/-|:|\./g, '') + '_z95_wdolph_g1_fspec_' + spectroColoredCache + '_d1023.255.png';
             }
         }).bind(this));
     };


### PR DESCRIPTION
legacy visualizer: use the server-minted tile tokens it already receives (#99)

The AngularJS visualizer was composing its tile URLs against the session-gated
proxy `/legacy-api/ingest/recordings/:attr`, which is the last thing keeping
that route alive and the sole blocker on closing #99.

It turns out no new plumbing is needed. The payload this view already fetches --
`/legacy-api/project/:url/recordings/info/:id` -> fetchSpectrogramTiles ->
attachTileMediaTokens -- has carried `mediaToken`, `mediaStreamId`,
`mediaStart`, `mediaEnd` and `mediaExp` on EVERY tile since #1806. This view was
simply ignoring them. Verified against live prod data: 11/11 tiles carry a
token.

So this reads what is already on the wire and points the tiles straight at
media-api, exactly as the SPA does.

USE THE SERVER'S WINDOW VERBATIM

  The replaced code recomputed start/end from `datetime` + `tile.s` in the
  browser. The token signs `streamId_startMs_endMs[_exp]`, so any client-side
  re-derivation risks disagreeing with what was signed by a millisecond -- and
  a mismatch is a SILENT 401 here, because a tile <img> that fails just renders
  as blank space. That is the fractional-ms defect class fixed in the SPA on
  2026-08-10, and this change removes the opportunity for it entirely by never
  recomputing the window.

  The palette stays client-side: render parameters are deliberately not part of
  the signed message, so the per-user spectro colour still works with no
  re-mint.

A fallback to the proxy is kept for the case where the server could not mint
(salt unset, or an older backend), so a misconfigured environment degrades to a
working authenticated path instead of blank tiles.

THE PROXY IS DELIBERATELY NOT DELETED IN THIS CHANGE

  It is still serving real users through the old code path right now: 77
  requests in the last 90 minutes, all `d1023.255` (this view's geometry), from
  two distinct accounts, all HTTP 200. Retiring the route in the same release
  that changes its only remaining caller would leave no margin if the port
  misbehaves. The sequence is: ship this, watch `d1023.255` proxy traffic fall
  to zero, then delete the route and its mount.

VERIFIED LIVE (in-pod, against real server payloads)

  The new composition was run over the real tile set and every URL fetched:
  22/22 tiles HTTP 200 image/png across both offered palettes (mtrue, mfalse)
  on the SAME token, and a token-stripped negative control returned 401 --
  which is what makes the 200s meaningful.