### PR TITLE
fix(media): reject zero-date windows instead of emitting an unparseable URL

### DIFF
--- a/app/utils/asset-url.js
+++ b/app/utils/asset-url.js
@@ -86,8 +86,38 @@ function mediaAssetExpiry () {
 function gluedUtcTimestamp (ms) {
     const d = new Date(ms);
     const p = function (n, w) { return String(n).padStart(w || 2, '0'); };
-    return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}T` +
+    // PAD THE YEAR TO 4 DIGITS. media-api parses this with the fixed-width
+    // format `YYYYMMDDTHHmmssSSSZ`, so a year below 1000 rendered unpadded
+    // produced a 7-character date part and a 400 ValidationError
+    // ("`stream`, `start` and `end` must be specified") -- see the year-0172
+    // zero-date class below. Padding alone does not make such a URL CORRECT,
+    // but it keeps a malformed date from becoming an unparseable filename.
+    return `${p(d.getUTCFullYear(), 4)}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}T` +
         `${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}${p(d.getUTCMilliseconds(), 3)}`;
+}
+
+/**
+ * Is this epoch-ms value a PLAUSIBLE recording instant?
+ *
+ * `isFinite`/`isNaN` is not enough. MariaDB zero-dates ('0000-00-00 00:00:00')
+ * reach the app in two different shapes depending on the query/driver path:
+ * as the STRING (which parses to NaN and was already rejected) or as a JS Date
+ * for YEAR 0172 (which has a perfectly finite getTime() of -56709072000000 and
+ * therefore sailed through every existing guard).
+ *
+ * That second shape is what broke template thumbnails on pattern-matching
+ * pages: the window was signed over a year-0172 instant and the filename came
+ * out as `1721217T000055086`, which media-api cannot parse.
+ *
+ * Recordings are audio uploads, so anything before ~1990 or more than a day in
+ * the future is corrupt data rather than a real window. Reject it and let the
+ * caller fall back to its placeholder, instead of emitting a URL that cannot
+ * work.
+ */
+const MIN_PLAUSIBLE_MS = Date.UTC(1990, 0, 1);
+function isPlausibleRecordingMs (ms) {
+    if (!isFinite(ms)) return false;
+    return ms >= MIN_PLAUSIBLE_MS && ms <= (Date.now() + 86400000);
 }
 
 function trimTrailingSlash (s) {
@@ -248,6 +278,9 @@ function mediaStreamToken (streamId, startMs, endMs, exp) {
 function mediaAssetUrl (streamId, rawStartMs, rawEndMs, asset) {
     if (!streamId || !asset) return null;
     if (!isFinite(rawStartMs) || !isFinite(rawEndMs)) return null;
+    // Reject corrupt windows HERE, at the one chokepoint every caller goes
+    // through, rather than in each caller's own date handling.
+    if (!isPlausibleRecordingMs(rawStartMs) || !isPlausibleRecordingMs(rawEndMs)) return null;
     // ROUND ONCE. Every downstream use — filename AND signature — flows from
     // these two integers, so they cannot drift apart.
     const startMs = Math.round(Number(rawStartMs));
@@ -314,7 +347,10 @@ function roiSpectrogramUrl (roi, opts) {
     const base = roi.datetimeUtc;
     if (!base) return null;
     const baseMs = new Date(base).getTime();
-    if (isNaN(baseMs)) return null;
+    // NOT just isNaN: a MariaDB zero-date arrives here as a JS Date for year
+    // 0172 when the driver has already parsed it, which is finite and passes
+    // isNaN. See isPlausibleRecordingMs.
+    if (!isPlausibleRecordingMs(baseMs)) return null;
     const from = Math.min(Number(roi.timeMin), Number(roi.timeMax));
     const to = Math.max(Number(roi.timeMin), Number(roi.timeMax));
     if (isNaN(from) || isNaN(to)) return null;


### PR DESCRIPTION
fix(media): reject zero-date windows instead of emitting an unparseable URL

PRODUCTION BUG, operator-reported. Template thumbnails on pattern-matching
pages requested URLs like

  .../vhaxlryvqguc_t1721217T000055086Z.1721217T000055892Z_r3537.5922_...png

and media-api answered 400 "`stream`, `start` and `end` must be specified".

TWO DEFECTS, ONE SYMPTOM

1. The window came from a MariaDB ZERO DATE. `0000-00-00 00:00:00` reaches the
   app in TWO different shapes depending on the query path: as the raw STRING
   (which parses to NaN and was already rejected) or, when the driver has
   parsed it, as a JS Date for YEAR 0172 -- whose getTime() is a perfectly
   finite -56709072000000. So it sailed straight through every isNaN/isFinite
   guard we had, and the window was signed over a year-0172 instant.

2. `gluedUtcTimestamp` did not pad the year. media-api parses this filename
   with the fixed-width format YYYYMMDDTHHmmssSSSZ, so year 172 rendered as
   `1721217T...` -- a 7-character date part, which is unparseable. Hence the
   400 rather than a 401.

THE FIX

Add `isPlausibleRecordingMs()` and apply it at the ONE chokepoint every caller
already goes through (mediaAssetUrl), plus at roiSpectrogramUrl's own date
parse so it bails early. Recordings are audio uploads, so anything before 1990
or more than a day in the future is corrupt data, not a real window -- reject
it and let the caller render its placeholder, which is the documented contract
for "cannot build".

Also pad the year to 4 digits. That alone does not make such a URL correct, but
a malformed date should never become an unparseable filename.

SCOPE: 1,825 templates sit on recordings with a zero/implausible date, so this
is a broad pre-existing condition, not a single bad row.

NOT A REGRESSION FROM TODAY'S WORK: this path (roiSpectrogramUrl -> signed
media-api URLs for ROI/template images) shipped on 2026-08-10 in 68233a34 /
acb5727b. Today's #1809 touched only comments in this file, and #1810 touched
only the AngularJS visualizer. Verified by diffing both commits.

VERIFIED IN-POD against the exact row that broke (template 77864):
  - year-0172 -> gluedUtcTimestamp now yields an 8-digit date part
  - mediaAssetUrl returns null for that window
  - roiSpectrogramUrl returns null for BOTH data shapes (string and Date)
  - REGRESSION GUARD: a normal 2026 recording still emits a working URL
  - boundary: 1989 rejected, 1990 accepted