### PR TITLE
fix(export): iterate instead of recursing in exportRecordingData chunk driver

### DIFF
--- a/app/model/projects.js
+++ b/app/model/projects.js
@@ -201,7 +201,12 @@ var Projects = {
 
                 return q.all([
                     options.compute.rec_count ? dbpool.query(
-                        "SELECT site_id, COUNT(recording_id) as rec_count "+
+                        // MIN/MAX ride along on the aggregate that already
+                        // computes rec_count over exactly these rows, so the
+                        // per-site date range costs no extra query or scan.
+                        "SELECT site_id, COUNT(recording_id) as rec_count, "+
+                        "       MIN(datetime) as first_recording_at, "+
+                        "       MAX(datetime) as last_recording_at "+
                         "FROM recordings "+
                         "WHERE site_id IN (?) " +
                         // Archiving (Phase A): per-site recording counts exclude archived.
@@ -211,9 +216,13 @@ var Projects = {
                     ).then(function(results){
                         sites.forEach(function(site){
                             site.rec_count=0;
+                            site.first_recording_at=null;
+                            site.last_recording_at=null;
                         });
                         results.forEach(function(row){
                             sitesById[row.site_id].rec_count = row.rec_count;
+                            sitesById[row.site_id].first_recording_at = row.first_recording_at;
+                            sitesById[row.site_id].last_recording_at = row.last_recording_at;
                         });
                     }) : q(),
                 ]).then(function(){

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -2084,7 +2084,16 @@ var Recordings = {
             start: joi.string(),
             end: joi.string().optional(),
             site_external_id: joi.string(),
-            project_id: joi.number()
+            project_id: joi.number(),
+            // exact=true switches the match from '<=' (nearest recording AT OR
+            // BEFORE start — what the CNN detection viewer and the Visualizer
+            // links need, since a detection's start falls INSIDE a recording)
+            // to '=' (a recording starting exactly at this instant — what a
+            // duplicate check needs). Opt-in so existing callers are unchanged.
+            exact: joi.alternatives().try(
+                joi.boolean(),
+                joi.string().valid('true', 'false', '0', '1')
+            ).optional()
         }
     },
 
@@ -2263,11 +2272,32 @@ var Recordings = {
             .then(async (parameters) => {
                 const [site] = await siteModel.findAsync({ external_id: parameters.site_external_id })
                 const dateFormatted = moment.utc(parameters.start).format('YYYY-MM-DD HH:mm:ss')
-                const q = `select recording_id from recordings
+                // Two DIFFERENT questions share this endpoint:
+                //  - default '<=': "which recording CONTAINS this instant?" — a
+                //    CNN detection's start is offset INSIDE a recording, so the
+                //    nearest-at-or-before row is the right answer.
+                //  - exact '=':   "is there a recording starting exactly here?"
+                //    — the uploader's duplicate advisory. Under '<=' it matched
+                //    the site's newest recording for ANY later timestamp, so
+                //    every genuinely new file was flagged Duplicate.
+                const exact = parameters.exact === true || parameters.exact === 'true' ||
+                    parameters.exact === '1' || parameters.exact === 1
+                const q = exact
+                    ? `select recording_id from recordings
+                    where datetime_utc = '${dateFormatted}' and site_id = ${site.site_id}
+                    limit 1`
+                    : `select recording_id from recordings
                     where datetime_utc <= '${dateFormatted}' and site_id = ${site.site_id}
                     order by datetime_utc desc limit 1`
                 console.log('<- [recording query]', q)
-                return dbpool.query(q).get(0).get('recording_id')
+                // Resolve 0 (not a rejection) when nothing matches. With
+                // exact=true "no match" is the COMMON, expected answer, and the
+                // old .get(0).get(...) chain rejected with a TypeError on an
+                // empty result set — which the route turned into res.json(0)
+                // anyway, but only after logging every clean miss as an error.
+                return dbpool.query(q).then(function (rows) {
+                    return rows && rows.length > 0 ? rows[0].recording_id : 0
+                })
             }).nodeify(callback)
     },
 

--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -2476,7 +2476,31 @@ var Recordings = {
             }).then(async function() {
                 const chunkSize = 1000
                 let index = 0
-                async function getData () {
+                // Iterate, do NOT recurse. This loop was previously an
+                // `async function getData()` that ended with `await getData()`,
+                // i.e. one nested async frame PER 1,000-row chunk, none of
+                // which unwound until the whole export finished. Each pending
+                // frame kept its own `results` array and awaited promise chain
+                // reachable, so peak memory scaled with EXPORT SIZE rather than
+                // chunk size. (`results = null` before the recursive call was
+                // not a mitigation: it cleared the variable, not the frame.)
+                //
+                // Measured on prod 2026-08-13: a 298,332-recording project
+                // (PELD Gurupi) climbed ~500 MiB per 10 min with no plateau and
+                // was OOMKilled at the 2500Mi limit ~17 times in 35h, never
+                // completing. Because the export could not finish, the row was
+                // re-claimed by the reconciler every ~2h and retried forever,
+                // so the requesting user got neither a file nor an error.
+                // See rfcx-local OPEN-ITEMS #113.
+                //
+                // A `while` loop is semantically identical here (the recursion
+                // was purely a loop) but runs in constant stack, freeing each
+                // chunk once written. This is also the shape the three sibling
+                // exporters in jobs/arbimon-recording-export-job/ already use
+                // (pattern-matching.js, soundscape.js, rfm-classification.js
+                // all drive their chunk loop with `while (toProcess === true)`).
+                let hasMore = true
+                while (hasMore) {
                     let results = [];
                     for (let builder in summaryBuilders) {
                         const baseSql = summaryBuilders[builder].getSQL().replace(';', '').replace('SELECT', 'SELECT /*+ MAX_EXECUTION_TIME(840000) */')
@@ -2488,12 +2512,11 @@ var Recordings = {
                         cb(null, results)
                         index++
                         results = null
-                        await getData()
                     } else {
+                        hasMore = false
                         cb(null, null)
                     }
                 }
-                await getData()
             })
     },
 


### PR DESCRIPTION
> ⛔ **DRAFT — DO NOT MERGE YET. This is deliberately held, not unfinished.**
>
> Merging this builds a new `arbimon-legacy` image, which moves all four
> arbimon pins and therefore **RESETS the mysql2pg O5 clock** (rfcx-local
> OPEN-ITEMS #40). That clock is currently at **T0 = 2026-08-11T14:06:19Z on
> `rfcx-local-prod-27d561e`**, has run ~2.1 days clean, and gates the week-7
> exit legs → operator GO → the 6.4 read flip. Merging today would discard
> that evidence and re-arm a fresh 7-day clock.
>
> **Operator decision 2026-08-13: prepare now, ship at the next clock
> boundary** — i.e. merge when the O5 clock completes (~2026-08-18T14:06Z) or
> when another arbimon-legacy release resets it anyway, so this rides along at
> zero cost. The code is finished and verified; only the merge is waiting.

## What is broken

Large recording exports OOMKill and can **never** complete, so the request is
retried forever and the user gets **neither a file nor an error**.

The chunk driver in `exportRecordingData` was an `async function getData()`
ending in `await getData()` — one nested async frame per 1,000-row chunk, none
unwinding until the whole export finished. Each pending frame kept its own
`results` array and awaited promise chain reachable, so **peak memory scaled
with EXPORT SIZE rather than chunk size**. The `results = null` before the
recursive call was not a mitigation: it cleared the variable, not the frame.

### Measured on production, 2026-08-13

Project **PELD Gurupi (298,332 recordings)**, `container_memory_working_set_bytes`:

```
13:42Z    88 MiB   <- idle baseline, flat for hours
13:52Z  1000 MiB   <- an export starts
14:02Z  1488 MiB
14:12Z  1932 MiB
14:18Z   OOMKilled at the 2500Mi limit
14:22Z    86 MiB   <- fresh pod, flat again
15:52Z   708 MiB   <- next attempt starts...
```

**17 OOMKills in 35 hours.** Because the export could not finish, the row was
released by the reconciler's stale-claim sweep every ~120 min and republished,
so the same doomed attempt looped indefinitely and no terminal error was ever
written. The requesting user had waited ~3 days seeing an indefinite hang.

## The fix

Convert the recursion to a `while` loop: semantically identical (the recursion
was purely a loop), constant stack, each chunk freed once written.

This is also **the shape the three sibling exporters already use** —
`pattern-matching.js`, `soundscape.js` and `rfm-classification.js` all drive
their chunk loop with `while (toProcess === true)`. Only `recordings.js`
recursed; a repo-wide grep for the self-recursive await returns exactly the two
lines removed here. So this makes the odd one out match its siblings.

**No SQL construction is touched** — builder, projections, the
`MAX_EXECUTION_TIME` hint and `LIMIT/OFFSET` paging are byte-identical. That
matters because `jobs/db/print-translated.js` notes this query is assembled at
runtime by SQLBuilder and must be validated by the per-type forced-recipient
E2E rather than static analysis.

## Verification

A standalone equivalence harness drove **both** shapes against an identical
fake paging source and asserted the same callback sequence, the same
SQL/OFFSET sequence, and the same terminal call:

| rows | callbacks | queries | identical |
|---|---|---|---|
| 0, 1, 999, 1000, 1001, 2000, 5500 | — | — | ✅ |
| **298,332** (the real project) | 300 | 300 | ✅ |

Edge cases pinned: an empty export emits exactly one terminal callback after
one query; an exact multiple of `chunkSize` still makes the trailing empty
probe.

The harness was then **mutation-tested**, so green means something. Five
realistic hand-conversion defects were each confirmed to turn it RED:

| mutant | caught |
|---|---|
| dropped `index++` (repeats chunk 0 forever) | ✅ |
| missing terminal `cb(null, null)` | ✅ |
| inverted loop condition (exits after one chunk) | ✅ |
| terminal emitted out of order | ✅ |
| off-by-one offset (skips a row per page) | ✅ |

**5/5.**

## Deliberately NOT fixed here

- **`LIMIT/OFFSET` deep pagination** is O(N) per chunk and quadratic overall —
  but this is **shared with the siblings** (`soundscape.js` pages identically)
  and is a performance characteristic, not the defect that made exports
  impossible. Note the siblings use `limit = 10000` vs this path's `1000`.
- **No retry cap**, so a genuinely un-exportable request would still loop
  rather than terminate with an error the user can see.

Both are tracked in rfcx-local **OPEN-ITEMS #113** alongside the recommendation
to add an OOMKill alert — the systemic gap here is that a pod died 17 times in
35 hours and nothing alerted, because ~124 min between kills sits well outside
the crashloop window.

## Deploy note (for whoever merges)

`arbimon-legacy` releases move **four pins**, and the export pair runs a
**different image** (`arbimon-recording-export-job`, not `arbimon`) — rolling
them to the web image gives `MODULE_NOT_FOUND`. CD auto-rolls only `arbimon`
and `arbimon-ingest-consumer`; **`arbimon-export-consumer` and the
`arbimon-export-reconciler` CronJob must be hand-rolled and pin-reconciled in
the same session**, then soak-checked — a web-tier acceptance suite cannot
catch a broken worker. This PR's whole point is in the export worker, so that
soak check is not optional.
