### PR TITLE
fix(soundscapes): PG-strict GROUP BY in getRegionTags — MIN() representatives (42803)

### DIFF
--- a/app/model/soundscapes.js
+++ b/app/model/soundscapes.js
@@ -443,26 +443,39 @@ let Soundscapes = {
 
         if(params.id){
             constraints.push('SRT.soundscape_region_tag_id = ' + dbpool.escape(params.id));
-            project.push('SRT.user_id as user', 'SRT.timestamp');
+            project.push('MIN(SRT.user_id) as user', 'MIN(SRT.timestamp) as timestamp');
             if(params.recording){
                 constraints.push('SRT.recording_id = ' + dbpool.escape(params.recording));
             }
         } else if(params.recording){
             constraints.push('SRT.recording_id = ' + dbpool.escape(params.recording));
-            project.push('SRT.user_id as user', 'SRT.timestamp');
+            project.push('MIN(SRT.user_id) as user', 'MIN(SRT.timestamp) as timestamp');
             groupby.push('SRT.recording_id');
         }
 
         groupby.push('SRT.soundscape_tag_id');
 
+        // PG-strict GROUP BY (mysql2pg #42803, hash e2600c86 — the #1790
+        // MIN() precedent): soundscape_region_tag_id and recording_id are
+        // NOT grouped and NOT unique per (region, tag) group — measured
+        // fan-out up to 99 rows/group — so adding them to GROUP BY would
+        // explode the result reaching the UI (237 groups -> 991 rows).
+        // MIN() keeps cardinality identical and makes the representative
+        // pick deterministic where MariaDB's was scan-order luck. ST.tag/
+        // ST.type join the GROUP BY instead: the join is on ST's PRIMARY
+        // KEY (soundscape_tag_id), already grouped, so they are 1:1 per
+        // group and adding them changes nothing (the #1790 aed-branch
+        // pattern). In the params.recording branch recording_id IS grouped,
+        // and MIN(recording_id) == recording_id there — one projection
+        // stays valid for every branch.
         return dbpool.queryHandler(
-            "SELECT SRT.soundscape_region_tag_id as id, SRT.soundscape_region_id as region, SRT.recording_id as recording,\n" +
+            "SELECT MIN(SRT.soundscape_region_tag_id) as id, SRT.soundscape_region_id as region, MIN(SRT.recording_id) as recording,\n" +
             (project.length ? "    " + project.join(", ")+", \n" : "")+
             "    ST.tag, ST.type, COUNT(*) as count \n" +
             "FROM soundscape_region_tags SRT \n" +
             "JOIN soundscape_tags ST ON ST.soundscape_tag_id = SRT.soundscape_tag_id\n" +
             "WHERE " + constraints.join(' AND ') + "\n" +
-            "GROUP BY " + groupby.join(", "), callback);
+            "GROUP BY " + groupby.join(", ") + ", ST.tag, ST.type", callback);
     },
 
     /** adds a soundscape region tags.

--- a/app/utils/dbpool-pg.selftest.js
+++ b/app/utils/dbpool-pg.selftest.js
@@ -629,6 +629,22 @@ eq('clustering: MIN(backtick col) + alias translates',
    m.translate('SELECT A.aed_id, MIN(C.`date_created`) as `date_created` FROM a A JOIN c C ON A.j = C.k GROUP BY A.aed_id, A.species_id'),
    'SELECT A.aed_id, MIN(C.date_created) as date_created FROM a A JOIN c C ON A.j = C.k GROUP BY A.aed_id, A.species_id');
 
+// ---- soundscape region-tags GROUP BY shape (P6 2026-08-16, 42803 hash e2600c86) --
+// getRegionTags() (soundscapes.js) fired the first genuine dialect_error on
+// the 17th clock: soundscape_region_tag_id + recording_id projected without
+// aggregation while grouped only by (region_id, tag_id) — measured fan-out
+// up to 99 rows/group, so the #1790 MIN() precedent applies (bare GROUP BY
+// addition would 4x the result reaching the UI: 237 groups vs 991 rows).
+// ST.tag/ST.type join the GROUP BY via ST's PK — cardinality-neutral. Pin
+// that the translator carries the fixed shape untouched.
+console.log('== soundscape region-tags GROUP BY shape (P6 2026-08-16) ==');
+eq('srt: MIN() representatives + PK-joined GROUP BY cols translate',
+   m.translate('SELECT MIN(SRT.soundscape_region_tag_id) as id, SRT.soundscape_region_id as region, MIN(SRT.recording_id) as recording, ST.tag, ST.type, COUNT(*) as count FROM soundscape_region_tags SRT JOIN soundscape_tags ST ON ST.soundscape_tag_id = SRT.soundscape_tag_id WHERE SRT.soundscape_region_id = 1 GROUP BY SRT.soundscape_region_id, SRT.soundscape_tag_id, ST.tag, ST.type'),
+   'SELECT MIN(SRT.soundscape_region_tag_id) as id, SRT.soundscape_region_id as region, MIN(SRT.recording_id) as recording, ST.tag, ST.type, COUNT(*) as count FROM soundscape_region_tags SRT JOIN soundscape_tags ST ON ST.soundscape_tag_id = SRT.soundscape_tag_id WHERE SRT.soundscape_region_id = 1 GROUP BY SRT.soundscape_region_id, SRT.soundscape_tag_id, ST.tag, ST.type');
+eq('srt: recording-branch shape (MIN user/timestamp projections) translates',
+   m.translate('SELECT MIN(SRT.soundscape_region_tag_id) as id, MIN(SRT.user_id) as user, MIN(SRT.timestamp) as timestamp, ST.tag, COUNT(*) as count FROM soundscape_region_tags SRT JOIN soundscape_tags ST ON ST.soundscape_tag_id = SRT.soundscape_tag_id WHERE SRT.soundscape_region_id = 1 AND SRT.recording_id = 2 GROUP BY SRT.soundscape_region_id, SRT.recording_id, SRT.soundscape_tag_id, ST.tag, ST.type'),
+   'SELECT MIN(SRT.soundscape_region_tag_id) as id, MIN(SRT.user_id) as user, MIN(SRT.timestamp) as timestamp, ST.tag, COUNT(*) as count FROM soundscape_region_tags SRT JOIN soundscape_tags ST ON ST.soundscape_tag_id = SRT.soundscape_tag_id WHERE SRT.soundscape_region_id = 1 AND SRT.recording_id = 2 GROUP BY SRT.soundscape_region_id, SRT.recording_id, SRT.soundscape_tag_id, ST.tag, ST.type');
+
 // ---- connection-lifetime SQLSTATE classification (P6, 2026-07-29) --------
 // #1781 ruled that a connection DEATH must never book as dialect_error (the
 // O5 gate's hard-zero metric). Its guard tested `!err.code` only, so an


### PR DESCRIPTION
**The first genuine dialect_error on the 17th O5 clock** (mysql2pg P6, hash `e2600c86`, 27 events on both pods 2026-08-16): `getRegionTags()` projects `soundscape_region_tag_id` + `recording_id` un-aggregated while grouping by `(region_id, tag_id)` — PG 42803.

**The naive fix (add columns to GROUP BY) was measured WRONG**: fan-out is up to 99 rows/group, so it would explode 237 groups into 991 rows reaching the UI. This applies the #1790 `MIN()` precedent: cardinality-neutral, deterministic where MariaDB was scan-order luck. `ST.tag/ST.type` join the GROUP BY via the PK join (1:1 per group). One projection shape serves all three param branches (`recording_id` is grouped in the recording branch, where `MIN == identity`).

**Verified pre-merge (execute-before-merge rule):**
- MariaDB old vs new: group-level identical, all 237 groups; 1 representative id changed (arbitrary→MIN)
- MariaDB new vs PG new: byte-identical 237/237
- recording-branch live pair: identical 4/4 both engines
- All 3 branch shapes through the **deployed** `translate()` in the prod pod → PG via pgbouncer: OK
- selftest 236→238 ALL PASS

Restarts the O5 clock (operator GO 2026-08-16 15:27 EDT, clock-economics rule).