### PR TITLE
fix(classifications): guard empty detail() result - an unguarded rows[0] killed the process

### DIFF
--- a/app/routes/data-api/project/classifications.js
+++ b/app/routes/data-api/project/classifications.js
@@ -46,9 +46,27 @@ router.get('/:classiId', function(req, res, next) {
         model.classifications.detail(req.params.classiId, function(err, rows) {
             if(err) return next(err);
 
+            // detail() aggregates classification_results for this job and then INNER
+            // JOINs job_params_classification/models/species/songtypes, so it
+            // legitimately returns ZERO rows for a classification that has no results
+            // yet (a job still running) or whose join partners are missing. Without
+            // this guard `rows[0]` is undefined and the assignment below throws a
+            // TypeError inside a DB callback -- an UNCAUGHT exception that kills the
+            // whole process.
+            // PRODUCTION INCIDENT 2026-08-17T17:06:32Z: an arbimon pod exited 1 with
+            // "Cannot set properties of undefined (setting 'errCount')" while users
+            // were POSTing /classifications/new. It also tripped UNHANDLED_ERROR_NET,
+            // a mysql2pg Phase-6 gate metric that must read 0.
+            // Mirrors the existing `if(!rows.length)` guard on the vector route below.
+            if(!rows || !rows.length) {
+                return res.status(404).json({ error: 'data not found'});
+            }
+
             var classifiacationDetails = rows[0];
 
-            classifiacationDetails.errCount = rowsRecs.count;
+            // rowsRecs was reassigned to rowsRecs[0] above and is undefined when the
+            // errors query returns no rows; default to 0 rather than throwing.
+            classifiacationDetails.errCount = (rowsRecs && rowsRecs.count !== undefined) ? rowsRecs.count : 0;
 
             res.json(classifiacationDetails);
         });


### PR DESCRIPTION
## Production incident 2026-08-17T17:06:32Z

An arbimon pod exited 1 with:

```
UNHANDLED_ERROR_NET {"kind":"uncaughtException","survivable":false}
TypeError: Cannot set properties of undefined (setting 'errCount')
  at app/routes/data-api/project/classifications.js:51
```

`GET /:classiId` called `model.classifications.detail()` then did `rows[0].errCount = ...` with **no guard**. `detail()` aggregates `classification_results` for the job and INNER JOINs `job_params_classification`/`models`/`species`/`songtypes`, so it legitimately returns **zero rows** for a classification with no results yet - e.g. a job still running.

Loki shows users POSTing `/classifications/new` in exactly that window, and job durations that day ranged **33s to 1h30m** - so the window where a classification exists but has no results is wide and routinely hit by anyone opening the page while their job runs.

Because the throw happens **inside a DB callback** it is an uncaught exception, so one such request **kills the entire process**. It also trips `UNHANDLED_ERROR_NET`, a mysql2pg Phase-6 gate metric required to read 0 (rfcx-local OPEN-ITEMS 171).

## Fix

Return **404** when `detail()` yields no rows - mirroring the `if(!rows.length)` guard that **already exists** on the `/:classiId/:recId/vector` route in this same file, so the shape follows local convention rather than inventing a new one.

Also defaults `errCount` to 0 when the errors query returns no rows (`rowsRecs` is reassigned to `rowsRecs[0]` above and can itself be undefined) - the same class of latent throw, one line earlier.

## Engine-independent

This is a missing null check, not a dialect/adapter issue. The crash path does traverse `pgshadow.shadowAfterRead()`, but that function is strictly read-only (early-returns unless `ENGINE==='shadow'`, only snapshots rows, never assigns to `mariaRows`), so it cannot produce the empty result.

## Validation

Exercised the handler logic against 6 shapes:

```
PASS  normal: results + errors         -> 200 errCount:3
PASS  normal: results, zero errors     -> 200 errCount:0
PASS  THE CRASH: no detail rows        -> 404 data not found
PASS  no detail rows AND no errors     -> 404 data not found
PASS  detail rows but errors empty     -> 200 errCount:0
PASS  rows null (defensive)            -> 404 data not found

6/6 handled without throwing
OLD code on crash shape: THREW -> Cannot set properties of undefined (setting 'errCount')
```

Normal cases keep their exact previous output; the pre-fix code reproduces the production message verbatim. `node --check` passes.

First occurrence in 14 days of Loki history - a rare latent path rather than a regression, but it **will** recur whenever a user opens a still-running classification.

Diff is add-only apart from the single `errCount` line: **+19 / -1**.