### PR TITLE
fix(visualizer): size the base spectrogram by duration so short recordings stop tiling into misaligned slivers

### DIFF
--- a/app/model/recordings.js
+++ b/app/model/recordings.js
@@ -652,7 +652,14 @@ var Recordings = {
                 // Colour IS offered deliberately elsewhere -- the visualizer's
                 // per-user palette (visualizer.spectro_color) -- which is
                 // untouched by this.
-                asset = `rfull_g1_fspec_mtrue_d10286.255_wdolph_z120.png`
+                //
+                // WIDTH IS DURATION-AWARE (2026-08-19). It used to be a flat
+                // `d10286.255` for EVERY recording regardless of length, which
+                // is the root cause of the visualizer's mis-aligned spectrogram
+                // tiles on SHORT recordings (rec 311378538 / 311378544,
+                // 0.963-1.02 s). See specWidthForDuration() for the full
+                // derivation and the measurements.
+                asset = `rfull_g1_fspec_mtrue_d${Recordings.specWidthForDuration(recording.duration)}.255_wdolph_z120.png`
                 break;
             case 'audio':
                 asset = `r${isFrequency ? fmin + '.' + fmax : 'full'}_g${isGain ? options.gain : 1}_${isFormat ? 'fwav.wav' : 'fmp3.mp3'}`
@@ -681,6 +688,91 @@ var Recordings = {
         // Same derivation as attachTileMediaTokens — keep them identical.
         const streamId = mediaStreamId(recording.uri, recording.external_id)
         return `${streamId}_t${start}Z.${end}Z_${asset}`
+    },
+
+    /**
+     * Width (px) of the FULL-RECORDING spectrogram that the tile grid is
+     * derived from.
+     *
+     * WHY THIS IS NOT A CONSTANT ANY MORE (2026-08-19, tile-seam defect).
+     * -------------------------------------------------------------------
+     * This width is never displayed. Its ONLY job is to set the tile GRID:
+     * tyler.js splits the base image into ceil(width / 1024) columns, and
+     * fetchSpectrogramTiles turns each column into a time window that the
+     * browser then fetches from media-api as an INDEPENDENT render.
+     *
+     * So `width` decides HOW MUCH AUDIO each tile covers -- and it was hard
+     * coded to 10286 for every recording. 10286 / 172 px-per-sec
+     * (config/spectrograms.json) == 59.8 s: the constant silently encodes
+     * "this recording is about a minute long". It is right for the common
+     * 60 s recording and badly wrong for a short one:
+     *
+     *     duration   tiles   audio per tile
+     *     60.0 s      11       5454 ms      <- what the constant assumes
+     *      0.963 s    11         87.5 ms    <- rec 311378544
+     *
+     * At 87.5 ms per tile the render is dominated by its own edges. sox
+     * derives its FFT window from the requested height (-y 1024 => 2048
+     * samples ~= 42.6 ms at 48 kHz), so an 87 ms tile is barely TWO analysis
+     * windows wide and its first/last columns are ramp artefacts rather than
+     * signal. Because every tile is rendered separately, those artefacts land
+     * at every tile boundary and the user sees the spectrogram break into
+     * vertical bands that do not line up.
+     *
+     * MEASURED on the real audio of rec 311378544 (0.963 s, 48048 Hz),
+     * comparing the assembled 2244x256 visualizer image against a single
+     * full-width render of the same audio:
+     *
+     *     assembly                              worst seam step  (grey levels)
+     *     single full-width render (truth)             1.92
+     *     ONE render, then sliced into 11              1.63   <- splitting is fine
+     *     11 INDEPENDENT renders (production)         23.87   <- the defect
+     *     1 tile sized to the recording (this fix)     0.93
+     *
+     * and the per-tile edge artefact shrinks as the tile gets longer:
+     *
+     *     tile duration   0.10s  0.25s  0.50s  1.0s   2.0s   4.0s
+     *     edge/interior    6.2x   2.8x   2.1x  1.9x   1.5x   1.4x
+     *
+     * Ruled OUT along the way (each tested, not assumed):
+     *   - tile PLACEMENT: the browser's left/width arithmetic is pixel-exact
+     *     (max 1 px rounding across all 10 boundaries);
+     *   - tile WINDOWS: the minted start/end timestamps are contiguous and
+     *     sum to exactly the recording duration (963 ms);
+     *   - sox auto-normalisation: re-rendering with an explicit `-Z 0`
+     *     ceiling reproduces the seams byte-for-byte, so per-render level
+     *     scaling is not the mechanism.
+     *
+     * THE FIX: give every recording the same time-per-tile that a 60 s
+     * recording already gets, by sizing the base image at the configured
+     * pixel density instead of a fixed 10286.
+     *
+     *   - clamped ABOVE at 10286, so recordings >= ~59.8 s -- the large
+     *     majority -- keep byte-identical attrs, cache keys and tile grids.
+     *     This deliberately changes nothing for the common case.
+     *   - clamped BELOW at one full tile (1024), so a very short recording
+     *     becomes ONE tile spanning the whole clip (no internal seams at all)
+     *     rather than a degenerate few-pixel render.
+     *   - falls back to the historical constant if duration is missing or
+     *     nonsensical, so a bad row degrades to today's behaviour.
+     *
+     * SIDE EFFECT, INTENDED: short recordings stop being rendered at ~62x the
+     * intended pixel density (a 1 s clip was asking media-api for a 10286 px
+     * image) and the visualizer fetches far fewer tiles for them.
+     *
+     * ⚠️ This value is part of the media-api asset name AND of the local
+     * per-variant cache key (buildAssetCacheKey), so changing it re-fills the
+     * base-spectrogram cache for recordings shorter than ~59.8 s. That is a
+     * cache miss, not a correctness risk. Recordings at/above the cap are
+     * untouched.
+     */
+    specWidthForDuration: function (duration) {
+        var MAX_WIDTH = 10286;              // == 59.8 s at 172 px/s: the historical constant
+        var MIN_WIDTH = 1024;               // exactly one tile (config spectrograms.tiles.max_width)
+        var pixPerSec = config("spectrograms").spectrograms.pixPerSec;
+        var dur = parseFloat(duration);
+        if (!isFinite(dur) || dur <= 0) return MAX_WIDTH;
+        return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, Math.round(dur * pixPerSec)));
     },
 
     /**

--- a/app/utils/spectro-cache-key.selftest.js
+++ b/app/utils/spectro-cache-key.selftest.js
@@ -19,6 +19,19 @@ const moment = require('moment-timezone');
 // --- app/model/recordings.js buildMediaApiAttr / buildAssetCacheKey) --------
 const audioFilePattern = /\.(wav|flac|opus)$/i;
 const freqFilterPrecision = 1;
+const SPEC_PIX_PER_SEC = 172;   // config/spectrograms.json spectrograms.pixPerSec
+
+// Lockstep with app/model/recordings.js specWidthForDuration (2026-08-19):
+// the base spectrogram is sized from the recording's own duration, clamped to
+// [one tile, the historical 59.8s constant], so short recordings stop being
+// split into 11 sub-100ms tiles whose independently-rendered edges misalign.
+function specWidthForDuration (duration) {
+    const MAX_WIDTH = 10286;
+    const MIN_WIDTH = 1024;
+    const dur = parseFloat(duration);
+    if (!isFinite(dur) || dur <= 0) return MAX_WIDTH;
+    return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, Math.round(dur * SPEC_PIX_PER_SEC)));
+}
 
 function buildMediaApiAttr (recording, type, options) {
     let asset, fmin, fmax, trimFrom, trimDuration;
@@ -36,7 +49,7 @@ function buildMediaApiAttr (recording, type, options) {
         trimDuration = options.trim.duration ? (+options.trim.duration) : (to - trimFrom);
     }
     switch (type) {
-        case 'spectro': asset = `rfull_g1_fspec_mtrue_d10286.255_wdolph_z120.png`; break;
+        case 'spectro': asset = `rfull_g1_fspec_mtrue_d${specWidthForDuration(recording.duration)}.255_wdolph_z120.png`; break;
         case 'audio': asset = `r${isFrequency ? fmin + '.' + fmax : 'full'}_g${isGain ? options.gain : 1}_${isFormat ? 'fwav.wav' : 'fmp3.mp3'}`; break;
         case 'template': asset = `r${fmin}.${fmax}_g1_fspec_mtrue_d400.400_wdolph_z120.png`; break;
     }
@@ -112,6 +125,45 @@ ok('audio: gain / frequency / format / trim each change the key', () => {
     assert.strictEqual(keys.size, 5);
 });
 
+ok('spectro width is duration-aware, and UNCHANGED at/above the cap', () => {
+    // 2026-08-19 tile-seam defect. The width sets the TILE GRID
+    // (ceil(width/1024) columns), i.e. how much audio each independently
+    // rendered tile covers. Hard-coding 10286 gave a 0.963 s recording ELEVEN
+    // ~87 ms tiles -- each barely two sox FFT windows wide -- so every tile
+    // boundary showed an edge artefact and the spectrogram appeared to break
+    // into misaligned vertical bands.
+    const at = d => buildMediaApiAttr({ ...rec, duration: d }, 'spectro', {});
+
+    // Long recordings must be BYTE-IDENTICAL to the old behaviour: same attr,
+    // same cache key, same tile grid. This is what keeps the fix low-risk.
+    assert.ok(at(60).includes('d10286.255'), at(60));
+    assert.ok(at(120).includes('d10286.255'), at(120));
+    assert.ok(at(59.8).includes('d10286.255'), at(59.8));
+
+    // Short recordings get a width proportional to their own duration...
+    assert.ok(at(30).includes('d5160.255'), at(30));
+    assert.ok(at(10).includes('d1720.255'), at(10));
+
+    // ...clamped below at exactly ONE tile, so the bug recordings render as a
+    // single seamless image instead of 11 mismatched slivers.
+    assert.ok(at(0.963).includes('d1024.255'), at(0.963));
+    assert.ok(at(1.02).includes('d1024.255'), at(1.02));
+
+    // A missing/garbage duration must degrade to the historical constant
+    // rather than produce a degenerate render.
+    assert.ok(at(undefined).includes('d10286.255'), String(at(undefined)));
+    assert.ok(at(0).includes('d10286.255'), at(0));
+    assert.ok(at(-5).includes('d10286.255'), at(-5));
+});
+
+ok('short-recording spectro keys stay distinct per duration', () => {
+    // The width is part of the attr, so it is part of the per-variant cache
+    // key: two different short recordings must not collide on one base image.
+    const a = buildAssetCacheKey({ ...rec, duration: 10 }, buildMediaApiAttr({ ...rec, duration: 10 }, 'spectro', {}), '.png');
+    const b = buildAssetCacheKey({ ...rec, duration: 30 }, buildMediaApiAttr({ ...rec, duration: 30 }, 'spectro', {}), '.png');
+    assert.notStrictEqual(a, b);
+});
+
 ok('template attr carries the monochrome flag + 400x400 dims', () => {
     const attr = buildMediaApiAttr(rec, 'template', roiA);
     assert.ok(attr.includes('_mtrue_'), 'monochrome flag missing: ' + attr);
@@ -129,6 +181,7 @@ ok('spectro attr is the FULL-recording MONOCHROME variant', () => {
     // (localStorage visualizer.spectro_color); it is not this asset's job.
     const attr = buildMediaApiAttr(rec, 'spectro', {});
     assert.ok(attr.includes('_mtrue_'), 'spectro must be monochrome: ' + attr);
+    // The 60 s fixture is at/above the cap, so it keeps the historical width.
     assert.ok(attr.includes('d10286.255'));
 });
 


### PR DESCRIPTION
Fixes the operator-reported SPA visualizer defect: spectrogram tiles "clearly don't visually align at the tiles' edges." Typified by rec `311378538` and `311378544` (project `wdfw-test`).

## The reported cause is not the actual cause

The report guessed cropping / scaling / placement. All three were measured and cleared:

- **Placement is pixel-exact.** Replaying `visualizer-spectrogram.vue`'s own `left`/`width` arithmetic over all 11 tiles gives max **1px** rounding across all 10 boundaries.
- **Tile windows are exact.** The minted `mediaStart`/`mediaEnd` are contiguous and sum to **exactly 963ms** — no gap, no overlap, no fractional-ms drift.
- **sox auto-normalisation is not the mechanism.** Re-rendering every tile with an explicit `-Z 0` dBFS ceiling reproduces the seams **byte-for-byte**. (`-Z` already defaults to 0.)
- **Splitting itself is fine.** Rendering the whole file once at tile density and *slicing* it gives a worst seam of 1.63. It is the **independent renders** that hurt.

## Actual root cause

`buildMediaApiAttr(recording, 'spectro', …)` asked media-api for a **fixed** `d10286.255`.

That width is **never displayed**. Its only job is to set the tile grid: `tyler.js` splits the base image into `ceil(width / 1024)` columns and `fetchSpectrogramTiles` turns each into a time window, which the browser fetches as a **separate PNG**.

`10286 / 172 px-per-sec` (`config/spectrograms.json`) **= 59.8s** — the constant silently encodes *"this recording is about a minute long."*

| duration | tiles | audio per tile |
|---|---|---|
| 60s | 11 | 5454ms ← what the constant assumes |
| 0.963s | 11 | **87.5ms** ← rec 311378544 |

sox derives its FFT window from the requested height (`-y 1024` → ~2048 samples → **~42.6ms** at 48kHz), so an 87ms tile is barely **two analysis windows** wide and its first/last columns are ramp artefacts rather than signal. Rendered independently, those artefacts land on **every** tile boundary — the vertical banding users see.

## Proof

All 11 tiles fetched from **live media-api** with the real server-minted tokens, stitched using the SPA's own placement math. Worst brightness step across the 10 boundaries (grey levels), assembled 2244×256:

| assembly | worst seam step |
|---|---|
| single full-width render (ground truth) | 1.92 |
| ONE render, then sliced into 11 | 1.63 |
| **11 INDEPENDENT renders (production today)** | **23.87** |
| **1 tile sized to the recording (this fix)** | **0.93** |

Column-profile correlation with ground truth: **0.7476 → 0.9149**. Confirmed visually both ways (stitched = "visibly banded into vertical blocks"; single render = "seamless").

Per-tile edge artefact decays with tile length (real audio, 512×1024 renders):

| tile duration | 0.10s | 0.25s | 0.50s | 1.0s | 2.0s | 4.0s |
|---|---|---|---|---|---|---|
| edge/interior | 6.2× | 2.8× | 2.1× | 1.9× | 1.5× | 1.4× |

## The fix

New `specWidthForDuration()` sizes the base image at the configured pixel density:

```js
Math.min(10286, Math.max(1024, Math.round(duration * pixPerSec)))
```

- **Clamped ABOVE at 10286** → recordings ≥ ~59.8s (the large majority) keep **byte-identical** attrs, cache keys and tile grids. Deliberately no change for the common case.
- **Clamped BELOW at 1024** (one tile) → a very short recording becomes **one seamless tile**.
- **Falls back to the old constant** on missing/≤0/NaN duration.

| duration | before | after |
|---|---|---|
| 0.963s | 10286px, 11 tiles, 87.5ms each | **1024px, 1 tile** |
| 1.02s | 10286px, 11 tiles, 92.7ms each | **1024px, 1 tile** |
| 10s | 10286px, 11 tiles | 1720px, 2 tiles |
| 30s | 10286px, 11 tiles | 5160px, 6 tiles |
| **59.8s / 60s / 120s** | 10286px, 11 tiles | **unchanged** |

Downstream geometry self-corrects: `pixels2Secs` derives from the **actual** PNG width (`specTiles.width`), so tile windows still tile the recording exactly — re-verified 0.963s…120s. The AngularJS visualizer consumes the same server payload and inherits the fix.

**Intended side effect:** short recordings stop being rendered at up to ~62× the intended pixel density (a 1s clip was requesting a 10286px image), so the visualizer fetches far fewer tiles for them.

## Risk

- ⚠️ The width is part of the media-api asset name **and** the per-variant cache key, so this **re-fills the base-spectrogram cache for recordings shorter than ~59.8s**. A cache miss, not a correctness risk. At/above the cap: untouched.
- `template`/ROI (`d400.400`) and audio attrs: **untouched**.
- `app/utils/spectro-cache-key.selftest.js` holds a replica of this logic and was updated in lockstep — **12/12 pass** (run against real deps). New cases pin the cap, the short-recording clamp, and the bad-duration fallback.

## Deploy note

CD auto-rolls only `arbimon` + `arbimon-ingest-consumer`. The **four-pin rule** applies at release: `arbimon-export-consumer` and the `arbimon-export-reconciler` CronJob run the `arbimon-recording-export-job` image and must be hand-rolled + pin-reconciled in the same session.

⚠️ An **O5 clock is running** (mysql2pg P6 endgame, ≈08-24 exit) and a forced `arbimon` roll restarts it — please sequence this release with the P6 owner.

Investigation record: `rfcx-local` PR #1074 (`runbooks/visualizer-tile-seams-2026-08-19.md`).
